### PR TITLE
No wrap on names & date in certificate page

### DIFF
--- a/app/javascript/issued_certificates/VerifyCertificate__Root.res
+++ b/app/javascript/issued_certificates/VerifyCertificate__Root.res
@@ -20,7 +20,7 @@ let heading = (currentUser, issuedCertificate) =>
   if currentUser {
     <span>
       {str("Congratulations ")}
-      <strong> {IssuedCertificate.profileName(issuedCertificate)->str} </strong>
+      <strong className="whitespace-no-wrap"> {IssuedCertificate.profileName(issuedCertificate)->str} </strong>
       {"!" |> str}
       <br />
       {str("You've earned it.")}
@@ -60,9 +60,9 @@ let make = (~issuedCertificate, ~verifyImageUrl, ~currentUser) => {
           </h3>
           <div className="text-sm mt-4">
             <span> {"This certificate was issued to " |> str} </span>
-            <strong> {issuedToName(issuedCertificate)} </strong>
+            <strong className="whitespace-no-wrap"> {issuedToName(issuedCertificate)} </strong>
             <span> {" on " |> str} </span>
-            <strong>
+            <strong className="whitespace-no-wrap">
               {issuedCertificate
               ->IssuedCertificate.issuedAt
               ->DateFns.formatPreset(~short=true, ~year=true, ())


### PR DESCRIPTION
## Proposed Changes

- No wrap on names & date in certificate page
  In certificate details page user name & certificate issued at date should not be wrapped. Nicer to read.


@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
