### PR TITLE
External Links in Header and Site links should open on a new tab

### DIFF
--- a/app/javascript/layouts/student/StudentTopNav.re
+++ b/app/javascript/layouts/student/StudentTopNav.re
@@ -3,7 +3,6 @@
 let str = React.string;
 
 open StudentTopNav__Types;
-let targetBlank(navTitle) = { navTitle === "Admin" || navTitle === "Dashboard" }
 
 let headerLink = (key, link) =>
   <div
@@ -12,9 +11,8 @@ let headerLink = (key, link) =>
     <a
       className="no-underline bg-gray-100 md:bg-white text-black hover:text-primary-500 w-full p-4 md:p-2"
       href={link |> NavLink.url}
-      target={targetBlank(NavLink.title(link)) ? "" : "_blank"}
-      rel={targetBlank(NavLink.title(link)) ? "" : "noopener"}
-    >
+      target=?{NavLink.local(link) ? None : Some("_blank")}
+      rel=?{NavLink.local(link) ? None : Some("noopener")}>
       {link |> NavLink.title |> str}
     </a>
   </div>;

--- a/app/javascript/layouts/student/StudentTopNav.re
+++ b/app/javascript/layouts/student/StudentTopNav.re
@@ -3,6 +3,7 @@
 let str = React.string;
 
 open StudentTopNav__Types;
+let targetBlank(navTitle) = { navTitle === "Admin" || navTitle === "Dashboard" }
 
 let headerLink = (key, link) =>
   <div
@@ -10,7 +11,10 @@ let headerLink = (key, link) =>
     className="md:ml-5 text-sm font-semibold text-center cursor-default flex w-1/2 sm:w-1/3 md:w-auto justify-center border-r border-b md:border-0">
     <a
       className="no-underline bg-gray-100 md:bg-white text-black hover:text-primary-500 w-full p-4 md:p-2"
-      href={link |> NavLink.url}>
+      href={link |> NavLink.url}
+      target={targetBlank(NavLink.title(link)) ? "" : "_blank"}
+      rel={targetBlank(NavLink.title(link)) ? "" : "noopener"}
+    >
       {link |> NavLink.title |> str}
     </a>
   </div>;

--- a/app/javascript/layouts/student/components/StudentTopNav__DropDown.re
+++ b/app/javascript/layouts/student/components/StudentTopNav__DropDown.re
@@ -14,7 +14,10 @@ let additionalLinks = (linksVisible, links) =>
               <div key={index |> string_of_int} className="">
                 <a
                   className="cursor-pointer block p-3 text-xs font-semibold text-gray-900 border-b border-gray-200 bg-white hover:text-primary-500 hover:bg-gray-200"
-                  href={link |> NavLink.url}>
+                  href={link |> NavLink.url}
+                  target="_blank"
+                  rel="noopener"
+                >
                   {link |> NavLink.title |> str}
                 </a>
               </div>

--- a/app/javascript/layouts/student/types/StudentTopNav__Types/StudentTopNav__NavLink.re
+++ b/app/javascript/layouts/student/types/StudentTopNav__Types/StudentTopNav__NavLink.re
@@ -12,3 +12,7 @@ let decode = json =>
     title: json |> field("title", string),
     url: json |> field("url", string),
   };
+
+let local = t => {
+  Js.Array.includes(t.title, [|"Admin", "Dashboard", "Coaches"|]);
+};

--- a/app/presenters/layouts/footer_presenter.rb
+++ b/app/presenters/layouts/footer_presenter.rb
@@ -7,10 +7,11 @@ module Layouts
     def nav_links
       footer_links = current_user.present? ? [{ title: 'Home', url: '/' }, { title: 'Dashboard', url: '/dashboard' }] : []
 
+      target_blank = { target_blank: { target: '_blank', rel: 'noopener' } }
       custom_links = SchoolLink.where(
         school: current_school,
         kind: SchoolLink::KIND_FOOTER
-      ).map { |sl| { title: sl.title, url: sl.url } }
+      ).map { |sl| { title: sl.title, url: sl.url }.merge(target_blank) }
 
       footer_links + custom_links
     end
@@ -68,11 +69,6 @@ module Layouts
 
     def terms_and_conditions?
       SchoolString::TermsAndConditions.saved?(current_school)
-    end
-
-    def add_target_blank?(title)
-      return {} if title == "Home" || title == "Dashboard"
-      { target: '_blank', rel: 'noopener' }
     end
   end
 end

--- a/app/presenters/layouts/footer_presenter.rb
+++ b/app/presenters/layouts/footer_presenter.rb
@@ -69,5 +69,10 @@ module Layouts
     def terms_and_conditions?
       SchoolString::TermsAndConditions.saved?(current_school)
     end
+
+    def add_target_blank?(title)
+      return {} if title == "Home" || title == "Dashboard"
+      { target: '_blank', rel: 'noopener' }
+    end
   end
 end

--- a/app/presenters/layouts/footer_presenter.rb
+++ b/app/presenters/layouts/footer_presenter.rb
@@ -7,11 +7,10 @@ module Layouts
     def nav_links
       footer_links = current_user.present? ? [{ title: 'Home', url: '/' }, { title: 'Dashboard', url: '/dashboard' }] : []
 
-      target_blank = { target_blank: { target: '_blank', rel: 'noopener' } }
       custom_links = SchoolLink.where(
         school: current_school,
         kind: SchoolLink::KIND_FOOTER
-      ).map { |sl| { title: sl.title, url: sl.url }.merge(target_blank) }
+      ).map { |sl| { title: sl.title, url: sl.url, custom: true } }
 
       footer_links + custom_links
     end

--- a/app/presenters/layouts/student_top_nav_presenter.rb
+++ b/app/presenters/layouts/student_top_nav_presenter.rb
@@ -32,7 +32,7 @@ module Layouts
           end
 
           # Both, with the user-based links at the front.
-          admin_link + dashboard_link + custom_links + coaches_link
+          admin_link + dashboard_link + coaches_link + custom_links
         end
     end
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,7 @@
           <div class="row">
             <% presenter.nav_links.each do |nav_link| %>
               <div class="col-md-4">
-                <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(presenter.add_target_blank?(nav_link[:title])) %>
+                <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(nav_link[:target_blank] || {} ) %>
               </div>
             <% end %>
           </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,12 @@
           <div class="row">
             <% presenter.nav_links.each do |nav_link| %>
               <div class="col-md-4">
-                <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(nav_link[:target_blank] || {} ) %>
+                <%= link_to(
+                    nav_link[:title], nav_link[:url], {
+                    class: 'footer-column__link'
+                  }.merge(nav_link[:custom] ? { target: '_blank', rel: 'noopener' } : {} )
+                  )
+                %>
               </div>
             <% end %>
           </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,7 @@
           <div class="row">
             <% presenter.nav_links.each do |nav_link| %>
               <div class="col-md-4">
-                <%= link_to nav_link[:title], nav_link[:url], class: 'footer-column__link' %>
+                <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(presenter.add_target_blank?(nav_link[:title])) %>
               </div>
             <% end %>
           </div>

--- a/app/views/layouts/_student_footer.html.erb
+++ b/app/views/layouts/_student_footer.html.erb
@@ -9,7 +9,12 @@
         <div class="w-full flex flex-row flex-wrap text-xs font-semibold">
           <% presenter.nav_links.each do |nav_link| %>
             <div class="w-1/3">
-              <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(nav_link[:target_blank] || {} ) %>
+              <%= link_to(
+                  nav_link[:title], nav_link[:url], {
+                  class: 'no-underline pt-2 pb-1 block hover:text-primary-500'
+                }.merge(nav_link[:custom] ? { target: '_blank', rel: 'noopener' } : {} )
+                )
+              %>
             </div>
           <% end %>
         </div>

--- a/app/views/layouts/_student_footer.html.erb
+++ b/app/views/layouts/_student_footer.html.erb
@@ -9,7 +9,7 @@
         <div class="w-full flex flex-row flex-wrap text-xs font-semibold">
           <% presenter.nav_links.each do |nav_link| %>
             <div class="w-1/3">
-              <%= link_to nav_link[:title], nav_link[:url], class: "no-underline pt-2 pb-1 block hover:text-primary-500" %>
+              <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(presenter.add_target_blank?(nav_link[:title])) %>
             </div>
           <% end %>
         </div>

--- a/app/views/layouts/_student_footer.html.erb
+++ b/app/views/layouts/_student_footer.html.erb
@@ -9,7 +9,7 @@
         <div class="w-full flex flex-row flex-wrap text-xs font-semibold">
           <% presenter.nav_links.each do |nav_link| %>
             <div class="w-1/3">
-              <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(presenter.add_target_blank?(nav_link[:title])) %>
+              <%= link_to nav_link[:title], nav_link[:url], { class: 'footer-column__link' }.merge(nav_link[:target_blank] || {} ) %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
original issue: #450 

### Adjustment

1. Custom links of StudentTopNav and footer can be opened on a new tab.
2. Default links, including `Home`, `Admin`, `Dashboard`, just remain opening in the same tab as before.
<img width="577" alt="Dashboard | Test School | Admins 2020-10-17 18-00-41" src="https://user-images.githubusercontent.com/50868409/96334354-c58c8880-10a2-11eb-9ca1-f02294fdfc14.png">

<img width="552" alt="Dashboard | Test School | Admins 2020-10-17 18-00-25" src="https://user-images.githubusercontent.com/50868409/96334363-d210e100-10a2-11eb-9a11-b6a1c79595b6.png">
