### PR TITLE
Remove last remaining use of Founder#tag_list

### DIFF
--- a/app/models/founder.rb
+++ b/app/models/founder.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Founder < ApplicationRecord
-  acts_as_taggable
-
   serialize :roles
 
   belongs_to :user

--- a/app/presenters/schools/courses/inactive_students_presenter.rb
+++ b/app/presenters/schools/courses/inactive_students_presenter.rb
@@ -26,7 +26,7 @@ module Schools
 
       def students
         @students ||=
-          founders.includes(user: { avatar_attachment: :blob }, taggings: :tag).map do |student|
+          founders.includes(user: { avatar_attachment: :blob }).map do |student|
             {
               id: student.id,
               team_id: student.startup_id,

--- a/app/services/applicants/create_student_service.rb
+++ b/app/services/applicants/create_student_service.rb
@@ -31,13 +31,13 @@ module Applicants
       user.regenerate_login_token if user.login_token.blank?
       user.update!(name: @applicant.name)
 
-      startup = Startup.create!(name: @applicant.name, level: first_level)
+      # Create the team and tag it.
+      team = Startup.create!(name: @applicant.name, level: first_level)
+      team.tag_list.add(tag)
+      team.save!
 
-      # Finally, create a student profile for the user and tag it.
-      student = Founder.create!(user: user, startup: startup)
-      student.tag_list.add(tag)
-      student.save!
-      student
+      # Finally, create a student profile for the user.
+      Founder.create!(user: user, startup: team)
     end
 
     def school

--- a/spec/services/applicants/create_student_service_spec.rb
+++ b/spec/services/applicants/create_student_service_spec.rb
@@ -31,7 +31,7 @@ describe Applicants::CreateStudentService do
       expect(startup.level).to eq(level_one)
 
       # Founder should have tag "Public Signup"
-      expect(student.tag_list).to eq([tag])
+      expect(startup.tag_list).to eq([tag])
 
       # Applicant should be destroyed
       expect(Applicant.where(email: applicant.email).count).to eq(0)

--- a/spec/system/courses/apply_spec.rb
+++ b/spec/system/courses/apply_spec.rb
@@ -53,8 +53,11 @@ feature "Apply for public courses", js: true do
     expect(page).to have_content("Welcome to #{school.name}!")
     expect(page).to have_content(applicant.name)
     expect(page).to have_content(public_course.name)
-    expect(Founder.last.tag_list).to include(saved_tag)
-    expect(Founder.last.tag_list).not_to include('Public Signup')
+
+    team = User.with_email(applicant.email).first.founders.first.startup
+
+    expect(team.tag_list).to include(saved_tag)
+    expect(team.tag_list).not_to include('Public Signup')
   end
 
   scenario 'applicant tries to sign up multiple times in quick succession' do
@@ -88,7 +91,7 @@ feature "Apply for public courses", js: true do
     visit enroll_applicants_path(Applicant.last.login_token)
 
     expect(page).to have_content("Welcome to #{school.name}!")
-    expect(Founder.last.tag_list).to include('Public Signup')
+    expect(Startup.last.tag_list).to include('Public Signup')
   end
 
   scenario 'applicant signing up with an unknown tag is given the default tag' do
@@ -100,8 +103,11 @@ feature "Apply for public courses", js: true do
     visit enroll_applicants_path(Applicant.last.login_token)
 
     expect(page).to have_content("Welcome to #{school.name}!")
-    expect(Founder.last.tag_list).to include('Public Signup')
-    expect(Founder.last.tag_list).not_to include('An unknown tag')
+
+    team = Startup.last
+
+    expect(team.tag_list).to include('Public Signup')
+    expect(team.tag_list).not_to include('An unknown tag')
   end
 
   scenario 'applicant tag is remembered even if user navigates away before returning and applying' do
@@ -119,7 +125,8 @@ feature "Apply for public courses", js: true do
     expect(page).to have_content("We've sent you a verification mail")
 
     visit enroll_applicants_path(Applicant.last.login_token)
-    expect(Founder.last.tag_list).to include(saved_tag)
+
+    expect(Startup.last.tag_list).to include(saved_tag)
   end
 
   scenario "user visits a public course in other school" do


### PR DESCRIPTION
This removes one remaining usage of `tag_list` on student entries - in the public course application page. This feature has been updated to set `tag_list` on the student's team entry - we'd moved all student tags to their team entries a while back, and had apparently missed out on this usage of `founder.tag_list`. I've also removed the `acts_as_taggable` invocation from the `Founder`.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~~Check if route, query, or mutation authorization looks correct.~~
- [ ] ~~Ensure that UI text is kept in I18n files.~~
- [ ] ~~Update developer and product docs, where applicable.~~
- [ ] ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- [ ] ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- [ ] ~~Check if changes in _packaged_ components have been published to `npm`.~~
- [ ] ~~Add development seeds for new tables.~~
