### PR TITLE
Have video upload limit based on Vimeo account plan

### DIFF
--- a/app/javascript/packs/SchoolsCoursesCurriculumPack.res
+++ b/app/javascript/packs/SchoolsCoursesCurriculumPack.res
@@ -7,6 +7,7 @@ type props = {
   targetGroups: list<TargetGroup.t>,
   targets: list<Target.t>,
   hasVimeoAccessToken: bool,
+  vimeoAccountPlan: string,
 }
 
 let decodeProps = json => {
@@ -18,6 +19,7 @@ let decodeProps = json => {
     targetGroups: json |> field("targetGroups", list(TargetGroup.decode)),
     targets: json |> field("targets", list(Target.decode)),
     hasVimeoAccessToken: json |> field("hasVimeoAccessToken", bool),
+    vimeoAccountPlan: json |> field("vimeoAccountPlan", string),
   }
 }
 
@@ -32,6 +34,7 @@ ReactDOMRe.renderToElementWithId(
     targetGroups=props.targetGroups
     targets=props.targets
     hasVimeoAccessToken=props.hasVimeoAccessToken
+    vimeoAccountPlan=props.vimeoAccountPlan
   />,
   "curriculum-editor",
 )

--- a/app/javascript/packs/SchoolsCoursesCurriculumPack.res
+++ b/app/javascript/packs/SchoolsCoursesCurriculumPack.res
@@ -7,7 +7,7 @@ type props = {
   targetGroups: list<TargetGroup.t>,
   targets: list<Target.t>,
   hasVimeoAccessToken: bool,
-  vimeoAccountPlan: string,
+  vimeoAccountPlan: option<VimeoPlan.t>,
 }
 
 let decodeProps = json => {
@@ -19,7 +19,10 @@ let decodeProps = json => {
     targetGroups: json |> field("targetGroups", list(TargetGroup.decode)),
     targets: json |> field("targets", list(Target.decode)),
     hasVimeoAccessToken: json |> field("hasVimeoAccessToken", bool),
-    vimeoAccountPlan: json |> field("vimeoAccountPlan", string),
+    vimeoAccountPlan: Belt.Option.map(
+      json |> optional(field("vimeoAccountPlan", string)),
+      VimeoPlan.decode,
+    ),
   }
 }
 

--- a/app/javascript/packs/SchoolsCoursesCurriculumPack.res
+++ b/app/javascript/packs/SchoolsCoursesCurriculumPack.res
@@ -7,7 +7,7 @@ type props = {
   targetGroups: list<TargetGroup.t>,
   targets: list<Target.t>,
   hasVimeoAccessToken: bool,
-  vimeoAccountPlan: option<VimeoPlan.t>,
+  vimeoPlan: option<VimeoPlan.t>,
 }
 
 let decodeProps = json => {
@@ -19,10 +19,7 @@ let decodeProps = json => {
     targetGroups: json |> field("targetGroups", list(TargetGroup.decode)),
     targets: json |> field("targets", list(Target.decode)),
     hasVimeoAccessToken: json |> field("hasVimeoAccessToken", bool),
-    vimeoAccountPlan: Belt.Option.map(
-      json |> optional(field("vimeoAccountPlan", string)),
-      VimeoPlan.decode,
-    ),
+    vimeoPlan: Belt.Option.map(json |> optional(field("vimeoPlan", string)), VimeoPlan.decode),
   }
 }
 
@@ -37,7 +34,7 @@ ReactDOMRe.renderToElementWithId(
     targetGroups=props.targetGroups
     targets=props.targets
     hasVimeoAccessToken=props.hasVimeoAccessToken
-    vimeoAccountPlan=props.vimeoAccountPlan
+    vimeoPlan=props.vimeoPlan
   />,
   "curriculum-editor",
 )

--- a/app/javascript/schools/courses/components/CurriculumEditor.res
+++ b/app/javascript/schools/courses/components/CurriculumEditor.res
@@ -121,7 +121,7 @@ let make = (
   ~targetGroups,
   ~targets,
   ~hasVimeoAccessToken,
-  ~vimeoAccountPlan,
+  ~vimeoPlan,
 ) => {
   let path = ReasonReactRouter.useUrl().path
   let (state, send) = React.useReducerWithMapState(
@@ -197,7 +197,7 @@ let make = (
       evaluationCriteria
       course
       updateTargetCB
-      vimeoAccountPlan
+      vimeoPlan
     />
     {switch state.editorAction {
     | Hidden => ReasonReact.null

--- a/app/javascript/schools/courses/components/CurriculumEditor.res
+++ b/app/javascript/schools/courses/components/CurriculumEditor.res
@@ -121,6 +121,7 @@ let make = (
   ~targetGroups,
   ~targets,
   ~hasVimeoAccessToken,
+  ~vimeoAccountPlan,
 ) => {
   let path = ReasonReactRouter.useUrl().path
   let (state, send) = React.useReducerWithMapState(
@@ -196,6 +197,7 @@ let make = (
       evaluationCriteria
       course
       updateTargetCB
+      vimeoAccountPlan
     />
     {switch state.editorAction {
     | Hidden => ReasonReact.null

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
@@ -379,11 +379,11 @@ let submitForm = (target, aboveContentBlock, state, send, addContentBlockCB, blo
 let maxVideoSize = vimeoAccountPlan => {
   switch vimeoAccountPlan {
   | "basic" => 500 * 1024 * 1024
-  | "plus" => 5000 * 1024 * 1024
+  | "plus"
   | "pro"
   | "business"
   | "premium" =>
-    20000 * 1024 * 1024
+    5000 * 1024 * 1024
   | _ => FileUtils.defaultVideoMaxSize
   }
 }
@@ -391,10 +391,10 @@ let maxVideoSize = vimeoAccountPlan => {
 let maxVideoSizeString = vimeoAccountPlan => {
   switch vimeoAccountPlan {
   | "basic" => "500 MB"
-  | "plus" => "5 GB"
+  | "plus"
   | "pro"
   | "business"
-  | "premium" => "20 GB"
+  | "premium" => "5 GB"
   | _ => "500 MB"
   }
 }

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
@@ -378,24 +378,30 @@ let submitForm = (target, aboveContentBlock, state, send, addContentBlockCB, blo
 
 let maxVideoSize = vimeoAccountPlan => {
   switch vimeoAccountPlan {
-  | "basic" => 500 * 1024 * 1024
-  | "plus"
-  | "pro"
-  | "business"
-  | "premium" =>
-    5000 * 1024 * 1024
-  | _ => FileUtils.defaultVideoMaxSize
+  | Some(plan) =>
+    switch plan {
+    | VimeoPlan.Basic => 500 * 1024 * 1024
+    | Plus
+    | Pro
+    | Business
+    | Premium =>
+      5000 * 1024 * 1024
+    }
+  | None => FileUtils.defaultVideoMaxSize
   }
 }
 
 let maxVideoSizeString = vimeoAccountPlan => {
   switch vimeoAccountPlan {
-  | "basic" => "500 MB"
-  | "plus"
-  | "pro"
-  | "business"
-  | "premium" => "5 GB"
-  | _ => "500 MB"
+  | Some(plan) =>
+    switch plan {
+    | VimeoPlan.Basic => "500 MB"
+    | Plus
+    | Pro
+    | Business
+    | Premium => "5 GB"
+    }
+  | None => "500 MB"
   }
 }
 
@@ -429,11 +435,14 @@ let handleFileInputChange = (
       let maxVideoSize = maxVideoSize(vimeoAccountPlan)
       switch (FileUtils.isVideo(file), FileUtils.hasValidSize(~maxSize=maxVideoSize, file)) {
       | (false, true | false) =>
-        Some("Invalid file format, please select an MP4, MOV, WMV, AVI or FLV file.")
+        Some("Invalid file format, please select an MP4, MOV, WMV or AVI file.")
       | (true, false) =>
-        Some({
-          "Please select a file less than " ++ maxVideoSizeString(vimeoAccountPlan) ++ " in size."
-        })
+        Some(
+          t(
+            ~variables=[("maximumVideoSize", maxVideoSizeString(vimeoAccountPlan))],
+            "video.upload_limit_warning",
+          ),
+        )
       | (true, true) => None
       }
     }

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
@@ -376,8 +376,8 @@ let submitForm = (target, aboveContentBlock, state, send, addContentBlockCB, blo
   }
 }
 
-let maxVideoSize = vimeoAccountPlan => {
-  switch vimeoAccountPlan {
+let maxVideoSize = vimeoPlan => {
+  switch vimeoPlan {
   | Some(plan) =>
     switch plan {
     | VimeoPlan.Basic => 500 * 1024 * 1024
@@ -391,8 +391,8 @@ let maxVideoSize = vimeoAccountPlan => {
   }
 }
 
-let maxVideoSizeString = vimeoAccountPlan => {
-  switch vimeoAccountPlan {
+let maxVideoSizeString = vimeoPlan => {
+  switch vimeoPlan {
   | Some(plan) =>
     switch plan {
     | VimeoPlan.Basic => "500 MB"
@@ -411,7 +411,7 @@ let handleFileInputChange = (
   state,
   send,
   addContentBlockCB,
-  vimeoAccountPlan,
+  vimeoPlan,
   blockType,
   event,
 ) => {
@@ -427,13 +427,13 @@ let handleFileInputChange = (
     | #Image =>
       FileUtils.isInvalid(~image=true, file) ? Some(t("image.invalid_image_warning")) : None
     | #VideoEmbed =>
-      let maxVideoSize = maxVideoSize(vimeoAccountPlan)
+      let maxVideoSize = maxVideoSize(vimeoPlan)
       switch (FileUtils.isVideo(file), FileUtils.hasValidSize(~maxSize=maxVideoSize, file)) {
       | (false, true | false) => Some(t("video.invalid_format_warning"))
       | (true, false) =>
         Some(
           t(
-            ~variables=[("maximumVideoSize", maxVideoSizeString(vimeoAccountPlan))],
+            ~variables=[("maximumVideoSize", maxVideoSizeString(vimeoPlan))],
             "video.upload_limit_warning",
           ),
         )
@@ -458,7 +458,7 @@ let uploadForm = (
   send,
   addContentBlockCB,
   blockType,
-  vimeoAccountPlan,
+  vimeoPlan,
 ) => {
   let fileSelectionHandler = handleFileInputChange(
     target,
@@ -466,7 +466,7 @@ let uploadForm = (
     state,
     send,
     addContentBlockCB,
-    vimeoAccountPlan,
+    vimeoPlan,
   )
 
   let (fileId, formId, onChange, fileType) = switch blockType {
@@ -617,7 +617,7 @@ let make = (
   ~aboveContentBlock=?,
   ~addContentBlockCB,
   ~hasVimeoAccessToken,
-  ~vimeoAccountPlan,
+  ~vimeoPlan,
 ) => {
   let (embedInputId, isAboveContentBlock) = switch aboveContentBlock {
   | Some(contentBlock) =>
@@ -635,15 +635,7 @@ let make = (
   )
 
   let uploadFormCurried = uploadType =>
-    uploadForm(
-      target,
-      aboveContentBlock,
-      state,
-      send,
-      addContentBlockCB,
-      uploadType,
-      vimeoAccountPlan,
-    )
+    uploadForm(target, aboveContentBlock, state, send, addContentBlockCB, uploadType, vimeoPlan)
 
   <DisablingCover
     disabled={disablingCoverDisabled(state.saving, state.uploadProgress)}

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
@@ -423,19 +423,13 @@ let handleFileInputChange = (
     let file = files[0]
 
     let error = switch blockType {
-    | #File =>
-      FileUtils.isInvalid(file) ? Some("Please select a file with a size less than 5 MB.") : None
+    | #File => FileUtils.isInvalid(file) ? Some(t("file.upload_size_warning")) : None
     | #Image =>
-      FileUtils.isInvalid(~image=true, file)
-        ? Some(
-            "Please select an image (PNG, JPEG, GIF) with a size less than 5 MB, and less than 4096px wide or high.",
-          )
-        : None
+      FileUtils.isInvalid(~image=true, file) ? Some(t("image.invalid_image_warning")) : None
     | #VideoEmbed =>
       let maxVideoSize = maxVideoSize(vimeoAccountPlan)
       switch (FileUtils.isVideo(file), FileUtils.hasValidSize(~maxSize=maxVideoSize, file)) {
-      | (false, true | false) =>
-        Some("Invalid file format, please select an MP4, MOV, WMV or AVI file.")
+      | (false, true | false) => Some(t("video.invalid_format_warning"))
       | (true, false) =>
         Some(
           t(

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentEditor.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentEditor.res
@@ -99,7 +99,7 @@ let setDirty = (contentBlockId, send, dirty) => send(SetDirty(contentBlockId, di
 
 let updateContentBlock = (send, contentBlock) => send(UpdateContentBlock(contentBlock))
 
-let editor = (target, hasVimeoAccessToken, vimeoAccountPlan, state, send) => {
+let editor = (target, hasVimeoAccessToken, vimeoPlan, state, send) => {
   let currentVersion = switch state.versions {
   | [] => <span className="italic"> {"Not Versioned" |> str} </span>
   | versions =>
@@ -144,7 +144,7 @@ let editor = (target, hasVimeoAccessToken, vimeoAccountPlan, state, send) => {
         <CurriculumEditor__ContentBlockCreator
           target
           hasVimeoAccessToken
-          vimeoAccountPlan
+          vimeoPlan
           aboveContentBlock=contentBlock
           addContentBlockCB={addContentBlock(send)}
         />
@@ -159,13 +159,13 @@ let editor = (target, hasVimeoAccessToken, vimeoAccountPlan, state, send) => {
       </div>
     }) |> React.array}
     <CurriculumEditor__ContentBlockCreator
-      target hasVimeoAccessToken vimeoAccountPlan addContentBlockCB={addContentBlock(send)}
+      target hasVimeoAccessToken vimeoPlan addContentBlockCB={addContentBlock(send)}
     />
   </div>
 }
 
 @react.component
-let make = (~target, ~hasVimeoAccessToken, ~vimeoAccountPlan, ~setDirtyCB) => {
+let make = (~target, ~hasVimeoAccessToken, ~vimeoPlan, ~setDirtyCB) => {
   let (state, send) = React.useReducer(
     reducer,
     {
@@ -190,6 +190,6 @@ let make = (~target, ~hasVimeoAccessToken, ~vimeoAccountPlan, ~setDirtyCB) => {
   <div className="max-w-3xl py-6 px-3 mx-auto">
     {state.loading
       ? SkeletonLoading.multiple(~count=2, ~element=SkeletonLoading.contents())
-      : editor(target, hasVimeoAccessToken, vimeoAccountPlan, state, send)}
+      : editor(target, hasVimeoAccessToken, vimeoPlan, state, send)}
   </div>
 }

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentEditor.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentEditor.res
@@ -99,7 +99,7 @@ let setDirty = (contentBlockId, send, dirty) => send(SetDirty(contentBlockId, di
 
 let updateContentBlock = (send, contentBlock) => send(UpdateContentBlock(contentBlock))
 
-let editor = (target, hasVimeoAccessToken, state, send) => {
+let editor = (target, hasVimeoAccessToken, vimeoAccountPlan, state, send) => {
   let currentVersion = switch state.versions {
   | [] => <span className="italic"> {"Not Versioned" |> str} </span>
   | versions =>
@@ -144,6 +144,7 @@ let editor = (target, hasVimeoAccessToken, state, send) => {
         <CurriculumEditor__ContentBlockCreator
           target
           hasVimeoAccessToken
+          vimeoAccountPlan
           aboveContentBlock=contentBlock
           addContentBlockCB={addContentBlock(send)}
         />
@@ -158,13 +159,13 @@ let editor = (target, hasVimeoAccessToken, state, send) => {
       </div>
     }) |> React.array}
     <CurriculumEditor__ContentBlockCreator
-      target hasVimeoAccessToken addContentBlockCB={addContentBlock(send)}
+      target hasVimeoAccessToken vimeoAccountPlan addContentBlockCB={addContentBlock(send)}
     />
   </div>
 }
 
 @react.component
-let make = (~target, ~hasVimeoAccessToken, ~setDirtyCB) => {
+let make = (~target, ~hasVimeoAccessToken, ~vimeoAccountPlan, ~setDirtyCB) => {
   let (state, send) = React.useReducer(
     reducer,
     {
@@ -189,6 +190,6 @@ let make = (~target, ~hasVimeoAccessToken, ~setDirtyCB) => {
   <div className="max-w-3xl py-6 px-3 mx-auto">
     {state.loading
       ? SkeletonLoading.multiple(~count=2, ~element=SkeletonLoading.contents())
-      : editor(target, hasVimeoAccessToken, state, send)}
+      : editor(target, hasVimeoAccessToken, vimeoAccountPlan, state, send)}
   </div>
 }

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDrawer.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDrawer.res
@@ -60,7 +60,7 @@ let make = (
   ~evaluationCriteria,
   ~course,
   ~updateTargetCB,
-  ~vimeoAccountPlan,
+  ~vimeoPlan,
 ) => {
   let url = ReasonReactRouter.useUrl()
   let (dirty, setDirty) = React.useState(() => false)
@@ -92,7 +92,7 @@ let make = (
     let (innerComponent, selectedPage) = switch pageName {
     | "content" => (
         <CurriculumEditor__ContentEditor
-          target hasVimeoAccessToken vimeoAccountPlan setDirtyCB={dirty => setDirty(_ => dirty)}
+          target hasVimeoAccessToken vimeoPlan setDirtyCB={dirty => setDirty(_ => dirty)}
         />,
         Content,
       )

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDrawer.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDrawer.res
@@ -60,6 +60,7 @@ let make = (
   ~evaluationCriteria,
   ~course,
   ~updateTargetCB,
+  ~vimeoAccountPlan,
 ) => {
   let url = ReasonReactRouter.useUrl()
   let (dirty, setDirty) = React.useState(() => false)
@@ -91,7 +92,7 @@ let make = (
     let (innerComponent, selectedPage) = switch pageName {
     | "content" => (
         <CurriculumEditor__ContentEditor
-          target hasVimeoAccessToken setDirtyCB={dirty => setDirty(_ => dirty)}
+          target hasVimeoAccessToken vimeoAccountPlan setDirtyCB={dirty => setDirty(_ => dirty)}
         />,
         Content,
       )

--- a/app/javascript/schools/courses/types/CurriculumEditor__Types.res
+++ b/app/javascript/schools/courses/types/CurriculumEditor__Types.res
@@ -8,3 +8,4 @@ module QuizQuestion = CurriculumEditor__QuizQuestion
 module TargetDetails = CurriculumEditor__TargetDetails
 module Version = CurriculumEditor__Version
 module ChecklistItem = TargetChecklistItem
+module VimeoPlan = CurriculumEditor__VimeoPlan

--- a/app/javascript/schools/courses/types/curriculum_editor/CurriculumEditor__VimeoPlan.res
+++ b/app/javascript/schools/courses/types/curriculum_editor/CurriculumEditor__VimeoPlan.res
@@ -1,0 +1,14 @@
+exception UnknowPlanName(string)
+
+type t = Basic | Plus | Pro | Business | Premium
+
+let decode = planName => {
+  switch planName {
+  | "basic" => Basic
+  | "plus" => Plus
+  | "pro" => Pro
+  | "business" => Business
+  | "premium" => Premium
+  | unknownPlan => raise(UnknowPlanName(unknownPlan))
+  }
+}

--- a/app/javascript/schools/courses/types/curriculum_editor/CurriculumEditor__VimeoPlan.res
+++ b/app/javascript/schools/courses/types/curriculum_editor/CurriculumEditor__VimeoPlan.res
@@ -1,4 +1,4 @@
-exception UnknowPlanName(string)
+exception UnknownPlanName(string)
 
 type t = Basic | Plus | Pro | Business | Premium
 
@@ -9,6 +9,6 @@ let decode = planName => {
   | "pro" => Pro
   | "business" => Business
   | "premium" => Premium
-  | unknownPlan => raise(UnknowPlanName(unknownPlan))
+  | unknownPlan => raise(UnknownPlanName(unknownPlan))
   }
 }

--- a/app/javascript/shared/utils/FileUtils.res
+++ b/app/javascript/shared/utils/FileUtils.res
@@ -1,5 +1,5 @@
 let defaultMaxSize = 5 * 1024 * 1024
-let defaultVideoMaxSize = 1000 * 1024 * 1024
+let defaultVideoMaxSize = 500 * 1024 * 1024
 
 let hasValidSize = (~maxSize, file) => file["size"] <= maxSize
 

--- a/app/javascript/shared/utils/FileUtils.res
+++ b/app/javascript/shared/utils/FileUtils.res
@@ -16,8 +16,7 @@ let isVideo = file =>
   | "video/mp4"
   | "video/mov"
   | "video/wmv"
-  | "video/avi"
-  | "video/flv" => true
+  | "video/avi" => true
   | _ => false
   }
 

--- a/app/presenters/schools/courses/curriculum_presenter.rb
+++ b/app/presenters/schools/courses/curriculum_presenter.rb
@@ -17,7 +17,7 @@ module Schools
           target_groups: target_groups,
           targets: targets,
           has_vimeo_access_token: vimeo_access_token?,
-          vimeo_account_plan: vimeo_account_plan
+          vimeo_plan: vimeo_plan
         }
       end
 
@@ -79,7 +79,7 @@ module Schools
         @vimeo_access_token = @course.school.configuration.dig('vimeo', 'access_token').present? || Rails.application.secrets.vimeo_access_token.present?
       end
 
-      def vimeo_account_plan
+      def vimeo_plan
         return unless vimeo_access_token?
 
         @course.school.configuration['vimeo']['account_type']

--- a/app/presenters/schools/courses/curriculum_presenter.rb
+++ b/app/presenters/schools/courses/curriculum_presenter.rb
@@ -74,15 +74,13 @@ module Schools
       end
 
       def vimeo_access_token?
-        @vimeo_access_token ||= begin
-          token = @course.school.configuration['vimeo'] && @course.school.configuration['vimeo']['access_token'] ||
-            Rails.application.secrets.vimeo_access_token
-          token.present?
-        end
+        return @vimeo_access_token if instance_variable_defined?(:@vimeo_access_token)
+
+        @vimeo_access_token = @course.school.configuration.dig('vimeo', 'access_token').present? || Rails.application.secrets.vimeo_access_token.present?
       end
 
       def vimeo_account_plan
-        return '' unless vimeo_access_token?
+        return unless vimeo_access_token?
 
         @course.school.configuration['vimeo']['account_type']
       end

--- a/app/presenters/schools/courses/curriculum_presenter.rb
+++ b/app/presenters/schools/courses/curriculum_presenter.rb
@@ -12,11 +12,12 @@ module Schools
       def props
         {
           course: course_data,
-          evaluationCriteria: evaluation_criteria,
+          evaluation_criteria: evaluation_criteria,
           levels: levels,
-          targetGroups: target_groups,
+          target_groups: target_groups,
           targets: targets,
-          hasVimeoAccessToken: vimeo_access_token?
+          has_vimeo_access_token: vimeo_access_token?,
+          vimeo_account_plan: vimeo_account_plan
         }
       end
 
@@ -41,7 +42,7 @@ module Schools
             id: level.id,
             name: level.name,
             number: level.number,
-            unlockAt: level.unlock_at
+            unlock_at: level.unlock_at
           }
         end
       end
@@ -54,7 +55,7 @@ module Schools
             description: target_group.description,
             level_id: target_group.level_id,
             milestone: target_group.milestone,
-            sortIndex: target_group.sort_index,
+            sort_index: target_group.sort_index,
             archived: target_group.archived
           }
         end
@@ -66,16 +67,24 @@ module Schools
             id: target.id,
             target_group_id: target.target_group_id,
             title: target.title,
-            sortIndex: target.sort_index,
+            sort_index: target.sort_index,
             visibility: target.visibility
           }
         end
       end
 
       def vimeo_access_token?
-        token = @course.school.configuration['vimeo'] && @course.school.configuration['vimeo']['access_token'] ||
-          Rails.application.secrets.vimeo_access_token
-        token.present?
+        @vimeo_access_token ||= begin
+          token = @course.school.configuration['vimeo'] && @course.school.configuration['vimeo']['access_token'] ||
+            Rails.application.secrets.vimeo_access_token
+          token.present?
+        end
+      end
+
+      def vimeo_account_plan
+        return '' unless vimeo_access_token?
+
+        @course.school.configuration['vimeo']['account_type']
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
         description_label: Description
         uploading: Uploading
         select_file_button: Select File and Upload
+        upload_limit_warning: "Please select a file less than %{maximumVideoSize} in size."
       embed:
         url_label: URL to Embed
         url_help: We support a number of third-party services (check link below). Just copy & paste the full URL to the page that contains the resource that you'd like to embed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,11 +121,16 @@ en:
         image: Image
         embed: Embed
         video: Video
+      file:
+        upload_size_warning: "Please select a file with a size less than 5 MB."
+      image:
+        invalid_image_warning: "Please select an image (PNG, JPEG, GIF) with a size less than 5 MB, and less than 4096px wide or high."
       video:
         title_label: Title
         description_label: Description
         uploading: Uploading
         select_file_button: Select File and Upload
+        invalid_format_warning: "Invalid file format, please select an MP4, MOV, WMV or AVI file."
         upload_limit_warning: "Please select a file less than %{maximumVideoSize} in size."
       embed:
         url_label: URL to Embed

--- a/spec/system/school/courses/target_content_editor_spec.rb
+++ b/spec/system/school/courses/target_content_editor_spec.rb
@@ -284,7 +284,7 @@ feature 'Target Content Editor', js: true do
           find('label', text: 'Select File and Upload').click
         end
 
-        expect(page).to have_text('Invalid file format, please select an MP4, MOV, WMV, AVI or FLV file')
+        expect(page).to have_text('Invalid file format, please select an MP4, MOV, WMV or AVI file')
 
         # Upload a video
         fill_in 'Title', with: title


### PR DESCRIPTION
## Proposed Changes

- Set video upload limit in the content editor based on the connected Vimeo account plan.

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] ~Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [x] Ensure that UI text is kept in I18n files.
- [ ] ~Update developer and product docs, where applicable.~
- [ ] ~Prep screenshot or demo video for changelog entry, and attach it to issue.~
- [x] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] ~Check if changes in _packaged_ components have been published to `npm`.~
- [ ] ~Add development seeds for new tables.~
