### PR TITLE
Handle inactive courses properly on the homepage

### DIFF
--- a/app/models/startup.rb
+++ b/app/models/startup.rb
@@ -28,49 +28,11 @@ class Startup < ApplicationRecord
     errors[:level] << 'cannot be assigned to level zero' unless level.number.positive?
   end
 
-  before_validation do
-    # Default product name to 'Untitled Product' if absent
-    self.name ||= 'Untitled Product'
-  end
-
-  before_destroy do
-    # Clear out associations from associated Founders (and pending ones).
-    Founder.where(startup_id: id).update_all(startup_id: nil) # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def founder_ids=(list_of_ids)
-    founders_list = Founder.find(list_of_ids.map(&:to_i).select { |e| e.is_a?(Integer) && e.positive? })
-    founders_list.each { |u| founders << u }
-  end
-
-  def founder?(founder)
-    return false unless founder
-
-    founder.startup_id == id
-  end
-
-  def possible_founders
-    founders + Founder.non_founders
-  end
-
-  def cofounders(founder)
-    founders - [founder]
-  end
-
-  # returns the date of the earliest verified timeline entry
-  def earliest_team_event_date
-    timeline_events.where.not(passed_at: nil).not_private.order(:created_at).first.try(:created_at)
-  end
-
   def display_name
     name
   end
 
   def timeline_events
     TimelineEvent.joins(:timeline_event_owners).where(timeline_event_owners: { founder: founders })
-  end
-
-  def active?
-    access_ends_at.blank? || (access_ends_at > Time.now)
   end
 end

--- a/app/presenters/home/index_presenter.rb
+++ b/app/presenters/home/index_presenter.rb
@@ -36,9 +36,19 @@ module Home
     def courses_as_student
       @courses_as_student ||= begin
         if current_user.present?
-          current_user.founders.joins(:course).pluck('courses.id')
+          current_user.founders.includes(:startup, :level).each_with_object({}) do |student, courses|
+            status = if student.dropped_out?
+              :dropped_out
+            elsif student.access_ended?
+              :access_ended
+            else
+              :active
+            end
+
+            courses[student.level.course_id] = status
+          end
         else
-          []
+          {}
         end
       end
     end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -25,7 +25,7 @@
       class="school-index__about flex relative bg-primary-900 shadow-xl rounded-lg mx-3 lg:mx-0 -mt-7">
       <div
         class=" <%= presenter.school_name_classes %>">
-        <p class="md:text-xl">Hello, welcome to </p>
+        <p class="md:text-xl"><%= t('home.index.welcome_prefix') %></p>
         <h1 class="leading-tight text-3xl md:text-5xl">
           <span> <%= current_school.name %> </span>
         </h1>
@@ -40,7 +40,7 @@
       <div>
         <div class="mx-auto text-center pt-8 mt-8">
           <h2 class="school-index-featured-courses__header relative text-2xl font-bold">
-            Featured Courses
+            <%= t('home.index.featured_courses_heading') %>
           </h2>
         </div>
         <div class="mx-auto">
@@ -71,21 +71,34 @@
                       <%= course.description %>
                     </div>
                     <div class="flex w-full p-6 justify-center">
-                      <% if presenter.courses_as_student.include?(course.id) %>
-                        <a class="w-full btn btn-secondary" href="/courses/<%= course.id %>/curriculum">
-                          <i class="fas fa-book mr-2"></i>
-                          View Course
-                        </a>
-                      <% else %>
+                      <% case presenter.courses_as_student[course.id] %>
+                      <% when nil %>
                         <a class="w-full btn <%= course.public_signup? ? 'btn-primary' : 'btn-default' %>" href="/courses/<%= course.id %>">
                           <% if course.public_signup? %>
                             <i class="fas fa-feather-alt mr-2"></i>
-                            Get started
+                            <%= t('home.index.get_started') %>
                           <% else %>
                             <i class="fas fa-info-circle mr-2"></i>
-                            Learn more
+                            <%= t('home.index.learn_more') %>
                           <% end %>
                         </a>
+                      <% when :dropped_out %>
+                        <div class="w-full bg-red-100 text-red-600 py-2 px-4 rounded flex text-sm font-semibold justify-center items-center">
+                          <i class="fas fa-user-slash mr-2"></i>
+                          <%= t('home.index.course_status.dropped_out') %>
+                        </div>
+                      <% when :access_ended %>
+                        <a class="w-full btn btn-secondary" href="/courses/<%= course.id %>/curriculum">
+                          <i class="fas fa-eye mr-2"></i>
+                          <%= t('home.index.course_status.access_ended') %>
+                        </a>
+                      <% when :active %>
+                        <a class="w-full btn btn-secondary" href="/courses/<%= course.id %>/curriculum">
+                          <i class="fas fa-book mr-2"></i>
+                          <%= t('home.index.course_status.active') %>
+                        </a>
+                      <% else %>
+                        <% raise "Encountered unexpected course status #{presenter.courses_as_student[course.id]}" %>
                       <% end %>
                     </div>
                   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,6 +481,18 @@ en:
     create:
       invalid_credentials: The supplied email address and password do not match. Please check your credentials and try again.
 
+  home:
+    index:
+      welcome_prefix: Hello, welcome to
+      featured_courses_heading: Featured Courses
+      get_started: Get started
+      learn_more: Learn more
+      course_status:
+        active: Continue course
+        access_ended: Review course content
+        dropped_out: Dropped out
+
+
   ####################################
   # THIRD-PARTY LIBRARY TRANSLATIONS #
   ####################################

--- a/spec/system/home/index_spec.rb
+++ b/spec/system/home/index_spec.rb
@@ -80,7 +80,27 @@ feature 'Index spec', js: true do
     scenario 'students can jump directly into the course curriculum' do
       sign_in_user student.user, referrer: root_path
 
-      expect(page).to have_link('View Course', href: curriculum_course_path(course_1))
+      expect(page).to have_link('Continue course', href: curriculum_course_path(course_1))
+    end
+
+    scenario 'student can review content of courses where access has ended' do
+      team.update!(access_ends_at: 1.day.ago)
+
+      sign_in_user student.user, referrer: root_path
+
+      expect(page).to have_link('Review course content', href: curriculum_course_path(course_1))
+    end
+
+    scenario 'student cannot access course content when they have dropped out' do
+      team.update!(dropped_out_at: 1.day.ago)
+
+      sign_in_user student.user, referrer: root_path
+
+      expect(page).not_to have_link('Continue course')
+
+      within("div[aria-label='#{course_1.name}'") do
+        expect(page).to have_text('Dropped out')
+      end
     end
   end
 end


### PR DESCRIPTION
## Proposed Changes

This adds different views for when a logged in student is dropped out, or whose access has ended.

This PR also changes the button label for when a student is active in the course, from _View Course_ to _Continue Course_.

@pupilfirst/developers

![Screenshot for changelog](https://res.cloudinary.com/sv-co/image/upload/v1612861971/pupilfirst_changelog/2021/homepage_course_status_trlllt.jpg)

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- [ ] ~~Update developer and product docs, where applicable.~~
- [x] Prep screenshot or demo video for changelog entry, and attach it to PR: [LINK](https://res.cloudinary.com/sv-co/image/upload/v1612861971/pupilfirst_changelog/2021/homepage_course_status_trlllt.jpg)
- [ ] ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- [ ] ~~Check if changes in _packaged_ components have been published to `npm`.~~
- [ ] ~~Add development seeds for new tables.~~
