### PR TITLE
Fix UI inconsistency when re-grading an old submission

### DIFF
--- a/app/javascript/courses/review/components/CoursesReview__SubmissionOverlay.res
+++ b/app/javascript/courses/review/components/CoursesReview__SubmissionOverlay.res
@@ -233,15 +233,9 @@ let make = (
           className="review-submission-overlay__submission-container relative container mx-auto max-w-3xl px-3 lg:px-0 pb-8">
           {submissionDetails
           |> SubmissionDetails.submissions
-          |> ArrayUtils.copyAndSort((s1, s2) =>
-            DateFns.differenceInSeconds(
-              OverlaySubmission.createdAt(s2),
-              OverlaySubmission.createdAt(s1),
-            )
-          )
           |> Array.mapi((index, overlaySubmission) =>
             <CoursesReview__SubmissionsList
-              key={index |> string_of_int}
+              key={OverlaySubmission.id(overlaySubmission)}
               overlaySubmission
               teamSubmission={submissionDetails |> SubmissionDetails.students |> Array.length > 1}
               targetEvaluationCriteriaIds={submissionDetails |> SubmissionDetails.targetEvaluationCriteriaIds}

--- a/app/javascript/courses/review/components/CoursesReview__SubmissionOverlay.res
+++ b/app/javascript/courses/review/components/CoursesReview__SubmissionOverlay.res
@@ -233,6 +233,12 @@ let make = (
           className="review-submission-overlay__submission-container relative container mx-auto max-w-3xl px-3 lg:px-0 pb-8">
           {submissionDetails
           |> SubmissionDetails.submissions
+          |> ArrayUtils.copyAndSort((s1, s2) =>
+            DateFns.differenceInSeconds(
+              OverlaySubmission.createdAt(s2),
+              OverlaySubmission.createdAt(s1),
+            )
+          )
           |> Array.mapi((index, overlaySubmission) =>
             <CoursesReview__SubmissionsList
               key={OverlaySubmission.id(overlaySubmission)}

--- a/app/javascript/courses/review/components/CoursesReview__SubmissionsList.res
+++ b/app/javascript/courses/review/components/CoursesReview__SubmissionsList.res
@@ -150,48 +150,48 @@ let make = (
   ~targetId,
   ~targetEvaluationCriteriaIds,
 ) =>
-  <div
-    ariaLabel={"submissions-overlay-card-" ++ (overlaySubmission |> OverlaySubmission.id)}
-    className={cardClasses(overlaySubmission)}>
-    <div className="rounded-b-lg shadow">
-      <div
-        className="p-4 md:px-6 md:py-5 border-b bg-white flex flex-col sm:flex-row items-center justify-between">
-        <div className="flex flex-col w-full sm:w-auto">
-          <h2 className="font-semibold text-sm lg:text-base leading-tight">
-            {"Submission #" ++ (submissionNumber |> string_of_int) |> str}
-          </h2>
-          <span className="text-xs text-gray-800 pt-px">
-            {overlaySubmission
-            ->OverlaySubmission.createdAt
-            ->DateFns.formatPreset(~year=true, ())
-            ->str}
-          </span>
+  <Spread props={"data-submission-id": OverlaySubmission.id(overlaySubmission)}>
+    <div className={cardClasses(overlaySubmission)}>
+      <div className="rounded-b-lg shadow">
+        <div
+          className="p-4 md:px-6 md:py-5 border-b bg-white flex flex-col sm:flex-row items-center justify-between">
+          <div className="flex flex-col w-full sm:w-auto">
+            <h2 className="font-semibold text-sm lg:text-base leading-tight">
+              {"Submission #" ++ (submissionNumber |> string_of_int) |> str}
+            </h2>
+            <span className="text-xs text-gray-800 pt-px">
+              {overlaySubmission
+              ->OverlaySubmission.createdAt
+              ->DateFns.formatPreset(~year=true, ())
+              ->str}
+            </span>
+          </div>
+          <div className="text-xs flex w-full sm:w-auto mt-2 sm:mt-0">
+            {showFeedbackSent(
+              overlaySubmission |> OverlaySubmission.feedback |> ArrayUtils.isNotEmpty,
+            )}
+            {showSubmissionStatus(overlaySubmission)}
+          </div>
         </div>
-        <div className="text-xs flex w-full sm:w-auto mt-2 sm:mt-0">
-          {showFeedbackSent(
-            overlaySubmission |> OverlaySubmission.feedback |> ArrayUtils.isNotEmpty,
-          )}
-          {showSubmissionStatus(overlaySubmission)}
-        </div>
+        <CoursesReview__GradeCard
+          overlaySubmission
+          teamSubmission
+          evaluationCriteria
+          targetEvaluationCriteriaIds
+          reviewChecklist
+          addGradingCB={addGrading(~addGradingCB, ~currentCoach, ~overlaySubmission)}
+          updateReviewChecklistCB
+          targetId
+        />
+        <CoursesReview__ShowFeedback
+          feedback={overlaySubmission |> OverlaySubmission.feedback}
+          reviewed={overlaySubmission |> OverlaySubmission.grades |> ArrayUtils.isNotEmpty}
+          submissionId={overlaySubmission |> OverlaySubmission.id}
+          reviewChecklist
+          addFeedbackCB={addFeedback(addFeedbackCB, currentCoach, overlaySubmission)}
+          updateReviewChecklistCB
+          targetId
+        />
       </div>
-      <CoursesReview__GradeCard
-        overlaySubmission
-        teamSubmission
-        evaluationCriteria
-        targetEvaluationCriteriaIds
-        reviewChecklist
-        addGradingCB={addGrading(~addGradingCB, ~currentCoach, ~overlaySubmission)}
-        updateReviewChecklistCB
-        targetId
-      />
-      <CoursesReview__ShowFeedback
-        feedback={overlaySubmission |> OverlaySubmission.feedback}
-        reviewed={overlaySubmission |> OverlaySubmission.grades |> ArrayUtils.isNotEmpty}
-        submissionId={overlaySubmission |> OverlaySubmission.id}
-        reviewChecklist
-        addFeedbackCB={addFeedback(addFeedbackCB, currentCoach, overlaySubmission)}
-        updateReviewChecklistCB
-        targetId
-      />
     </div>
-  </div>
+  </Spread>

--- a/app/javascript/courses/review/types/CoursesReview__SubmissionDetails.res
+++ b/app/javascript/courses/review/types/CoursesReview__SubmissionDetails.res
@@ -85,9 +85,9 @@ let decodeJs = details =>
 
 let updateSubmission = (submission, t) => {
   ...t,
-  submissions: t.submissions
-  |> Js.Array.filter(s => s |> OverlaySubmission.id != (submission |> OverlaySubmission.id))
-  |> Array.append([submission]),
+  submissions: t.submissions |> Js.Array.map(s =>
+    OverlaySubmission.id(s) == OverlaySubmission.id(submission) ? submission : s
+  ),
 }
 
 let makeIndexSubmission = (overlaySubmission, t) =>
@@ -97,7 +97,7 @@ let makeIndexSubmission = (overlaySubmission, t) =>
     ~createdAt=overlaySubmission |> OverlaySubmission.createdAt,
     ~levelId=t.levelId,
     ~userNames=t.students
-    |> Array.map(student => student |> CoursesReview__Student.name)
+    |> Js.Array.map(student => student |> CoursesReview__Student.name)
     |> Js.Array.joinWith(", "),
     ~status=Some(
       IndexSubmission.makeStatus(

--- a/app/javascript/shared/components/Spread.res
+++ b/app/javascript/shared/components/Spread.res
@@ -1,0 +1,2 @@
+@react.component
+let make = (~props, ~children) => React.cloneElement(children, props)

--- a/example.env
+++ b/example.env
@@ -46,6 +46,9 @@ JAVASCRIPT_DRIVER=headless_chrome
 # This is the number of seconds capybara will wait for expected content.
 CAPYBARA_MAX_WAIT_TIME=5
 
+# Number of times to retry a failing system test.
+RSPEC_RETRY_COUNT=2
+
 # Report runtime errors to Rollbar.
 ROLLBAR_CLIENT_TOKEN=post_client_item_from_rollbar
 ROLLBAR_SERVER_TOKEN=post_server_item_from_rollbar

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -141,11 +141,21 @@ RSpec.configure do |config|
   # Show retry status in spec process.
   config.verbose_retry = true
 
-  # Try twice (retry once).
-  config.default_retry_count = 2
+  # show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
 
-  # Only retry when Selenium raises Net::ReadTimeout.
-  config.exceptions_to_retry = [Net::ReadTimeout]
+  # Run retry only on JS-enabled tests.
+  config.around :each, :js do |ex|
+    ex.run_with_retry retry: ENV['RSPEC_RETRY_COUNT'].to_i
+  end
+
+  # callback to be run between retries
+  config.retry_callback = proc do |ex|
+    # run some additional clean up task - can be filtered by example metadata
+    if ex.metadata[:js]
+      Capybara.reset!
+    end
+  end
 end
 
 # Increase Capybara's default maximum wait time to 5 seconds to allow for some slow responds (timeline builder).

--- a/spec/system/certificates/auto_issue_certificates_spec.rb
+++ b/spec/system/certificates/auto_issue_certificates_spec.rb
@@ -259,7 +259,7 @@ feature 'Automatic issuance of certificates', js: true do
       scenario 'student resubmits the final target' do
         sign_in_user coach.user, referrer: review_timeline_event_path(@resubmission)
 
-        within("div[aria-label='submissions-overlay-card-#{@resubmission.id}']") do
+        within("div[data-submission-id='#{@resubmission.id}']") do
           find("button[title='Good']").click
         end
 

--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Submission review overlay' do
+feature 'Submission review overlay', js: true do
   include UserSpecHelper
   include MarkdownEditorHelper
   include NotificationHelper
@@ -38,7 +38,7 @@ feature 'Submission review overlay' do
     let!(:submission_pending) { create(:timeline_event, :with_owners, owners: [student], latest: true, target: target) }
     let!(:submission_pending_2) { create(:timeline_event, :with_owners, owners: [student], latest: true, target: target_2) }
 
-    scenario 'coach visits submission review page', js: true do
+    scenario 'coach visits submission review page' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_pending)
 
       within("div[aria-label='submissions-overlay-header']") do
@@ -61,7 +61,7 @@ feature 'Submission review overlay' do
       expect(page).to have_button('Save grades', disabled: true)
     end
 
-    scenario 'coach evaluates a pending submission and gives a feedback', js: true do
+    scenario 'coach evaluates a pending submission and gives a feedback' do
       sign_in_user coach.user, referrer: review_course_path(course)
 
       expect(page).to have_content(target.title)
@@ -123,7 +123,7 @@ feature 'Submission review overlay' do
       expect(page).to_not have_text(submission.target.title)
     end
 
-    scenario 'coach generates feedback from review checklist', js: true do
+    scenario 'coach generates feedback from review checklist' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_pending)
 
       # Checklist item 1
@@ -230,7 +230,7 @@ feature 'Submission review overlay' do
       expect(target.reload.review_checklist).to eq([])
     end
 
-    scenario 'coach evaluates a pending submission and mark a checklist as incorrect', js: true do
+    scenario 'coach evaluates a pending submission and mark a checklist as incorrect' do
       question_1 = Faker::Lorem.sentence
       question_2 = Faker::Lorem.sentence
       question_3 = Faker::Lorem.sentence
@@ -335,7 +335,7 @@ feature 'Submission review overlay' do
       expect(submission_pending.reload.checklist).to eq(submission_checklist)
     end
 
-    scenario 'coach evaluates a pending submission without giving a feedback', js: true do
+    scenario 'coach evaluates a pending submission without giving a feedback' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_pending)
 
       expect(page).to have_content('Grade Card')
@@ -385,7 +385,7 @@ feature 'Submission review overlay' do
       expect(page).to have_text("The page you were looking for doesn't exist!")
     end
 
-    scenario 'coach is warned when a student has dropped out', js: true do
+    scenario 'coach is warned when a student has dropped out' do
       team.update!(dropped_out_at: 1.day.ago)
 
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_pending)
@@ -393,7 +393,7 @@ feature 'Submission review overlay' do
       expect(page).to have_text('This submission is from a student whose access to the course has ended, or has dropped out.')
     end
 
-    scenario "coach is warned when a student's access to course has ended", js: true do
+    scenario "coach is warned when a student's access to course has ended" do
       team.update!(access_ends_at: 1.day.ago)
 
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_pending)
@@ -408,14 +408,14 @@ feature 'Submission review overlay' do
         submission_pending.founders << another_team.founders.first
       end
 
-      scenario 'coach is warned when one student in the submission is inactive', js: true do
+      scenario 'coach is warned when one student in the submission is inactive' do
         sign_in_user coach.user, referrer: review_timeline_event_path(submission_pending)
 
         expect(page).to have_text('This submission is linked to one or more students whose access to the course has ended, or have dropped out.')
       end
     end
 
-    scenario 'coach leaves a note about a student', js: true do
+    scenario 'coach leaves a note about a student' do
       note = Faker::Lorem.sentence
 
       sign_in_user team_coach.user, referrer: review_timeline_event_path(submission_pending)
@@ -442,7 +442,7 @@ feature 'Submission review overlay' do
       expect(new_notes.first.student_id).to eq(student.id)
     end
 
-    scenario 'coach leaves a note for a team submission', js: true do
+    scenario 'coach leaves a note for a team submission' do
       another_student = team.founders.where.not(id: student).first
       submission_pending.founders << another_student
       note = Faker::Lorem.sentence
@@ -471,7 +471,7 @@ feature 'Submission review overlay' do
       expect(new_notes.pluck(:student_id)).to contain_exactly(student.id, another_student.id)
     end
 
-    scenario 'coach opens the overlay for a submission after its status has changed in the DB', js: true do
+    scenario 'coach opens the overlay for a submission after its status has changed in the DB' do
       # Opening the overlay should reload data on index if it's different.
       sign_in_user coach.user, referrer: review_course_path(course)
 
@@ -522,9 +522,9 @@ feature 'Submission review overlay' do
 
   context 'with a reviewed submission' do
     let!(:submission_reviewed) { create(:timeline_event, :with_owners, latest: true, owners: team.founders, target: target, evaluator_id: coach.id, evaluated_at: 1.day.ago, passed_at: 1.day.ago) }
-    let!(:timeline_event_grade) { create(:timeline_event_grade, timeline_event: submission_reviewed, evaluation_criterion: evaluation_criterion_1) }
+    let!(:timeline_event_grade) { create(:timeline_event_grade, timeline_event: submission_reviewed, evaluation_criterion: evaluation_criterion_1, grade: 4) }
 
-    scenario 'coach visits submission review page', js: true do
+    scenario 'coach visits submission review page' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_reviewed)
 
       within("div[aria-label='submissions-overlay-header']") do
@@ -557,7 +557,7 @@ feature 'Submission review overlay' do
       expect(page).to have_button('Add feedback')
     end
 
-    scenario 'coach add his feedback', js: true do
+    scenario 'coach add his feedback' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_reviewed)
 
       within("div[aria-label='submission-status']") do
@@ -593,7 +593,7 @@ feature 'Submission review overlay' do
       expect(submission.startup_feedback.last.feedback).to eq(feedback)
     end
 
-    scenario 'coach can undo grading', js: true do
+    scenario 'coach can undo grading' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_reviewed)
 
       within("div[aria-label='submission-status']") do
@@ -613,9 +613,44 @@ feature 'Submission review overlay' do
       expect(submission.evaluated_at).to eq(nil)
       expect(submission.timeline_event_grades).to eq([])
     end
+
+    context 'with two reviewed submissions' do
+      let!(:submission_reviewed_old) { create(:timeline_event, :with_owners, owners: team.founders, target: target, created_at: 3.days.ago) }
+
+      scenario 'coach re-grades an old submission' do
+        sign_in_user coach.user, referrer: review_timeline_event_path(submission_reviewed_old)
+
+        within("div[data-submission-id='#{submission_reviewed_old.id}']") do
+          within("div[aria-label='evaluation-criterion-#{evaluation_criterion_1.id}']") do
+            find("button[title='Good']").click
+          end
+
+          within("div[aria-label='evaluation-criterion-#{evaluation_criterion_2.id}']") do
+            find("button[title='Bad']").click
+          end
+
+          click_button 'Save grades'
+        end
+
+        expect(page).to have_text('The submission has been marked as reviewed')
+
+        screenshot_and_open_image
+
+        within("div[data-submission-id='#{submission_reviewed_old.id}']") do
+          expect(page).to have_text('Submission #1')
+          expect(page).to have_text('2/4')
+          expect(page).to have_text('1/3')
+        end
+
+        within("div[data-submission-id='#{submission_reviewed.id}']") do
+          expect(page).to have_text('Submission #2')
+          expect(page).to have_text('4/4')
+        end
+      end
+    end
   end
 
-  context 'Evaluation criteria changed for a target with graded submissions' do
+  context 'when evaluation criteria changed for a target with graded submissions' do
     let(:target_1) { create :target, :for_founders, target_group: target_group }
     let!(:submission_reviewed) { create(:timeline_event, :with_owners, latest: true, owners: [team.founders.first], target: target_1, evaluator_id: coach.id, evaluated_at: 1.day.ago, passed_at: 1.day.ago) }
     let!(:timeline_event_grade_1) { create(:timeline_event_grade, timeline_event: submission_reviewed, evaluation_criterion: evaluation_criterion_1) }
@@ -626,7 +661,7 @@ feature 'Submission review overlay' do
       target_1.evaluation_criteria << [evaluation_criterion_1]
     end
 
-    scenario 'coach visits a submission and grades pending submission', js: true do
+    scenario 'coach visits a submission and grades pending submission' do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_reviewed)
 
       within("div[data-submission-id='#{submission_reviewed.id}']") do
@@ -669,7 +704,7 @@ feature 'Submission review overlay' do
       submission_reviewed.startup_feedback << feedback
     end
 
-    scenario 'team coach add his feedback', js: true do
+    scenario 'team coach add his feedback' do
       sign_in_user team_coach.user, referrer: review_timeline_event_path(submission_reviewed)
       within("div[aria-label='submission-status']") do
         expect(page).to have_text('Completed')
@@ -701,7 +736,7 @@ feature 'Submission review overlay' do
       expect(submission.startup_feedback.last.feedback).to eq(feedback)
     end
 
-    scenario 'team coach undo submission', js: true do
+    scenario 'team coach undo grading' do
       sign_in_user team_coach.user, referrer: review_timeline_event_path(submission_reviewed)
 
       within("div[aria-label='submission-status']") do
@@ -749,7 +784,7 @@ feature 'Submission review overlay' do
     let!(:timeline_event_grade_3) { create(:timeline_event_grade, timeline_event: submission_reviewed_3, evaluation_criterion: evaluation_criterion_1) }
     let!(:timeline_event_grade_4) { create(:timeline_event_grade, timeline_event: submission_reviewed_4, evaluation_criterion: evaluation_criterion_1) }
 
-    scenario "coach viewing a submission's review page is only shown other submissions with identical owners", js: true do
+    scenario "coach viewing a submission's review page is only shown other submissions with identical owners" do
       sign_in_user team_coach.user, referrer: review_timeline_event_path(submission_reviewed_1)
 
       # submission 1
@@ -772,7 +807,7 @@ feature 'Submission review overlay' do
     end
   end
 
-  context 'when there are team targets and individual target submissions to review', js: true do
+  context 'when there are team targets and individual target submissions to review' do
     let(:individual_target) { create :target, :for_founders, target_group: target_group }
     let(:team_target) { create :target, :for_team, target_group: target_group }
     let(:team_1) { create :startup, level: level }

--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -629,7 +629,7 @@ feature 'Submission review overlay' do
     scenario 'coach visits a submission and grades pending submission', js: true do
       sign_in_user coach.user, referrer: review_timeline_event_path(submission_reviewed)
 
-      within("div[aria-label='submissions-overlay-card-#{submission_reviewed.id}']") do
+      within("div[data-submission-id='#{submission_reviewed.id}']") do
         # Evaluation criteria at the point of grading are shown for reviewed submissions
         within("div[aria-label='evaluation-criterion-#{evaluation_criterion_1.id}']") do
           expect(page).to have_text(evaluation_criterion_1.name)
@@ -642,7 +642,7 @@ feature 'Submission review overlay' do
         end
       end
 
-      within("div[aria-label='submissions-overlay-card-#{submission_pending.id}']") do
+      within("div[data-submission-id='#{submission_pending.id}']") do
         # New list of evaluation criteria are shown for pending submissions
         expect(page).to have_text(evaluation_criterion_1.name)
         expect(page).not_to have_text(evaluation_criterion_2.name)


### PR DESCRIPTION
This fixes a bug in the coach's submission review overlay, where undoing the grading for an old submission (when a student has more than one submission), and then re-grading it would cause the UI to show the new grade on an incorrect submission. This fixes the UI-failure - the data stored by the server was unaffected, and a page reload would have shown the correct info.

This PR also includes a few other miscellaneous changes:

1. It introduces the `Spread` component.
2. It makes usage of the `rspec-retry` gem configurable via an environment variable.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~~Check if route, query, or mutation authorization looks correct.~~
- [ ] ~~Ensure that UI text is kept in I18n files.~~
- [ ] ~~Update developer and product docs, where applicable.~~
- [ ] ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- [ ] ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- [ ] ~~Check if changes in _packaged_ components have been published to `npm`.~~
- [ ] ~~Add development seeds for new tables.~~
