### PR TITLE
Fix order of loaded submissions on coach's review interface

### DIFF
--- a/app/graphql/types/pupilfirst_connection.rb
+++ b/app/graphql/types/pupilfirst_connection.rb
@@ -1,0 +1,23 @@
+module Types
+  class PupilfirstConnection < ConnectionWithCounts
+    def self.edge_type(edge_type_class, edge_class: GraphQL::Relay::Edge, node_type: edge_type_class.node_type, nodes_field: true)
+      # Set this connection's graphql name
+      node_type_name = node_type.graphql_name
+
+      @node_type = node_type
+      @edge_type = edge_type_class
+
+      field :edges, [edge_type_class],
+        null: false,
+        description: "A list of edges.",
+        method: :edge_nodes,
+        edge_class: edge_class
+
+      field :nodes, [node_type],
+        null: false,
+        description: "A list of nodes." if nodes_field
+
+      description("The connection type for #{node_type_name}.")
+    end
+  end
+end

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -1,5 +1,7 @@
 module Types
   class SubmissionType < Types::BaseObject
+    connection_type_class Types::PupilfirstConnection
+
     field :id, ID, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :evaluated_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/javascript/courses/review/components/CoursesReview__SubmissionsTab.re
+++ b/app/javascript/courses/review/components/CoursesReview__SubmissionsTab.re
@@ -51,21 +51,12 @@ let updateSubmissions =
       updateSubmissionsCB,
       nodes,
     ) => {
+  let newSubmissionsList =
+    Js.Array.map(IndexSubmission.decodeJs, nodes)
+    ->Js.Array.concat(submissions);
+
   updateSubmissionsCB(
-    ~submissions=
-      submissions
-      |> Array.append(
-           (
-             switch (nodes) {
-             | None => [||]
-             | Some(submissionsArray) =>
-               submissionsArray |> IndexSubmission.decodeJs
-             }
-           )
-           |> Array.to_list
-           |> List.flatten
-           |> Array.of_list,
-         ),
+    ~submissions=newSubmissionsList,
     ~selectedTab,
     ~hasNextPage,
     ~totalCount,

--- a/app/javascript/courses/review/types/CoursesReview__IndexSubmission.re
+++ b/app/javascript/courses/review/types/CoursesReview__IndexSubmission.re
@@ -65,36 +65,27 @@ let make =
 
 let makeStatus = (~passedAt, ~feedbackSent) => {passedAt, feedbackSent};
 
-let decodeJs = details =>
-  details
-  |> Js.Array.map(s =>
-       switch (s) {
-       | Some(submission) =>
-         let status =
-           submission##evaluatedAt
-           ->Belt.Option.map(_ =>
-               makeStatus(
-                 ~passedAt=
-                   submission##passedAt->Belt.Option.map(DateFns.decodeISO),
-                 ~feedbackSent=submission##feedbackSent,
-               )
-             );
+let decodeJs = submission => {
+  let status =
+    submission##evaluatedAt
+    ->Belt.Option.map(_ =>
+        makeStatus(
+          ~passedAt=submission##passedAt->Belt.Option.map(DateFns.decodeISO),
+          ~feedbackSent=submission##feedbackSent,
+        )
+      );
 
-         [
-           make(
-             ~id=submission##id,
-             ~title=submission##title,
-             ~createdAt=DateFns.decodeISO(submission##createdAt),
-             ~levelId=submission##levelId,
-             ~userNames=submission##userNames,
-             ~status,
-             ~coachIds=submission##coachIds,
-             ~teamName=submission##teamName,
-           ),
-         ];
-       | None => []
-       }
-     );
+  make(
+    ~id=submission##id,
+    ~title=submission##title,
+    ~createdAt=DateFns.decodeISO(submission##createdAt),
+    ~levelId=submission##levelId,
+    ~userNames=submission##userNames,
+    ~status,
+    ~coachIds=submission##coachIds,
+    ~teamName=submission##teamName,
+  );
+};
 
 let replace = (e, l) => l |> Array.map(s => s.id == e.id ? e : s);
 

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -4275,12 +4275,20 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "SubmissionEdge",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SubmissionEdge",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -4291,12 +4299,20 @@
             "description": "",
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Submission",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Submission",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/spec/system/courses/review_spec.rb
+++ b/spec/system/courses/review_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Course review' do
+feature "Coach's review interface" do
   include UserSpecHelper
 
   let(:school) { create :school, :current }
@@ -340,13 +340,18 @@ feature 'Course review' do
   end
 
   context 'when there are over 25 submissions' do
+    let(:student_l1) { team_l1.founders.first }
+    let(:student_l3) { team_l3.founders.first }
+    let(:earliest_submitted) { student_l1.timeline_events.order(created_at: :ASC).first }
+    let(:earliest_reviewed) { student_l3.timeline_events.order(evaluated_at: :ASC).first }
+
     before do
       (1..30).each do |n|
         # Passed submissions
-        create(:timeline_event, :with_owners, owners: [team_l3.founders.first], latest: n == 1, target: target_l1, evaluator_id: course_coach.id, evaluated_at: n.days.ago, passed_at: n.days.ago, created_at: n.days.ago)
+        create(:timeline_event, :with_owners, owners: [student_l3], latest: n == 1, target: target_l1, evaluator_id: course_coach.id, evaluated_at: n.days.ago, passed_at: n.days.ago, created_at: n.days.ago)
 
         # Pending submissions
-        create(:timeline_event, :with_owners, latest: true, target: target_l1, owners: [team_l1.founders.first], created_at: n.days.ago)
+        create(:timeline_event, :with_owners, latest: true, target: target_l1, owners: [student_l1], created_at: n.days.ago)
       end
     end
 
@@ -365,6 +370,7 @@ feature 'Course review' do
 
       expect(page).to have_text(target_l1.title, count: 30)
       expect(page).not_to have_button('Load more...')
+      expect(find("#submissions a:last-child")['href']).to end_with("/submissions/#{earliest_submitted.id}/review")
 
       click_button 'Reviewed'
 
@@ -374,6 +380,7 @@ feature 'Course review' do
 
       expect(page).to have_text(target_l1.title, count: 30)
       expect(page).not_to have_button('Load more...')
+      expect(find("#submissions a:last-child")['href']).to end_with("/submissions/#{earliest_reviewed.id}/review")
     end
   end
 

--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Submissions review' do
+feature 'Submission review overlay' do
   include UserSpecHelper
   include MarkdownEditorHelper
   include NotificationHelper


### PR DESCRIPTION
This commit also adds a `Types::PupilfirstConnection` that sets the type of `connection_type` responses to `[Object!]!` (non-null array, with non-null objects. This fits better with the way we use `.connection_type` and makes decoding easier.