### PR TITLE
Submission graded domain event

### DIFF
--- a/app/jobs/timeline_events/after_grading_job.rb
+++ b/app/jobs/timeline_events/after_grading_job.rb
@@ -2,7 +2,8 @@ module TimelineEvents
   class AfterGradingJob < ApplicationJob
     queue_as :default
 
-    def perform(submission)
+    def perform(submission_id)
+      submission = TimelineEvent.find(submission_id)
       # Only process submissions from reviewed submissions.
       return unless submission.reviewed?
 

--- a/app/queries/create_grading_mutator.rb
+++ b/app/queries/create_grading_mutator.rb
@@ -32,7 +32,6 @@ class CreateGradingMutator < ApplicationQuery
         checklist: checklist,
       )
 
-      TimelineEvents::AfterGradingJob.perform_later(submission)
       update_coach_note if note.present?
       send_feedback if feedback.present?
     end

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -1,0 +1,4 @@
+ActiveSupport::Notifications.subscribe("submission_graded.pupilfirst") do |_, _, _, _, payload|
+  submission = TimelineEvent.find(payload.fetch(:resource_id))
+  TimelineEvents::AfterGradingJob.perform_later(submission)
+end

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -1,4 +1,3 @@
 ActiveSupport::Notifications.subscribe("submission_graded.pupilfirst") do |_, _, _, _, payload|
-  submission = TimelineEvent.find(payload.fetch(:resource_id))
-  TimelineEvents::AfterGradingJob.perform_later(submission)
+  TimelineEvents::AfterGradingJob.perform_later(payload.fetch(:resource_id))
 end


### PR DESCRIPTION
## Proposed Changes

- Move `TimelineEvents::AfterGradingJob` out of the mutator - it is now triggered by domain event subscription defined in subscriptions initializer
- showcase how event driven architecture could be introduced in Pupilfirst

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
