### PR TITLE
Course Call to Action when Access Ended 💡

### DIFF
--- a/app/javascript/users/home/components/UsersDashboard__Root.res
+++ b/app/javascript/users/home/components/UsersDashboard__Root.res
@@ -109,6 +109,8 @@ let callToAction = (course, currentSchoolAdmin) =>
     #DroppedOut
   } else if course->Course.ended {
     #CourseEnded
+  } else if course->Course.accessEnded {
+    #AccessEnded
   } else {
     #ViewCourse
   }
@@ -122,6 +124,7 @@ let ctaFooter = (course, currentSchoolAdmin) => {
     ctaButton(t("cta.edit_curriculum"), "/school/courses/" ++ (courseId ++ "/curriculum"))
   | #ReviewSubmissions => ctaButton(t("cta.review_submissions"), studentLink(courseId, "review"))
   | #DroppedOut => ctaText(t("cta.dropped_out"), "fas fa-user-slash")
+  | #AccessEnded => ctaText(t("cta.access_ended"), "fas fa-history")
   | #CourseEnded => ctaText(t("cta.course_ended"), "fas fa-history")
   }
 }

--- a/app/javascript/users/home/types/UsersDashboard__Course.res
+++ b/app/javascript/users/home/types/UsersDashboard__Course.res
@@ -8,6 +8,7 @@ type t = {
   exited: bool,
   thumbnailUrl: option<string>,
   linkedCommunities: array<string>,
+  accessEnded: bool,
   ended: bool,
 }
 
@@ -19,6 +20,7 @@ let description = t => t.description
 let exited = t => t.exited
 let thumbnailUrl = t => t.thumbnailUrl
 let linkedCommunities = t => t.linkedCommunities
+let accessEnded = t => t.accessEnded
 let ended = t => t.ended
 let enableLeaderboard = t => t.enableLeaderboard
 
@@ -34,6 +36,7 @@ let decode = json => {
     enableLeaderboard: json |> field("enableLeaderboard", bool),
     thumbnailUrl: json |> field("thumbnailUrl", nullable(string)) |> Js.Null.toOption,
     linkedCommunities: json |> field("linkedCommunities", array(string)),
+    accessEnded: json |> field("accessEnded", bool),
     ended: json |> field("ended", bool),
   }
 }

--- a/app/presenters/users/dashboard_presenter.rb
+++ b/app/presenters/users/dashboard_presenter.rb
@@ -100,9 +100,15 @@ module Users
           exited: student_dropped_out(course.id),
           thumbnail_url: course.thumbnail_url,
           linked_communities: course.communities.pluck(:id).map(&:to_s),
+          access_ended: course_access_end(course),
           ended: course.ended?
         }
       end
+    end
+    
+    def course_access_end(course) 
+      course_founder = course.founders.not_dropped_out.find_by(user_id: current_user.id)
+      course_founder.present? && course_founder.access_ended?
     end
 
     def student_dropped_out(course_id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,6 +495,7 @@ en:
       communities: Communities
       course_locked_message: Your student profile for this course is locked, and cannot be updated.
       cta:
+        access_ended: Access Ended
         course_ended: Course Ended
         dropped_out: Dropped out
         edit_curriculum: Edit Curriculum

--- a/spec/system/users/dashboard_spec.rb
+++ b/spec/system/users/dashboard_spec.rb
@@ -11,43 +11,86 @@ feature 'User Dashboard', js: true do
   let(:course_1) { create :course, school: school }
   let(:course_1_level_1) { create :level, :one, course: course_1 }
   let(:course_1_startup_1) { create :startup, level: course_1_level_1 }
-  let(:founder) { create :founder, startup: course_1_startup_1, dashboard_toured: false }
+  let(:founder) do
+    create :founder, startup: course_1_startup_1, dashboard_toured: false
+  end
 
   # Course 2 - Existing course
   let(:course_2) { create :course, school: school }
   let(:course_2_level_1) { create :level, :one, course: course_2 }
   let(:course_2_startup_1) { create :startup, level: course_2_level_1 }
-  let!(:course_2_founder_1) { create :founder, startup: course_2_startup_1, user: founder.user, dashboard_toured: true }
+  let!(:course_2_founder_1) do
+    create :founder,
+           startup: course_2_startup_1,
+           user: founder.user,
+           dashboard_toured: true
+  end
 
   # Course 3 - Ended course
   let(:course_3) { create :course, school: school, ends_at: 1.day.ago }
   let(:course_3_level_1) { create :level, :one, course: course_3 }
   let(:course_3_startup_1) { create :startup, level: course_3_level_1 }
-  let!(:course_3_founder_1) { create :founder, startup: course_3_startup_1, user: founder.user }
-  let!(:course_3_student_profile_for_admin) { create :founder, startup: course_3_startup_1, user: school_admin.user }
+  let!(:course_3_founder_1) do
+    create :founder, startup: course_3_startup_1, user: founder.user
+  end
+  let!(:course_3_student_profile_for_admin) do
+    create :founder, startup: course_3_startup_1, user: school_admin.user
+  end
 
   # Course 4 - Founder Exited
   let(:course_4) { create :course, school: school }
   let(:course_4_level_1) { create :level, :one, course: course_4 }
-  let(:course_4_startup_1) { create :team, level: course_4_level_1, dropped_out_at: 1.day.ago }
-  let!(:course_4_founder_1) { create :founder, startup: course_4_startup_1, user: founder.user }
+  let(:course_4_startup_1) do
+    create :team, level: course_4_level_1, dropped_out_at: 1.day.ago
+  end
+  let!(:course_4_founder_1) do
+    create :founder, startup: course_4_startup_1, user: founder.user
+  end
+
+  # Course 5 - Access Ended
+  let(:course_5) { create :course, school: school }
+  let(:course_5_level_1) { create :level, :one, course: course_5 }
+  let(:course_5_startup_1) do
+    create :startup, level: course_5_level_1, access_ends_at: 1.day.ago
+  end
+  let!(:course_5_founder_1) do
+    create :founder, startup: course_5_startup_1, user: founder.user
+  end
 
   # Course Archived
-  let(:course_archived) { create :course, school: school, archived_at: 1.day.ago }
+  let(:course_archived) do
+    create :course, school: school, archived_at: 1.day.ago
+  end
   let(:course_archived_level_1) { create :level, :one, course: course_archived }
-  let(:course_archived_team_1) { create :team, level: course_archived_level_1, dropped_out_at: 1.day.ago }
-  let!(:course_archived_student_1) { create :founder, startup: course_archived_team_1, user: founder.user }
-  let!(:course_archived_student_2) { create :founder, startup: course_archived_team_1 }
-  let!(:course_archived_student_profile_for_admin) { create :founder, startup: course_archived_team_1, user: school_admin.user }
+  let(:course_archived_team_1) do
+    create :team, level: course_archived_level_1, dropped_out_at: 1.day.ago
+  end
+  let!(:course_archived_student_1) do
+    create :founder, startup: course_archived_team_1, user: founder.user
+  end
+  let!(:course_archived_student_2) do
+    create :founder, startup: course_archived_team_1
+  end
+  let!(:course_archived_student_profile_for_admin) do
+    create :founder, startup: course_archived_team_1, user: school_admin.user
+  end
 
   # Course Ended - For Admin
   let!(:course_ended) { create :course, school: school, ends_at: 1.day.ago }
 
   # seed community
-  let!(:community_1) { create :community, school: school, target_linkable: true }
-  let!(:community_2) { create :community, school: school, target_linkable: true }
-  let!(:community_3) { create :community, school: school, target_linkable: true }
-  let!(:community_4) { create :community, school: school, target_linkable: true }
+  let!(:community_1) do
+    create :community, school: school, target_linkable: true
+  end
+  let!(:community_2) do
+    create :community, school: school, target_linkable: true
+  end
+  let!(:community_3) do
+    create :community, school: school, target_linkable: true
+  end
+  let!(:community_4) do
+    create :community, school: school, target_linkable: true
+  end
 
   let(:course_coach) { create :faculty, school: school }
   let(:team_coach) { create :faculty, school: school }
@@ -56,12 +99,25 @@ feature 'User Dashboard', js: true do
 
   before do
     create :faculty_course_enrollment, faculty: course_coach, course: course_1
-    create :faculty_startup_enrollment, :with_course_enrollment, faculty: team_coach, startup: course_2_founder_1.startup
-    create :community_course_connection, course: course_1, community: community_1
-    create :community_course_connection, course: course_2, community: community_2
-    create :community_course_connection, course: course_3, community: community_3
-    create :community_course_connection, course: course_4, community: community_4
-    create :community_course_connection, course: course_archived, community: community_4
+    create :faculty_startup_enrollment,
+           :with_course_enrollment,
+           faculty: team_coach,
+           startup: course_2_founder_1.startup
+    create :community_course_connection,
+           course: course_1,
+           community: community_1
+    create :community_course_connection,
+           course: course_2,
+           community: community_2
+    create :community_course_connection,
+           course: course_3,
+           community: community_3
+    create :community_course_connection,
+           course: course_4,
+           community: community_4
+    create :community_course_connection,
+           course: course_archived,
+           community: community_4
   end
 
   scenario 'student visits the dashboard page' do
@@ -71,32 +127,56 @@ feature 'User Dashboard', js: true do
     within("div[aria-label=\"#{course_1.name}\"]") do
       expect(page).to have_text(course_1.name)
       expect(page).to have_text(course_1.description)
-      expect(page).to have_link("View Course", href: curriculum_course_path(course_1))
+      expect(page).to have_link(
+        'View Course',
+        href: curriculum_course_path(course_1)
+      )
     end
 
     # A course which is going on.
     within("div[aria-label=\"#{course_2.name}\"]") do
       expect(page).to have_text(course_2.name)
       expect(page).to have_text(course_2.description)
-      expect(page).to have_link("View Course", href: curriculum_course_path(course_2))
+      expect(page).to have_link(
+        'View Course',
+        href: curriculum_course_path(course_2)
+      )
     end
 
     # A course which has ended.
     within("div[aria-label=\"#{course_3.name}\"]") do
       expect(page).to have_text(course_3.name)
       expect(page).to have_text(course_3.description)
-      expect(page).to have_link("View Curriculum", href: curriculum_course_path(course_3))
-      expect(page).to have_text("Course Ended")
+      expect(page).to have_link(
+        'View Curriculum',
+        href: curriculum_course_path(course_3)
+      )
+      expect(page).to have_text('Course Ended')
     end
 
     # Course from which student has dropped out.
     within("div[aria-label=\"#{course_4.name}\"]") do
       expect(page).to have_text(course_4.name)
       expect(page).to have_text(course_4.description)
-      expect(page).to have_text("Dropped out")
-      expect(page).not_to have_link("View Curriculum", href: curriculum_course_path(course_4))
+      expect(page).to have_text('Dropped out')
+      expect(page).not_to have_link(
+        'View Curriculum',
+        href: curriculum_course_path(course_4)
+      )
     end
 
+    # Course where student's access has ended.
+    within("div[aria-label=\"#{course_5.name}\"]") do
+      expect(page).to have_text(course_5.name)
+      expect(page).to have_text(course_5.description)
+      expect(page).to have_text('Access Ended')
+      expect(page).to have_link(
+        'View Curriculum',
+        href: curriculum_course_path(course_5)
+      )
+    end
+
+    # Course that has been archived.
     expect(page).not_to have_text(course_archived.name)
 
     click_button 'Communities'
@@ -119,9 +199,18 @@ feature 'User Dashboard', js: true do
 
     expect(page).to have_text(course_1.name)
     expect(page).to have_text(course_1.description)
-    expect(page).to have_link("View Curriculum", href: curriculum_course_path(course_1))
-    expect(page).to have_link("Review Submissions", href: review_course_path(course_1))
-    expect(page).to have_link("My Students", href: students_course_path(course_1))
+    expect(page).to have_link(
+      'View Curriculum',
+      href: curriculum_course_path(course_1)
+    )
+    expect(page).to have_link(
+      'Review Submissions',
+      href: review_course_path(course_1)
+    )
+    expect(page).to have_link(
+      'My Students',
+      href: students_course_path(course_1)
+    )
 
     expect(page).not_to have_text(course_2.name)
     expect(page).not_to have_text(course_3.name)
@@ -141,9 +230,18 @@ feature 'User Dashboard', js: true do
 
     expect(page).to have_text(course_2.name)
     expect(page).to have_text(course_2.description)
-    expect(page).to have_link("View Curriculum", href: curriculum_course_path(course_2))
-    expect(page).to have_link("Review Submissions", href: review_course_path(course_2))
-    expect(page).to have_link("My Students", href: students_course_path(course_2))
+    expect(page).to have_link(
+      'View Curriculum',
+      href: curriculum_course_path(course_2)
+    )
+    expect(page).to have_link(
+      'Review Submissions',
+      href: review_course_path(course_2)
+    )
+    expect(page).to have_link(
+      'My Students',
+      href: students_course_path(course_2)
+    )
 
     expect(page).not_to have_text(course_1.name)
     expect(page).not_to have_text(course_3.name)
@@ -167,16 +265,31 @@ feature 'User Dashboard', js: true do
     expect(page).to have_text(course_4.name)
 
     # school admin can preview all courses in school
-    expect(page).to have_link("View Course", href: curriculum_course_path(course_1))
-    expect(page).to have_link("View Course", href: curriculum_course_path(course_2))
+    expect(page).to have_link(
+      'View Course',
+      href: curriculum_course_path(course_1)
+    )
+    expect(page).to have_link(
+      'View Course',
+      href: curriculum_course_path(course_2)
+    )
+
     # ended course with a student profile will be listed on the dashboard
-    expect(page).to have_link("View Course", href: curriculum_course_path(course_3))
-    expect(page).to have_link("View Course", href: curriculum_course_path(course_4))
+    expect(page).to have_link(
+      'View Course',
+      href: curriculum_course_path(course_3)
+    )
+    expect(page).to have_link(
+      'View Course',
+      href: curriculum_course_path(course_4)
+    )
+
     # ended and archived courses will be hidden
     expect(page).not_to have_text(course_archived.name)
     expect(page).not_to have_text(course_ended.name)
 
     click_button 'Communities'
+
     # school admin has access to all communities in school
     expect(page).to have_text(community_1.name)
     expect(page).to have_text(community_2.name)
@@ -192,26 +305,51 @@ feature 'User Dashboard', js: true do
     expect(page).not_to have_text(course_3.name)
     expect(page).not_to have_text(course_4.name)
 
-    expect(page).to have_link("Edit Curriculum", href: curriculum_school_course_path(course_1))
-    expect(page).to have_link("View Curriculum", href: curriculum_course_path(course_1))
+    expect(page).to have_link(
+      'Edit Curriculum',
+      href: curriculum_school_course_path(course_1)
+    )
+    expect(page).to have_link(
+      'View Curriculum',
+      href: curriculum_course_path(course_1)
+    )
   end
 
   context 'when the student has been issued some certificates' do
     let(:certificate_1) { create :certificate, course: course_1 }
     let(:certificate_2) { create :certificate, course: course_2 }
     let(:certificate_3) { create :certificate, course: course_2 }
-    let!(:issued_certificate_1) { create :issued_certificate, certificate: certificate_1, user: founder.user }
-    let!(:issued_certificate_2) { create :issued_certificate, certificate: certificate_2, user: founder.user }
-    let!(:revoked_certificate) { create :issued_certificate, certificate: certificate_3, user: founder.user, revoker: school_admin.user, revoked_at: Time.zone.now }
+    let!(:issued_certificate_1) do
+      create :issued_certificate, certificate: certificate_1, user: founder.user
+    end
+    let!(:issued_certificate_2) do
+      create :issued_certificate, certificate: certificate_2, user: founder.user
+    end
+    let!(:revoked_certificate) do
+      create :issued_certificate,
+             certificate: certificate_3,
+             user: founder.user,
+             revoker: school_admin.user,
+             revoked_at: Time.zone.now
+    end
 
     scenario 'student browses certificates on the dashboard page' do
       sign_in_user(founder.user, referrer: dashboard_path)
 
       # Switch to certificates tab and see if there are two links.
       click_button 'Certificates'
-      expect(page).to have_link('View Certificate', href: "/c/#{issued_certificate_1.serial_number}")
-      expect(page).to have_link('View Certificate', href: "/c/#{issued_certificate_2.serial_number}")
-      expect(page).not_to have_link('View Certificate', href: "/c/#{revoked_certificate.serial_number}")
+      expect(page).to have_link(
+        'View Certificate',
+        href: "/c/#{issued_certificate_1.serial_number}"
+      )
+      expect(page).to have_link(
+        'View Certificate',
+        href: "/c/#{issued_certificate_2.serial_number}"
+      )
+      expect(page).not_to have_link(
+        'View Certificate',
+        href: "/c/#{revoked_certificate.serial_number}"
+      )
     end
   end
 
@@ -227,13 +365,18 @@ feature 'User Dashboard', js: true do
 
       # Course from which student has dropped out.
       within("div[aria-label=\"#{course_4.name}\"]") do
-        expect(page).to have_link("View Curriculum", href: curriculum_course_path(course_4))
-        expect(page).to_not have_text("Your student profile for this course is locked, and cannot be updated")
+        expect(page).to have_link(
+          'View Curriculum',
+          href: curriculum_course_path(course_4)
+        )
+        expect(page).to_not have_text(
+                              'Your student profile for this course is locked, and cannot be updated'
+                            )
       end
     end
   end
 
-  scenario "dashboard hides archived courses and linked resources" do
+  scenario 'dashboard hides archived courses and linked resources' do
     sign_in_user(course_archived_student_2.user, referrer: dashboard_path)
 
     expect(page).not_to have_text(course_archived.name)


### PR DESCRIPTION
## Proposed Changes

- Add access_ended to Dashboard Presenter
- Change UserDashboard Course Type (add field)
- Implement new Call to Action (#AccessEnded)

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Check if route, query, or mutation authorization looks correct.
- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Check if new tables or columns that have been added need to be handled in the following services:
- [x] Check if changes in _packaged_ components have been published to `npm`.
- [x] Add development seeds for new tables.

## Screenshot

![image](https://user-images.githubusercontent.com/57325503/112765973-4de95f00-902d-11eb-9de1-af54c921d070.png)

📌 Closes #666