### PR TITLE
fix editor selection

### DIFF
--- a/app/javascript/shared/components/MarkdownEditor.re
+++ b/app/javascript/shared/components/MarkdownEditor.re
@@ -212,16 +212,9 @@ let updateTextareaAfterDelay = (state, (startPosition, endPosition)) => {
           element
           |> DomUtils.Element.unsafeToHtmlInputElement
           |> HtmlInputElement.setSelectionRange(startPosition, endPosition);
-          switch (
-            Webapi.Dom.Document.getElementById(state.id, Webapi.Dom.document)
-          ) {
-          | None => ()
-          | Some(element) =>
-            switch (Webapi.Dom.Element.asHtmlElement(element)) {
-            | None => ()
-            | Some(h) => Webapi.Dom.HtmlElement.focus(h)
-            }
-          };
+          Webapi.Dom.Document.getElementById(state.id, Webapi.Dom.document)
+          ->Belt.Option.flatMap(Webapi.Dom.Element.asHtmlElement)
+          ->Belt.Option.mapWithDefault((), Webapi.Dom.HtmlElement.focus);
         },
         renderDelay,
       )

--- a/app/javascript/shared/components/MarkdownEditor.re
+++ b/app/javascript/shared/components/MarkdownEditor.re
@@ -223,12 +223,11 @@ let updateTextareaAfterDelay = (state, cursorPosition) => {
   );
 };
 
-let finalizeChange = (~oldValue, ~newValue, ~state, ~send, ~onChange) => {
-  let offset = (newValue |> String.length) - (oldValue |> String.length);
+let finalizeChange = (~newValue, ~state, ~send, ~onChange, ~offset) => {
   let (_, selectionEnd) = state.selection;
 
   // The cursor needs to be bumped to account for changed value.
-  send(BumpSelection(offset / 2));
+  send(BumpSelection(offset));
 
   // Report the modified value to the parent.
   onChange(newValue);
@@ -260,7 +259,13 @@ let modifyPhrase = (oldValue, state, send, onChange, phraseModifer) => {
       oldValue |> wrapWith(wrapper, selectionStart, selectionEnd);
     };
 
-  finalizeChange(~oldValue, ~newValue, ~state, ~send, ~onChange);
+  finalizeChange(
+    ~newValue,
+    ~state,
+    ~send,
+    ~onChange,
+    ~offset=String.(length(newValue) - length(oldValue)) / 2,
+  );
 };
 
 let controlsContainerClasses = mode =>
@@ -390,7 +395,13 @@ let handleUploadFileResponse = (oldValue, state, send, onChange, json) => {
     let insert = "\n" ++ markdownEmbedCode ++ "\n";
     let (_, selectionEnd) = state.selection;
     let newValue = oldValue |> insertAt(insert, selectionEnd);
-    finalizeChange(~oldValue, ~newValue, ~state, ~send, ~onChange);
+    finalizeChange(
+      ~newValue,
+      ~state,
+      ~send,
+      ~onChange,
+      ~offset=String.(length(newValue) - length(oldValue)),
+    );
     send(FinishUploading);
   } else {
     send(


### PR DESCRIPTION
fixes #489

old PR #490. 

Determining offset based on the action. If the action is 

- a file upload then offset would be the string difference length.  

- control buttons then divide the offset with two 

focus on the selection after clicking bold,italics button