### PR TITLE
Devs notifications

### DIFF
--- a/app/services/developers/event_publisher.rb
+++ b/app/services/developers/event_publisher.rb
@@ -1,7 +1,7 @@
 module Developers
   class EventPublisher
-    def execute(course, event_type, actor, resource)
-      ActiveSupport::Notifications.instrument("#{event_type}.pupilfirst", resource_id: resource.id, actor_id: actor.id, course_id: course.id)
+    def execute(event_type, actor, resource)
+      ActiveSupport::Notifications.instrument("#{event_type}.pupilfirst", resource_id: resource.id, actor_id: actor.id)
     end
   end
 end

--- a/app/services/developers/event_publisher.rb
+++ b/app/services/developers/event_publisher.rb
@@ -1,7 +1,7 @@
 module Developers
   class EventPublisher
-    def execute(context, event_type, actor, resource)
-      ActiveSupport::Notifications.instrument("#{event_type}.pupilfirst", resource_id: resource.id, actor_id: actor.id, context_id: context.id)
+    def execute(course, event_type, actor, resource)
+      ActiveSupport::Notifications.instrument("#{event_type}.pupilfirst", resource_id: resource.id, actor_id: actor.id, course_id: course.id)
     end
   end
 end

--- a/app/services/developers/event_publisher.rb
+++ b/app/services/developers/event_publisher.rb
@@ -1,0 +1,7 @@
+module Developers
+  class EventPublisher
+    def execute(context, event_type, actor, resource)
+      ActiveSupport::Notifications.instrument("#{event_type}.pupilfirst", resource_id: resource.id, actor_id: actor.id, context_id: context.id)
+    end
+  end
+end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -9,7 +9,7 @@ module Developers
     end
 
     def execute(course, event_type, actor, resource)
-      @event_publisher.execute(course, event_type, actor, resource)
+      @event_publisher.execute(event_type, actor, resource)
       @webhook_service.execute(course, event_type, resource)
     end
   end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -1,10 +1,15 @@
 module Developers
   class NotificationService
-    def initialize(webhook_service: WebhookDeliveries::CreateService.new)
+    def initialize(
+      webhook_service: WebhookDeliveries::CreateService.new,
+      event_publisher: Developers::EventPublisher.new
+    )
       @webhook_service = webhook_service
+      @event_publisher = event_publisher
     end
 
-    def execute(context, event_type, _actor, resource)
+    def execute(context, event_type, actor, resource)
+      @event_publisher.execute(context, event_type, actor, resource)
       @webhook_service.execute(context, event_type, resource)
     end
   end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -1,12 +1,7 @@
 module Developers
   class NotificationService
-    def initialize(course, event_type)
-      @course     = course
-      @event_type = event_type
-    end
-
-    def execute(_actor, resource)
-      WebhookDeliveries::CreateService.new(@course, @event_type).execute(resource)
+    def execute(course, event_type, _actor, resource)
+      WebhookDeliveries::CreateService.new.execute(course, event_type, resource)
     end
   end
 end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -1,0 +1,12 @@
+module Developers
+  class NotificationService
+    def initialize(course, event_type)
+      @course     = course
+      @event_type = event_type
+    end
+
+    def execute(_actor, resource)
+      WebhookDeliveries::CreateService.new(@course, @event_type).execute(resource)
+    end
+  end
+end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -8,9 +8,9 @@ module Developers
       @event_publisher = event_publisher
     end
 
-    def execute(context, event_type, actor, resource)
-      @event_publisher.execute(context, event_type, actor, resource)
-      @webhook_service.execute(context, event_type, resource)
+    def execute(course, event_type, actor, resource)
+      @event_publisher.execute(course, event_type, actor, resource)
+      @webhook_service.execute(course, event_type, resource)
     end
   end
 end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -1,7 +1,7 @@
 module Developers
   class NotificationService
-    def execute(course, event_type, _actor, resource)
-      WebhookDeliveries::CreateService.new.execute(course, event_type, resource)
+    def execute(context, event_type, _actor, resource)
+      WebhookDeliveries::CreateService.new.execute(context, event_type, resource)
     end
   end
 end

--- a/app/services/developers/notification_service.rb
+++ b/app/services/developers/notification_service.rb
@@ -1,7 +1,11 @@
 module Developers
   class NotificationService
+    def initialize(webhook_service: WebhookDeliveries::CreateService.new)
+      @webhook_service = webhook_service
+    end
+
     def execute(context, event_type, _actor, resource)
-      WebhookDeliveries::CreateService.new.execute(context, event_type, resource)
+      @webhook_service.execute(context, event_type, resource)
     end
   end
 end

--- a/app/services/timeline_events/create_service.rb
+++ b/app/services/timeline_events/create_service.rb
@@ -11,7 +11,12 @@ module TimelineEvents
         TimelineEvent.create!(@params).tap do |te|
           @founder.timeline_event_owners.create!(timeline_event: te, latest: true)
           create_team_entries(te) if @params[:target].team_target?
-          Developers::NotificationService.new(@founder.course, WebhookDelivery.events[:submission_created]).execute(@founder, te)
+          Developers::NotificationService.new.execute(
+            @founder.course,
+            WebhookDelivery.events[:submission_created],
+            @founder,
+            te
+          )
           update_latest_flag(te)
         end
       end

--- a/app/services/timeline_events/create_service.rb
+++ b/app/services/timeline_events/create_service.rb
@@ -1,9 +1,10 @@
 module TimelineEvents
   class CreateService
-    def initialize(params, founder)
+    def initialize(params, founder, notification_service: Developers::NotificationService.new)
       @params = params
       @founder = founder
       @target = params[:target]
+      @notification_service = notification_service
     end
 
     def execute
@@ -11,7 +12,7 @@ module TimelineEvents
         TimelineEvent.create!(@params).tap do |te|
           @founder.timeline_event_owners.create!(timeline_event: te, latest: true)
           create_team_entries(te) if @params[:target].team_target?
-          Developers::NotificationService.new.execute(
+          @notification_service.execute(
             @founder.course,
             WebhookDelivery.events[:submission_created],
             @founder.user,

--- a/app/services/timeline_events/create_service.rb
+++ b/app/services/timeline_events/create_service.rb
@@ -14,7 +14,7 @@ module TimelineEvents
           Developers::NotificationService.new.execute(
             @founder.course,
             WebhookDelivery.events[:submission_created],
-            @founder,
+            @founder.user,
             te
           )
           update_latest_flag(te)

--- a/app/services/timeline_events/create_service.rb
+++ b/app/services/timeline_events/create_service.rb
@@ -11,7 +11,7 @@ module TimelineEvents
         TimelineEvent.create!(@params).tap do |te|
           @founder.timeline_event_owners.create!(timeline_event: te, latest: true)
           create_team_entries(te) if @params[:target].team_target?
-          WebhookDeliveries::CreateService.new(@founder.course, WebhookDelivery.events[:submission_created]).execute(te)
+          Developers::NotificationService.new(@founder.course, WebhookDelivery.events[:submission_created]).execute(@founder, te)
           update_latest_flag(te)
         end
       end

--- a/app/services/webhook_deliveries/create_service.rb
+++ b/app/services/webhook_deliveries/create_service.rb
@@ -1,22 +1,13 @@
 module WebhookDeliveries
   class CreateService
-    def initialize(course, event_type)
-      @course = course
-      @event_type = event_type
-    end
+    def execute(course, event_type, resource)
+      webhook_endpoint = course.webhook_endpoint
 
-    def execute(resource)
       return unless webhook_endpoint&.active?
 
-      return unless @event_type.in? webhook_endpoint.events
+      return unless event_type.in? webhook_endpoint.events
 
-      WebhookDeliveries::DeliverJob.perform_later(@event_type, @course, resource)
-    end
-
-    private
-
-    def webhook_endpoint
-      @webhook_endpoint ||= @course.webhook_endpoint
+      WebhookDeliveries::DeliverJob.perform_later(event_type, course, resource)
     end
   end
 end

--- a/app/services/webhook_deliveries/create_service.rb
+++ b/app/services/webhook_deliveries/create_service.rb
@@ -1,13 +1,13 @@
 module WebhookDeliveries
   class CreateService
-    def execute(course, event_type, resource)
-      webhook_endpoint = course.webhook_endpoint
+    def execute(context, event_type, resource)
+      webhook_endpoint = context.webhook_endpoint
 
       return unless webhook_endpoint&.active?
 
       return unless event_type.in? webhook_endpoint.events
 
-      WebhookDeliveries::DeliverJob.perform_later(event_type, course, resource)
+      WebhookDeliveries::DeliverJob.perform_later(event_type, context, resource)
     end
   end
 end

--- a/app/services/webhook_deliveries/create_service.rb
+++ b/app/services/webhook_deliveries/create_service.rb
@@ -1,13 +1,12 @@
 module WebhookDeliveries
   class CreateService
-    def execute(context, event_type, resource)
-      webhook_endpoint = context.webhook_endpoint
+    def execute(course, event_type, resource)
+      webhook_endpoint = course.webhook_endpoint
 
       return unless webhook_endpoint&.active?
-
       return unless event_type.in? webhook_endpoint.events
 
-      WebhookDeliveries::DeliverJob.perform_later(event_type, context, resource)
+      WebhookDeliveries::DeliverJob.perform_later(event_type, course, resource)
     end
   end
 end

--- a/spec/services/developers/event_publisher_spec.rb
+++ b/spec/services/developers/event_publisher_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Developers::EventPublisher do
   subject { described_class.new }
-  let(:context_) { double(:context, id: 123) }
+  let(:course) { double(:course, id: 123) }
   let(:event_type) { 'any-given-event' }
   let(:actor) { double(:actor, id: 234) }
   let(:resource) { double(:resource, id: 456) }
@@ -14,12 +14,12 @@ describe Developers::EventPublisher do
       events << ActiveSupport::Notifications::Event.new(*args)
     end
 
-    subject.execute(context_, event_type, actor, resource)
+    subject.execute(course, event_type, actor, resource)
 
     expect(events.map(&:payload)).to eq [{
       resource_id: resource.id,
       actor_id: actor.id,
-      context_id: context_.id
+      course_id: course.id
     }]
 
     ActiveSupport::Notifications.unsubscribe('any-given-event.pupilfirst')

--- a/spec/services/developers/event_publisher_spec.rb
+++ b/spec/services/developers/event_publisher_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe Developers::EventPublisher do
   subject { described_class.new }
-  let(:course) { double(:course, id: 123) }
   let(:event_type) { 'any-given-event' }
   let(:actor) { double(:actor, id: 234) }
   let(:resource) { double(:resource, id: 456) }
@@ -14,12 +13,11 @@ describe Developers::EventPublisher do
       events << ActiveSupport::Notifications::Event.new(*args)
     end
 
-    subject.execute(course, event_type, actor, resource)
+    subject.execute(event_type, actor, resource)
 
     expect(events.map(&:payload)).to eq [{
       resource_id: resource.id,
       actor_id: actor.id,
-      course_id: course.id
     }]
 
     ActiveSupport::Notifications.unsubscribe('any-given-event.pupilfirst')

--- a/spec/services/developers/event_publisher_spec.rb
+++ b/spec/services/developers/event_publisher_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Developers::EventPublisher do
+  subject { described_class.new }
+  let(:context_) { double(:context, id: 123) }
+  let(:event_type) { 'any-given-event' }
+  let(:actor) { double(:actor, id: 234) }
+  let(:resource) { double(:resource, id: 456) }
+
+  it 'works' do
+    events = []
+
+    ActiveSupport::Notifications.subscribe('any-given-event.pupilfirst') do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    subject.execute(context_, event_type, actor, resource)
+
+    expect(events.map(&:payload)).to eq [{
+      resource_id: resource.id,
+      actor_id: actor.id,
+      context_id: context_.id
+    }]
+
+    ActiveSupport::Notifications.unsubscribe('any-given-event.pupilfirst')
+  end
+end

--- a/spec/services/developers/notification_service_spec.rb
+++ b/spec/services/developers/notification_service_spec.rb
@@ -11,7 +11,7 @@ describe Developers::NotificationService do
 
   it 'pass the call to webhook service & event pubisher' do
     expect(webhook_service).to receive(:execute).with(course, event_type, resource).once
-    expect(event_publisher).to receive(:execute).with(course, event_type, actor, resource).once
+    expect(event_publisher).to receive(:execute).with(event_type, actor, resource).once
     subject.execute(course, event_type, actor, resource)
   end
 end

--- a/spec/services/developers/notification_service_spec.rb
+++ b/spec/services/developers/notification_service_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Developers::NotificationService do
+  subject { described_class.new(webhook_service: webhook_service) }
+  let(:context_) { Object.new }
+  let(:event_type) { 'any-given-event' }
+  let(:actor) { Object.new }
+  let(:resource) { Object.new }
+  let(:webhook_service) { instance_double('WebhookDeliveries::CreateService') }
+
+  it 'pass the call to WebhookDeliveries::CreateService' do
+    expect(webhook_service).to receive(:execute).with(context_, event_type, resource).once
+    subject.execute(context_, event_type, actor, resource)
+  end
+end

--- a/spec/services/developers/notification_service_spec.rb
+++ b/spec/services/developers/notification_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Developers::NotificationService do
   subject { described_class.new(webhook_service: webhook_service, event_publisher: event_publisher) }
-  let(:context_) { Object.new }
+  let(:course) { Object.new }
   let(:event_type) { 'any-given-event' }
   let(:actor) { Object.new }
   let(:resource) { Object.new }
@@ -10,8 +10,8 @@ describe Developers::NotificationService do
   let(:event_publisher) { instance_double('Developers::EventPublisher') }
 
   it 'pass the call to webhook service & event pubisher' do
-    expect(webhook_service).to receive(:execute).with(context_, event_type, resource).once
-    expect(event_publisher).to receive(:execute).with(context_, event_type, actor, resource).once
-    subject.execute(context_, event_type, actor, resource)
+    expect(webhook_service).to receive(:execute).with(course, event_type, resource).once
+    expect(event_publisher).to receive(:execute).with(course, event_type, actor, resource).once
+    subject.execute(course, event_type, actor, resource)
   end
 end

--- a/spec/services/developers/notification_service_spec.rb
+++ b/spec/services/developers/notification_service_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 describe Developers::NotificationService do
-  subject { described_class.new(webhook_service: webhook_service) }
+  subject { described_class.new(webhook_service: webhook_service, event_publisher: event_publisher) }
   let(:context_) { Object.new }
   let(:event_type) { 'any-given-event' }
   let(:actor) { Object.new }
   let(:resource) { Object.new }
   let(:webhook_service) { instance_double('WebhookDeliveries::CreateService') }
+  let(:event_publisher) { instance_double('Developers::EventPublisher') }
 
-  it 'pass the call to WebhookDeliveries::CreateService' do
+  it 'pass the call to webhook service & event pubisher' do
     expect(webhook_service).to receive(:execute).with(context_, event_type, resource).once
+    expect(event_publisher).to receive(:execute).with(context_, event_type, actor, resource).once
     subject.execute(context_, event_type, actor, resource)
   end
 end

--- a/spec/services/timeline_events/create_service_spec.rb
+++ b/spec/services/timeline_events/create_service_spec.rb
@@ -35,6 +35,14 @@ describe TimelineEvents::CreateService do
       expect(last_submission.timeline_event_owners.pluck(:latest).uniq).to eq([true])
     end
 
+    it 'publishes submission.created event' do
+      notification_service = instance_double('Developers::NotificationService')
+      expect(notification_service).to receive(:execute)
+        .with(student.course, "submission.created", student.user, an_instance_of(TimelineEvent))
+      subject = described_class.new(params, student, notification_service: notification_service)
+      subject.execute
+    end
+
     context 'when target is a team target and student is in a team' do
       let(:student) { create :founder }
       let(:target) { create :target, role: Target::ROLE_TEAM, target_group: target_group }

--- a/spec/services/webhook_deliveries/create_service_spec.rb
+++ b/spec/services/webhook_deliveries/create_service_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 describe WebhookDeliveries::CreateService do
-  subject { described_class.new(course, event_type) }
+  subject { described_class.new }
   let(:course) { create :course }
   let(:event_type) { WebhookDelivery.events[:submission_created] }
   let(:submission) { create :timeline_event }
 
   describe '#execute' do
     it 'does nothing when the when the course does not have a webhook endpoint' do
-      expect { subject.execute(submission) }.not_to change { WebhookDelivery.count } # rubocop:disable Lint/AmbiguousBlockAssociation
+      expect { subject.execute(course, event_type, submission) }.not_to change { WebhookDelivery.count } # rubocop:disable Lint/AmbiguousBlockAssociation
     end
 
     context 'when the course has a valid webhook endpoint' do
@@ -17,7 +17,7 @@ describe WebhookDeliveries::CreateService do
       it 'schedules the webhook delivery job' do
         stub_request(:post, webhook_endpoint.webhook_url).to_return(body: '')
 
-        expect { subject.execute(submission) }.to change { WebhookDelivery.count }.by(1)
+        expect { subject.execute(course, event_type, submission) }.to change { WebhookDelivery.count }.by(1)
       end
     end
 
@@ -25,7 +25,7 @@ describe WebhookDeliveries::CreateService do
       let!(:webhook_endpoint) { create :webhook_endpoint, course: course, active: false }
 
       it 'does nothing' do
-        expect { subject.execute(submission) }.not_to change { WebhookDelivery.count } # rubocop:disable Lint/AmbiguousBlockAssociation
+        expect { subject.execute(course, event_type, submission) }.not_to change { WebhookDelivery.count } # rubocop:disable Lint/AmbiguousBlockAssociation
       end
     end
 
@@ -33,7 +33,7 @@ describe WebhookDeliveries::CreateService do
       let!(:webhook_endpoint) { create :webhook_endpoint, course: course, events: [] }
 
       it 'does nothing' do
-        expect { subject.execute(submission) }.not_to change { WebhookDelivery.count } # rubocop:disable Lint/AmbiguousBlockAssociation
+        expect { subject.execute(course, event_type, submission) }.not_to change { WebhookDelivery.count } # rubocop:disable Lint/AmbiguousBlockAssociation
       end
     end
   end


### PR DESCRIPTION
## Proposed Changes

- Introduce internal notification system to communicate between app modules based on discussion here https://github.com/pupilfirst/pupilfirst/discussions/613
- WebhookDeliveries::CreateService is now triggered now by dev's notifications 
- ActiveSupport::Notifications used to implement internal pub/sub mechanism
- Services composition used to allow anyone to provide it's own pub/sub and/or webhook services

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
