### PR TITLE
Add edit buttons to the student curriculum UI for course authors

### DIFF
--- a/app/javascript/courses/curricula/components/CoursesCurriculum.css
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.css
@@ -27,3 +27,7 @@
 .curriculum__target-status--locked {
   @apply bg-gray-100 text-gray-800 border-gray-600;
 }
+
+.courses-curriculum__target-container:hover .courses-curriculum__target-quick-link {
+  @apply border-gray-300 text-gray-700;
+}

--- a/app/javascript/courses/curricula/components/CoursesCurriculum.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.res
@@ -472,6 +472,20 @@ let make = (
               setState(state => {...state, showLevelZero: showLevelZero})}
             levelZero
           />
+          {ReactUtils.nullUnless(
+            <div className="text-center mt-2 max-w-3xl mx-auto">
+              <a
+                className="btn btn-primary-ghost btn-small"
+                href={"/school/courses/" ++
+                Course.id(course) ++
+                "/curriculum?level=" ++
+                Level.number(currentLevel)->string_of_int}>
+                <i className="fas fa-pencil-alt" />
+                <span className="ml-2"> {str("Edit Level")} </span>
+              </a>
+            </div>,
+            author,
+          )}
           {currentLevel |> Level.isLocked && accessLockedLevels
             ? <div className="text-center p-3 mt-5 border rounded-lg bg-blue-100 max-w-3xl mx-auto">
                 {"This level is still locked for students, and will be unlocked on " |> str}

--- a/app/javascript/courses/curricula/components/CoursesCurriculum.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.res
@@ -450,6 +450,7 @@ let make = (
         evaluationCriteria
         coaches
         preview
+        author
       />
 
     | None => React.null

--- a/app/javascript/courses/curricula/components/CoursesCurriculum.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum.res
@@ -47,7 +47,7 @@ let rendertarget = (target, statusOfTargets, author, courseId) => {
     </Link>
     {ReactUtils.nullUnless(
       <a
-        title={"Edit target " ++ Target.title(target)}
+        title={t("edit_target_button_title", ~variables=[("title", Target.title(target))])}
         href={"/school/courses/" ++ courseId ++ "/targets/" ++ targetId ++ "/content"}
         className="hidden lg:block courses-curriculum__target-quick-link text-gray-400 border-l border-transparent py-6 px-3 hover:bg-gray-200">
         <i className="fas fa-pencil-alt" />
@@ -74,7 +74,7 @@ let renderTargetGroup = (targetGroup, targets, statusOfTargets, author, courseId
         : React.null}
       <div className="p-6 pt-5">
         <div className="text-2xl font-bold leading-snug">
-          {targetGroup |> TargetGroup.name |> str}
+          {TargetGroup.name(targetGroup)->str}
         </div>
         <MarkdownBlock
           className="text-sm max-w-md mx-auto leading-snug"
@@ -113,8 +113,8 @@ let handleLockedLevel = level =>
     | Some(date) =>
       let dateString = date->DateFns.format("MMMM d, yyyy")
       <div className="font-semibold text-md px-3">
-        <p> {t("level_locked_notice") |> str} </p>
-        <p> {"You can access the content on " ++ (dateString ++ ".") |> str} </p>
+        <p> {t("level_locked_notice")->str} </p>
+        <p> {t("level_locked_explanation", ~variables=[("date", dateString)])->str} </p>
       </div>
     | None => React.null
     }}
@@ -482,17 +482,21 @@ let make = (
                 "/curriculum?level=" ++
                 Level.number(currentLevel)->string_of_int}>
                 <i className="fas fa-pencil-alt" />
-                <span className="ml-2"> {str("Edit Level")} </span>
+                <span className="ml-2"> {t("edit_level_button")->str} </span>
               </a>
             </div>,
             author,
           )}
           {currentLevel |> Level.isLocked && accessLockedLevels
-            ? <div className="text-center p-3 mt-5 border rounded-lg bg-blue-100 max-w-3xl mx-auto">
-                {"This level is still locked for students, and will be unlocked on " |> str}
-                <strong> {currentLevel |> Level.unlockDateString |> str} </strong>
-                {"." |> str}
-              </div>
+            ? <div
+                className="text-center p-3 mt-5 border rounded-lg bg-blue-100 max-w-3xl mx-auto"
+                dangerouslySetInnerHTML={
+                  "__html": t(
+                    "level_locked_for_students_notice",
+                    ~variables=[("date", Level.unlockDateString(currentLevel))],
+                  ),
+                }
+              />
             : React.null}
           {Level.isUnlocked(currentLevel) || accessLockedLevels
             ? targetGroupsInLevel == []

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Learn.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Learn.res
@@ -1,7 +1,19 @@
 open CoursesCurriculum__Types
 
 @react.component
-let make = (~targetDetails) => {
-  let contentBlocks = targetDetails |> TargetDetails.contentBlocks |> ContentBlock.sort
-  <div id="learn-component"> <TargetContentView contentBlocks /> </div>
+let make = (~targetDetails, ~author, ~courseId, ~targetId) => {
+  <div id="learn-component">
+    {ReactUtils.nullUnless(
+      <a
+        className="btn btn-primary-ghost btn-small"
+        href={"/school/courses/" ++ courseId ++ "/targets/" ++ targetId ++ "/content"}>
+        <i className="fas fa-pencil-alt" />
+        <span className="ml-2"> {React.string("Edit Content")} </span>
+      </a>,
+      author,
+    )}
+    <TargetContentView
+      contentBlocks={TargetDetails.contentBlocks(targetDetails)->ContentBlock.sort}
+    />
+  </div>
 }

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Learn.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Learn.res
@@ -1,5 +1,7 @@
 open CoursesCurriculum__Types
 
+let t = I18n.t(~scope="components.CoursesCurriculum__Learn")
+
 @react.component
 let make = (~targetDetails, ~author, ~courseId, ~targetId) => {
   <div id="learn-component">
@@ -8,7 +10,7 @@ let make = (~targetDetails, ~author, ~courseId, ~targetId) => {
         className="btn btn-primary-ghost btn-small"
         href={"/school/courses/" ++ courseId ++ "/targets/" ++ targetId ++ "/content"}>
         <i className="fas fa-pencil-alt" />
-        <span className="ml-2"> {React.string("Edit Content")} </span>
+        <span className="ml-2"> {t("edit_target_button")->React.string} </span>
       </a>,
       author,
     )}

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.res
@@ -307,9 +307,9 @@ let handleLocked = (target, targets, targetStatus, statusOfTargets) =>
 
 let overlayContentClasses = bool => bool ? "" : "hidden"
 
-let learnSection = (targetDetails, tab) =>
+let learnSection = (targetDetails, tab, author, courseId, targetId) =>
   <div className={overlayContentClasses(tab == Learn)}>
-    <CoursesCurriculum__Learn targetDetails />
+    <CoursesCurriculum__Learn targetDetails author courseId targetId />
   </div>
 
 let discussSection = (target, targetDetails, tab) =>
@@ -518,6 +518,7 @@ let make = (
   ~evaluationCriteria,
   ~coaches,
   ~preview,
+  ~author,
 ) => {
   let (state, send) = React.useReducer(reducer, initialState)
 
@@ -560,7 +561,7 @@ let make = (
     | Some(targetDetails) =>
       <div>
         <div className="container mx-auto mt-6 md:mt-8 max-w-3xl px-3 lg:px-0">
-          {learnSection(targetDetails, state.tab)}
+          {learnSection(targetDetails, state.tab, author, Course.id(course), Target.id(target))}
           {discussSection(target, targetDetails, state.tab)}
           {completeSection(
             state,

--- a/app/javascript/courses/curricula/types/CoursesCurriculum__TargetStatus.res
+++ b/app/javascript/courses/curricula/types/CoursesCurriculum__TargetStatus.res
@@ -164,11 +164,11 @@ let lockReasonToString = lr =>
 
 let statusToString = t =>
   switch t.status {
-  | Pending => "Pending"
-  | PendingReview => "Pending Review"
-  | Completed => "Completed"
-  | Rejected => "Rejected"
-  | Locked(_) => "Locked"
+  | Pending => tc("status.pending")
+  | PendingReview => tc("status.pending_review")
+  | Completed => tc("status.completed")
+  | Rejected => tc("status.rejected")
+  | Locked(_) => tc("status.locked")
   }
 
 let statusClassesSufix = t =>

--- a/app/javascript/packs/CoursesCurriculumPack.res
+++ b/app/javascript/packs/CoursesCurriculumPack.res
@@ -3,6 +3,7 @@ open CoursesCurriculum__Types
 let decodeProps = json => {
   open Json.Decode
   (
+    field("author", bool, json),
     field("course", Course.decode, json),
     field("levels", array(Level.decode), json),
     field("targetGroups", array(TargetGroup.decode), json),
@@ -19,6 +20,7 @@ let decodeProps = json => {
 }
 
 let (
+  author,
   course,
   levels,
   targetGroups,
@@ -36,6 +38,7 @@ let (
 
 ReactDOMRe.renderToElementWithId(
   <CoursesCurriculum
+    author
     course
     levels
     targetGroups

--- a/app/javascript/shared/utils/DomUtils.res
+++ b/app/javascript/shared/utils/DomUtils.res
@@ -33,12 +33,14 @@ let isDevelopment = () =>
 
 let goBack = () => window |> Window.history |> History.back
 
-let hasUrlParam = (~key) =>
-  (window
+let getUrlParam = (~key) =>
+  window
   |> Window.location
   |> Location.search
   |> Webapi.Url.URLSearchParams.make
-  |> Webapi.Url.URLSearchParams.get(key))->Belt.Option.isSome
+  |> Webapi.Url.URLSearchParams.get(key)
+
+let hasUrlParam = (~key) => getUrlParam(~key)->Belt.Option.isSome
 
 module FormData = {
   type t = Fetch.formData

--- a/app/presenters/courses/curriculum_presenter.rb
+++ b/app/presenters/courses/curriculum_presenter.rb
@@ -43,12 +43,17 @@ module Courses
 
     def default_props
       {
+        author: author?,
         course: course_details,
         levels: levels_details,
         target_groups: target_groups,
         targets: targets,
         access_locked_levels: access_locked_levels
       }
+    end
+
+    def author?
+      current_school_admin.present? || @course.course_authors.exists?(user: current_user)
     end
 
     def evaluation_criteria

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,14 +91,20 @@ en:
         other: "This certificate has been issued %{count} times.<br/>These changes will also be applied to these %{count} issued certificates."
       cannot_be_auto_issued_warning: Please note that the last level of this course does not have any milestone targets. This certificate will be auto-issued only if the last level has at least one milestone target.
     CoursesCurriculum:
+      edit_level_button: Edit Level
+      edit_target_button_title: "Edit target %{title}"
+      level_locked_for_students_notice: "This level is still locked for students, and will be unlocked on <strong>%{date}</strong>."
       issued_certificate_heading: Congratulations! You have been issued a certificate.
       issued_certificate_button: View Certificate
       level_locked: Level locked
       level_locked_notice: "The level is currently locked!"
+      level_locked_explanation: "You can access the content on %{date}."
       nav_previous_level: Previous Level
       nav_next_level: Next Level
       empty_level_content_notice: "There's no published content on this level."
       milestone_targets: Milestone targets
+    CoursesCurriculum__Learn:
+      edit_target_button: Edit Content
     CoursesCurriculum__NoticeManager:
       course_complete_title: Congratulations! You have completed all milestone targets in the final level.
       course_complete_description: You've completed our coursework. Feel free to complete targets that you might have left out, and read up at attached links.
@@ -239,6 +245,12 @@ en:
       access_locked: Your access to this course has ended.
       level_locked: You must level up to complete this target.
       prerequisites_incomplete: This target has pre-requisites that are incomplete.
+      status:
+        pending: Pending
+        pending_review: Pending Review
+        completed: Completed
+        rejected: Rejected
+        locked: Locked
     CurriculumEditor__ContentBlockCreator:
       button_labels:
         markdown: Markdown

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -328,6 +328,10 @@ feature "Student's view of Course Curriculum", js: true do
       # The first level should be selected, and all levels should be available.
       click_button "L1: #{level_1.name}"
 
+      # An admin should be shown links to edit the level and its targets.
+      expect(page).to have_link('Edit Level', href: curriculum_school_course_path(id: course.id, level: 1))
+      expect(page).to have_selector("a[href='#{content_school_course_target_path(course_id: course.id, id: completed_target_l1.id)}']")
+
       [level_2, level_3, level_4, level_5, locked_level_6].each do |l|
         expect(page).to have_button("L#{l.number}: #{l.name}")
       end

--- a/spec/system/school/courses/curriculum_editor_spec.rb
+++ b/spec/system/school/courses/curriculum_editor_spec.rb
@@ -45,12 +45,14 @@ feature 'Curriculum Editor', js: true do
   end
 
   scenario 'admin creates a basic course framework by adding level, target group and targets' do
-    sign_in_user school_admin.user, referrer: curriculum_school_course_path(course)
+    sign_in_user school_admin.user, referrer: curriculum_school_course_path(course, level: 1)
 
-    # he should be on the last level
-    expect(page).to have_text('Level 2: ' + level_2.name)
+    # When the level number is specified as a param, it should be selected.
+    expect(page).to have_text(target_group_1.name)
 
-    # all targets and target groups on that level should be visible
+    visit(curriculum_school_course_path(course))
+
+    # Visiting the page without the level param should default selection to the max level, with all is targets and groups visible.
     expect(page).to have_text(target_group_2.name)
     expect(page).to have_text(target_3.title)
     expect(page).to have_text(target_4.title)

--- a/spec/system/targets/show_spec.rb
+++ b/spec/system/targets/show_spec.rb
@@ -586,6 +586,7 @@ feature 'Target Overlay', js: true do
         sign_in_user school_admin.user, referrer: target_path(target_l1)
 
         expect(page).to have_content('You are currently looking at a preview of this course.')
+        expect(page).to have_link('Edit Content', href: content_school_course_target_path(course_id: target_l1.course.id, id: target_l1.id))
 
         # This target should have a 'Complete' section.
         find('.course-overlay__body-tab-item', text: 'Complete').click


### PR DESCRIPTION
## Proposed Changes

This adds edit buttons to the student's view of a course's curriculum when the user viewing the curriculum has the permission to edit it.

![edit_links_in_student_view](https://user-images.githubusercontent.com/98546/107535955-3b36da00-6be7-11eb-8c78-4a0595a88e4d.jpg)

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- [ ] ~~Update developer and product docs, where applicable.~~
- [x] Prep screenshot or demo video for changelog entry, and attach it to PR: [LINK](https://res.cloudinary.com/sv-co/image/upload/v1612973086/pupilfirst_changelog/2021/edit_links_in_student_view_m3ta0a.jpg)
- [ ] ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- [ ] ~~Check if changes in _packaged_ components have been published to `npm`.~~
- [ ] ~~Add development seeds for new tables.~~
