### PR TITLE
feat: Parameterize the expiration of reset_password_token

### DIFF
--- a/app/services/users/validate_reset_token_service.rb
+++ b/app/services/users/validate_reset_token_service.rb
@@ -22,10 +22,31 @@ module Users
     def valid_request?
       return false if user.blank?
 
-      return false if user.reset_password_sent_at.blank?
+      return false if user.reset_password_sent_at.blank? && time_limitation?
 
+      if time_limitation?
+        valid_time?
+      else
+        true
+      end
+    end
+
+    def valid_time?
       time_since_last_mail = Time.zone.now - user.reset_password_sent_at
-      time_since_last_mail < 30.minutes
+      time_since_last_mail < time_limit_minutes
+    end
+
+    def time_limitation?
+      ENV.fetch('RESET_PASSWORD_TOKEN_TIME_LIMIT') { '' }.present?
+    end
+
+    def time_limit_minutes
+      env_var = ENV.fetch('RESET_PASSWORD_TOKEN_TIME_LIMIT') { '' } 
+      if env_var.present?
+        env_var.to_i.minutes
+      else
+        0.minutes
+      end
     end
   end
 end

--- a/spec/services/users/validate_reset_token_service_spec.rb
+++ b/spec/services/users/validate_reset_token_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe Users::ValidateResetTokenService do
+  let!(:token) { SecureRandom.uuid }
+  subject { described_class.new(token) }
+
+  describe '#authenticate' do
+    it 'returns nil if no user has the token' do
+      create :user
+      serv = described_class.new(token)
+      expect(serv.authenticate).to eq(nil)
+    end
+
+    context 'with time limit' do
+      let(:time_limit_minutes) { 3 }
+
+      before do
+        allow(subject).to receive(:time_limitation?) { true }
+        allow(subject).to receive(:time_limit_minutes) { time_limit_minutes.minutes }
+      end
+
+      it 'returns user based on #reset_password_token' do
+        sent_at = Time.zone.now - (time_limit_minutes - 1).minutes
+        user = create :user, reset_password_token: token, reset_password_sent_at: sent_at
+        expect(subject.authenticate).to eq(user)
+      end
+
+      it 'returns nil due to time limit' do
+        sent_at = Time.zone.now - (time_limit_minutes + 1).minutes
+        user = create :user, reset_password_sent_at: sent_at
+        expect(subject.authenticate).to eq(nil)
+      end
+    end
+
+    context 'without time limit' do
+      before do
+        allow(subject).to receive(:time_limitation?) { false }
+      end
+
+      it 'returns user based on #reset_password_token' do
+        user = create :user, reset_password_token: token
+        expect(subject.authenticate).to eq(user)
+      end
+    end
+  end
+end

--- a/spec/services/users/validate_reset_token_service_spec.rb
+++ b/spec/services/users/validate_reset_token_service_spec.rb
@@ -27,7 +27,7 @@ describe Users::ValidateResetTokenService do
 
       it 'returns nil due to time limit' do
         sent_at = Time.zone.now - (time_limit_minutes + 1).minutes
-        user = create :user, reset_password_sent_at: sent_at
+        create :user, reset_password_sent_at: sent_at
         expect(subject.authenticate).to eq(nil)
       end
     end


### PR DESCRIPTION
## Proposed Changes

- Add parameter to control if `User#reset_password_token` should be validated against the time when the reset_token was sent.
- This parameter also control how long, in minutes, the reset_password_token is valid after reset_password was sent.

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
