### PR TITLE
Add HMAC-based authentication for webhook requests

### DIFF
--- a/app/jobs/webhook_deliveries/deliver_job.rb
+++ b/app/jobs/webhook_deliveries/deliver_job.rb
@@ -4,17 +4,23 @@ module WebhookDeliveries
 
     def perform(event_type, course, resource)
       webhook_endpoint = course.webhook_endpoint
+
       payload = {
         data: data(event_type, resource),
         event: event_type
       }
+
       uri = URI.parse(webhook_endpoint.webhook_url)
+
       request = Net::HTTP::Post.new(uri.request_uri)
       request['Content-Type'] = 'application/json'
       request.body = payload.to_json
+      request['Authorization'] = "PF-HMAC-SHA256 #{hmac(webhook_endpoint.hmac_key, request.body)}"
+
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = Rails.application.secrets.webhook_read_timeout
       http.use_ssl = (uri.scheme == 'https' && !Rails.env.development?)
+
       response = http.request(request)
 
       WebhookDelivery.create!(
@@ -28,7 +34,7 @@ module WebhookDeliveries
         response_body: response.body
       )
 
-    rescue => e
+    rescue Net::OpenTimeout => e
       if event_type.in? course.webhook_endpoint.events
         WebhookDelivery.create!(
           error_class: e.class.name,
@@ -46,8 +52,12 @@ module WebhookDeliveries
         when WebhookDelivery.events[:submission_created]
           TimelineEvents::CreateWebhookDataService.new(resource).data
         else
-          raise "undefined webhook event type: #{event_type}"
+          raise "Unknown webhook event type: #{event_type}"
       end
+    end
+
+    def hmac(key, data)
+      OpenSSL::HMAC.hexdigest('SHA256', key, data)
     end
   end
 end

--- a/db/migrate/20200901104722_add_hmac_key_to_webhook_endpoint.rb
+++ b/db/migrate/20200901104722_add_hmac_key_to_webhook_endpoint.rb
@@ -1,0 +1,14 @@
+class AddHmacKeyToWebhookEndpoint < ActiveRecord::Migration[6.0]
+  class WebhookEndpoint < ApplicationRecord
+  end
+
+  def change
+    add_column :webhook_endpoints, :hmac_key, :string
+
+    WebhookEndpoint.all.each do |endpoint|
+      endpoint.update!(hmac_key: SecureRandom.base64)
+    end
+
+    change_column_null :webhook_endpoints, :hmac_key, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_130014) do
+ActiveRecord::Schema.define(version: 2020_09_01_104722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -762,6 +762,7 @@ ActiveRecord::Schema.define(version: 2020_08_20_130014) do
     t.string "webhook_url", null: false
     t.boolean "active", default: true
     t.jsonb "events", array: true
+    t.string "hmac_key", null: false
     t.index ["course_id"], name: "index_webhook_endpoints_on_course_id", unique: true
   end
 

--- a/spec/factories/webhook_endpoint.rb
+++ b/spec/factories/webhook_endpoint.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     active { true }
     webhook_url { Faker::Internet.url }
     events { WebhookDelivery.events.values }
+    hmac_key { SecureRandom.base64 }
   end
 end


### PR DESCRIPTION
This also restricts error class capture to 'Net::Timeout' and makes it so that the job now raises an error when an unknown event type is encountered, instead of squashing the error and storing failed delivery attempt.