### PR TITLE
Allow alignment of images in permissive markdown blocks

### DIFF
--- a/app/javascript/shared/components/MarkdownBlock.css
+++ b/app/javascript/shared/components/MarkdownBlock.css
@@ -228,6 +228,14 @@
   @apply markdown-block__table-td;
 }
 
+.markdown-block__permissive img[align="left"] {
+  @apply py-4 pr-6;
+}
+
+.markdown-block__permissive img[align="right"] {
+  @apply py-4 pl-6;
+}
+
 /*
  * Styling used in questions and answer blocks in the
  * community section.

--- a/app/javascript/shared/utils/sanitize.js
+++ b/app/javascript/shared/utils/sanitize.js
@@ -92,7 +92,7 @@ const sanitize = (profile, dirtyHtml) => {
     allowedTags: sanitizationProfile(profile),
     allowedAttributes: {
       a: ["href", "name", "target"],
-      img: ["src", "title", "alt", "width", "height"],
+      img: ["src", "title", "alt", "width", "height", "align"],
       td: ["rowspan", "colspan"],
     },
     allowedClasses: {


### PR DESCRIPTION
This allows for the authoring of text that "flows" around images.

@vinutv Note - I've set up a bit of default padding for both cases, i.e., when the image is aligned to the left, and to the right.

![image_alignment_demo](https://user-images.githubusercontent.com/98546/87321638-1f346280-c54a-11ea-85f7-b751cbc893ea.gif)
