### PR TITLE
Improve community updates in daily digest email

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,5 +4,17 @@ class TopicsController < ApplicationController
 
   def show
     @topic = authorize(Topic.live.find(params[:id]))
+
+    key = views_cache_key(@topic)
+
+    # Increment views only once per hour per user.
+    return if Rails.cache.exist?(key)
+
+    @topic.increment!(:views) # rubocop:disable Rails/SkipsModelValidations
+    Rails.cache.write(key, 1, expires_in: 1.hour)
+  end
+
+  def views_cache_key(topic)
+    "topics/#{topic.id}/views/#{current_user.id}"
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,17 +4,6 @@ class TopicsController < ApplicationController
 
   def show
     @topic = authorize(Topic.live.find(params[:id]))
-
-    key = views_cache_key(@topic)
-
-    # Increment views only once per hour per user.
-    return if Rails.cache.exist?(key)
-
-    @topic.increment!(:views) # rubocop:disable Rails/SkipsModelValidations
-    Rails.cache.write(key, 1, expires_in: 1.hour)
-  end
-
-  def views_cache_key(topic)
-    "topics/#{topic.id}/views/#{current_user.id}"
+    Topics::IncrementViewsService.new(@topic).execute(current_user)
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -6,17 +6,16 @@ class Topic < ApplicationRecord
 
   has_many :posts, dependent: :restrict_with_error
   has_one :first_post, -> { where post_number: 1 }, class_name: 'Post', inverse_of: :topic
+  has_one :creator, through: :first_post
   has_many :replies, -> { where('post_number > ?', 1) }, class_name: 'Post', inverse_of: :topic
   has_many :live_replies, -> { where('post_number > ?', 1).merge(Post.live) }, class_name: 'Post', inverse_of: :topic
   has_many :post_likes, through: :posts
 
   scope :live, -> { where(archived: false) }
 
-  delegate :creator, to: :first_post
-
   pg_search_scope :search_by_title, against: :title, using: {
-    tsearch: { prefix: true, any_word: true }
-  }
+                                      tsearch: { prefix: true, any_word: true },
+                                    }
 
   def solution
     replies.find_by(solution: true)

--- a/app/services/topics/increment_views_service.rb
+++ b/app/services/topics/increment_views_service.rb
@@ -1,0 +1,21 @@
+module Topics
+  class IncrementViewsService
+    def initialize(topic)
+      @topic = topic
+    end
+
+    def execute(user)
+      key = views_cache_key(user)
+
+      # Increment views only once per hour per user.
+      return if Rails.cache.exist?(key)
+
+      @topic.increment!(:views) # rubocop:disable Rails/SkipsModelValidations
+      Rails.cache.write(key, 1, expires_in: 1.hour)
+    end
+
+    def views_cache_key(user)
+      "topics/#{@topic.id}/views/#{user.id}"
+    end
+  end
+end

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -87,6 +87,10 @@
                         <i class="far fa-comment-dots text-xl text-gray-600"></i>
                         <p class="text-xs pt-1"><%= topic.live_replies_count %></p>
                       </span>
+                      <span class="px-2 text-center" aria-label="Views">
+                        <i class="far fa-eye text-xl text-gray-600"></i>
+                        <p class="text-xs pt-1"><%= topic.views %></p>
+                      </span>
                     <% end %>
                   </span>
                 </a>

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -79,7 +79,7 @@
                     <% if presenter.new_topic?(topic) %>
                       <div class="bg-green-600 text-white px-2 py-1 text-xs font-semibold rounded-sm">New!</div>
                     <% else %>
-                      <span class="px-4 text-center" aria-label="Likes">
+                      <span class="pr-2 text-center" aria-label="Likes">
                         <i class="far fa-thumbs-up text-xl text-gray-600"></i>
                         <p class="text-xs pt-1"><%= topic.first_post.post_likes.count %></p>
                       </span>
@@ -87,7 +87,7 @@
                         <i class="far fa-comment-dots text-xl text-gray-600"></i>
                         <p class="text-xs pt-1"><%= topic.live_replies_count %></p>
                       </span>
-                      <span class="px-2 text-center" aria-label="Views">
+                      <span class="pl-2 text-center" aria-label="Views">
                         <i class="far fa-eye text-xl text-gray-600"></i>
                         <p class="text-xs pt-1"><%= topic.views %></p>
                       </span>

--- a/app/views/user_mailer/daily_digest.html.erb
+++ b/app/views/user_mailer/daily_digest.html.erb
@@ -1,6 +1,7 @@
 <%
   school_name = @user.school.name
   recipient_name = @user.name
+
   def article(count)
     count > 1 ? 'are' : 'is'
   end
@@ -21,18 +22,18 @@
 <% end %>
 
 <% content_for :body do %>
-  <% if @updates[:updates_for_coach].present? %>
-    <% pending_submissions_count = @updates[:updates_for_coach].map { |s| s[:pending_submissions] }.sum %>
+  <% if @updates[:coach].present? %>
+    <% pending_submissions_count = @updates[:coach].map { |s| s[:pending_submissions] }.sum %>
     <p style="margin-top: 10px;">
 
       There <%= article(pending_submissions_count) %> <strong><%= pending_submissions_count %></strong>
       new <%= 'submission'.pluralize(pending_submissions_count) %> to review
-      in <%= pluralize(@updates[:updates_for_coach].length, 'course') %>
+      in <%= pluralize(@updates[:coach].length, 'course') %>
       that you are a coach in:
     </p>
 
     <ul style="padding: 0; margin-top: 0; margin-left: 30px; list-style-type: circle;">
-      <% @updates[:updates_for_coach].each do |stats| %>
+      <% @updates[:coach].each do |stats| %>
         <li style="padding: 2px 0px;">
           <%= link_to "#{stats[:course_name]}:", review_course_url(stats[:course_id]), style: 'color: #6025C0; border-radius: 8px; padding: 0px;' %>
           <span><strong><%= stats[:pending_submissions] %></strong>
@@ -45,33 +46,48 @@
     </ul>
   <% end %>
 
-  <% if @updates[:community_updates].present? %>
-    <% topics_count = @updates[:community_updates].values.map { |v| v[:topics].length }.sum %>
-    <p style="margin-top: 10px;">
-      There <%= article(topics_count) %> <strong><%= topics_count %></strong> new
-      <%= 'topic'.pluralize(topics_count) %> in <%= pluralize(@updates[:community_updates].length, 'community') %>
-      that you are a
-      part of.
+  <% if @updates[:community_new].present? %>
+    <p style="margin-top: 15px;">
+      Latest topics posted on your communities:
     </p>
 
-    <% @updates[:community_updates].each do |community_id, community_updates| %>
-      <%= link_to community_updates[:community_name], community_url(community_id), style: 'font-size: 120%; color: #6025C0; border-radius: 8px; padding: 0px 4px;' %>
-
-      <ul style="padding: 0; margin-top: 0; margin-left: 30px; list-style-type: circle;">
-        <% community_updates[:topics].each do |topic| %>
-          <li style="padding: 2px 0px;">
-            <%= link_to topic[:title], topic_url(topic[:id]) %>
-            <span style="font-size: 75%;">
-            &mdash; <strong><%= topic[:author] %></strong>
-              <%= topic[:type] == 'new' ? '' : "(no activity, asked #{pluralize(topic[:days_ago], 'day')} ago)" %>
-          </span>
-          </li>
-        <% end %>
-      </ul>
+    <% @updates[:community_new].each do |topic| %>
+      <div>
+        <%= link_to topic[:title], topic_url(topic[:id]) %>
+        <span style="font-size: 75%;">
+          &mdash; <strong><%= topic[:author] %></strong>
+        </span>
+      </div>
+      <div style="font-size: 75%; border-bottom: 1px solid lightgray; margin-bottom: 4px; padding-bottom: 4px;">
+        <%= link_to topic[:community_name], community_url(topic[:community_id]) %>,
+        <%= pluralize(topic[:views], 'view') %>,
+        <%= pluralize(topic[:replies], 'reply') %>.
+      </div>
     <% end %>
   <% end %>
 
-  <p style="font-size: 75%;">
+  <% if @updates[:community_recently_active].present? %>
+    <p style="margin-top: 15px;">
+      Older, popular topics that have seen new activity:
+    </p>
+
+    <% @updates[:community_recently_active].each do |topic| %>
+      <div>
+        <%= link_to topic[:title], topic_url(topic[:id]) %>
+        <span style="font-size: 75%;">
+          &mdash; <strong><%= topic[:author] %></strong>
+        </span>
+      </div>
+      <div style="font-size: 75%; border-bottom: 1px solid lightgray; margin-bottom: 4px; padding-bottom: 4px;">
+        <%= link_to topic[:community_name], community_url(topic[:community_id]) %>,
+        <%= pluralize(topic[:views], 'view') %>,
+        <%= pluralize(topic[:replies], 'reply') %>,
+        asked <%= pluralize(topic[:days_ago], 'day') %> ago.
+      </div>
+    <% end %>
+  <% end %>
+
+  <p style="font-size: 75%; text-align: center; margin-top: 15px;">
     You can control these emails from <%= link_to "your profile edit page", edit_user_url %>.
   </p>
 <% end %>

--- a/app/views/user_mailer/daily_digest.html.erb
+++ b/app/views/user_mailer/daily_digest.html.erb
@@ -66,12 +66,12 @@
     <% end %>
   <% end %>
 
-  <% if @updates[:community_recently_active].present? %>
+  <% if @updates[:community_reactivated].present? %>
     <p style="margin-top: 15px;">
       Older, popular topics that have seen new activity:
     </p>
 
-    <% @updates[:community_recently_active].each do |topic| %>
+    <% @updates[:community_reactivated].each do |topic| %>
       <div>
         <%= link_to topic[:title], topic_url(topic[:id]) %>
         <span style="font-size: 75%;">

--- a/db/migrate/20200917094317_add_views_to_topic.rb
+++ b/db/migrate/20200917094317_add_views_to_topic.rb
@@ -1,0 +1,5 @@
+class AddViewsToTopic < ActiveRecord::Migration[6.0]
+  def change
+    add_column :topics, :views, :int, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_104722) do
+ActiveRecord::Schema.define(version: 2020_09_17_094317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -693,6 +693,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_104722) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "views", default: 0
     t.index ["community_id"], name: "index_topics_on_community_id"
     t.index ["target_id"], name: "index_topics_on_target_id"
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -6,15 +6,10 @@ class UserMailerPreview < ActionMailer::Preview
   def daily_digest
     user = Founder.last.user
 
-    community_updates = {
-      1 => community_digest(2),
-      2 => community_digest(1, 3),
-      3 => community_digest(3, 4, true)
-    }
-
     updates = {
-      community_updates: community_updates,
-      updates_for_coach: updates_for_coach
+      community_new: new_topics,
+      community_recently_active: recently_active_topics,
+      coach: updates_for_coach
     }
 
     UserMailer.daily_digest(user, updates)
@@ -38,19 +33,28 @@ class UserMailerPreview < ActionMailer::Preview
 
   private
 
-  def community_digest(count, starting_id = 1, no_activity = false)
-    {
-      community_name: Faker::Lorem.words(number: 2).join(' ').titleize,
-      topics: (1..count).map do |id|
-        {
-          id: starting_id + id - 1,
-          title: Faker::Lorem.sentence,
-          author: Faker::Name.name,
-          days_ago: no_activity ? rand(1..6) : 0,
-          type: no_activity ? 'no_activity' : 'new'
-        }
-      end
-    }
+  def new_topics
+    community_topics(5, 10, :new)
+  end
+
+  def recently_active_topics
+    community_topics(5, 1, :recently_active)
+  end
+
+  def community_topics(count, starting_id, update_type)
+    (0..(count - 1)).map do |index|
+      {
+        id: starting_id + index,
+        title: Faker::Lorem.sentence,
+        views: rand(100),
+        replies: update_type == :new ? rand(4) : rand(1..5),
+        days_ago: update_type == :new ? 0 : rand(1..6),
+        author: Faker::Name.name,
+        type: update_type,
+        community_id: rand(10),
+        community_name: Faker::Lorem.words(number: 2).join(' ').titleize
+      }
+    end
   end
 
   def updates_for_coach

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -8,7 +8,7 @@ class UserMailerPreview < ActionMailer::Preview
 
     updates = {
       community_new: new_topics,
-      community_recently_active: recently_active_topics,
+      community_reactivated: reactivated_topics,
       coach: updates_for_coach
     }
 
@@ -37,8 +37,8 @@ class UserMailerPreview < ActionMailer::Preview
     community_topics(5, 10, :new)
   end
 
-  def recently_active_topics
-    community_topics(5, 1, :recently_active)
+  def reactivated_topics
+    community_topics(5, 1, :reactivated)
   end
 
   def community_topics(count, starting_id, update_type)

--- a/spec/services/daily_digest_service_spec.rb
+++ b/spec/services/daily_digest_service_spec.rb
@@ -158,7 +158,7 @@ describe DailyDigestService do
       end
     end
 
-    context 'when the user is a faculty' do
+    context 'when the user is a coach' do
       let(:course_1) { create :course, school: school }
       let(:level_1) { create :level, :one, course: course_1 }
       let(:target_group_1) { create :target_group, level: level_1 }
@@ -203,6 +203,7 @@ describe DailyDigestService do
         create :faculty_course_enrollment, faculty: coach_2, course: course_3
         create :topic, :with_first_post, community: community_1, creator: t1_user
         create :topic, :with_first_post, community: community_2, creator: t3_user
+
         target_1.evaluation_criteria << evaluation_criterion_1
         target_2.evaluation_criteria << evaluation_criterion_2
       end
@@ -211,15 +212,16 @@ describe DailyDigestService do
         subject.execute
 
         open_email(coach.user.email)
-
         b = sanitize_html(current_email.body)
+
         expect(b).to include(course_1.name)
         expect(b).to include(course_2.name)
         expect(b).to include("There are 3")
         expect(b).to include("new submissions to review")
         expect(b).to include("in 2 courses")
 
-        # The email should include community updates
+        # The email should include community updates, but only
+        # from the courses where the coach is enrolled.
         expect(b).to include(community_1.name)
         expect(b).not_to include(community_2.name)
       end

--- a/spec/system/community/community_spec.rb
+++ b/spec/system/community/community_spec.rb
@@ -4,6 +4,7 @@ feature 'Community', js: true do
   include UserSpecHelper
   include NotificationHelper
   include MarkdownEditorHelper
+  include ActiveSupport::Testing::TimeHelpers
 
   # Setup a course with students and target for community.
   let(:school) { create :school, :current }
@@ -166,6 +167,35 @@ feature 'Community', js: true do
     find("div[aria-label='Unlike reply #{reply_1.id}']").click
     expect(page).to have_selector("div[aria-label='Like reply #{reply_1.id}']")
     expect(reply_1.post_likes.where(user: student_2.user).count).to eq(0)
+  end
+
+  scenario 'a user visiting a topic affects its view count' do
+    original_views = topic_1.views
+
+    sign_in_user(student_2.user, referrer: topic_path(topic_1))
+
+    expect(page).to have_text(topic_1.first_post.body)
+
+    # Views should have been incremented by 1.
+    expect(topic_1.reload.views).to eq(original_views + 1)
+
+    # Revisiting the page "soon" should not increase the count.
+    click_link community.name
+    expect(page).to have_link('Create a new topic')
+    click_link topic_1.title
+
+    expect(page).to have_text(topic_1.first_post.body)
+    expect(topic_1.reload.views).to eq(original_views + 1)
+
+    # Revisiting after a "long while" should increase the count again.
+    travel_to(90.minutes.from_now) do
+      click_link community.name
+      expect(page).to have_link('Create a new topic')
+      click_link topic_1.title
+
+      expect(page).to have_text(topic_1.first_post.body)
+      expect(topic_1.reload.views).to eq(original_views + 2)
+    end
   end
 
   scenario 'an active faculty visits community' do


### PR DESCRIPTION
Here's the plan:

- [x] Add `views: int` to `topics` table - this is a critical indicator of _popularity_ that we aren't tracking right now.
- [x] Remove the two existing community update inclusion filters (everything from today, and upto 5 topics with no activity from upto a week ago).
- [x] Add new category - _"New & Popular topics today"_ - up to five topics created in the past 24 hours, sorted by number of views.
- [x] Add new category - _"Other popular topics with new activity"_ - up to five topics sorted by number of replies in the past 24 hours and number of views, that haven't been included in the above list.
- [x] All topic links must include a link to the community - there should be no seperate list of links per community as it is now. This might make individual topic entries a bit bigger, but it'll make the mail much more of a _digest_.

@pratham2504 @mahesh-krishnakumar @bodhish Thoughts?