### PR TITLE
Fix invalid component state when navigating from one target to another via router

### DIFF
--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.res
@@ -22,6 +22,7 @@ type state = {
 
 type action =
   | Select(tab)
+  | ResetTargetDetails
   | SetTargetDetails(TargetDetails.t)
   | AddSubmission(Target.role)
   | ClearTargetDetails
@@ -31,6 +32,7 @@ let initialState = {targetDetails: None, tab: Learn}
 let reducer = (state, action) =>
   switch action {
   | Select(tab) => {...state, tab: tab}
+  | ResetTargetDetails => initialState
   | SetTargetDetails(targetDetails) => {
       ...state,
       targetDetails: Some(targetDetails),
@@ -50,6 +52,8 @@ let closeOverlay = course =>
   ReasonReactRouter.push("/courses/" ++ ((course |> Course.id) ++ "/curriculum"))
 
 let loadTargetDetails = (target, send, ()) => {
+  send(ResetTargetDetails)
+
   {
     open Js.Promise
     Fetch.fetch("/targets/" ++ ((target |> Target.id) ++ "/details_v2"))
@@ -522,7 +526,7 @@ let make = (
 ) => {
   let (state, send) = React.useReducer(reducer, initialState)
 
-  React.useEffect1(loadTargetDetails(target, send), [target |> Target.id])
+  React.useEffect1(loadTargetDetails(target, send), [Target.id(target)])
 
   React.useEffect(() => {
     ScrollLock.activate()

--- a/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.res
+++ b/app/javascript/courses/curricula/components/CoursesCurriculum__Overlay.res
@@ -22,7 +22,7 @@ type state = {
 
 type action =
   | Select(tab)
-  | ResetTargetDetails
+  | ResetState
   | SetTargetDetails(TargetDetails.t)
   | AddSubmission(Target.role)
   | ClearTargetDetails
@@ -32,7 +32,7 @@ let initialState = {targetDetails: None, tab: Learn}
 let reducer = (state, action) =>
   switch action {
   | Select(tab) => {...state, tab: tab}
-  | ResetTargetDetails => initialState
+  | ResetState => initialState
   | SetTargetDetails(targetDetails) => {
       ...state,
       targetDetails: Some(targetDetails),
@@ -52,8 +52,6 @@ let closeOverlay = course =>
   ReasonReactRouter.push("/courses/" ++ ((course |> Course.id) ++ "/curriculum"))
 
 let loadTargetDetails = (target, send, ()) => {
-  send(ResetTargetDetails)
-
   {
     open Js.Promise
     Fetch.fetch("/targets/" ++ ((target |> Target.id) ++ "/details_v2"))
@@ -259,7 +257,7 @@ let overlayStatus = (course, target, targetStatus, preview) =>
 
 let renderLockReason = reason => renderLocked(reason |> TargetStatus.lockReasonToString)
 
-let prerequisitesIncomplete = (reason, target, targets, statusOfTargets) => {
+let prerequisitesIncomplete = (reason, target, targets, statusOfTargets, send) => {
   let prerequisiteTargetIds = target |> Target.prerequisiteTargetIds
 
   let prerequisiteTargets =
@@ -279,6 +277,7 @@ let prerequisitesIncomplete = (reason, target, targets, statusOfTargets) => {
           )
 
         <Link
+          onClick={_ => send(ResetState)}
           href={"/targets/" ++ (target |> Target.id)}
           ariaLabel={"Select Target " ++ (target |> Target.id)}
           key={target |> Target.id}
@@ -293,11 +292,12 @@ let prerequisitesIncomplete = (reason, target, targets, statusOfTargets) => {
   </div>
 }
 
-let handleLocked = (target, targets, targetStatus, statusOfTargets) =>
+let handleLocked = (target, targets, targetStatus, statusOfTargets, send) =>
   switch targetStatus |> TargetStatus.status {
   | Locked(reason) =>
     switch reason {
-    | PrerequisitesIncomplete => prerequisitesIncomplete(reason, target, targets, statusOfTargets)
+    | PrerequisitesIncomplete =>
+      prerequisitesIncomplete(reason, target, targets, statusOfTargets, send)
     | CourseLocked
     | AccessLocked
     | LevelLocked =>
@@ -539,7 +539,7 @@ let make = (
     <div className="bg-gray-100 border-b border-gray-400 px-3">
       <div className="course-overlay__header-container pt-12 lg:pt-0 mx-auto">
         {overlayStatus(course, target, targetStatus, preview)}
-        {handleLocked(target, targets, targetStatus, statusOfTargets)}
+        {handleLocked(target, targets, targetStatus, statusOfTargets, send)}
         {handlePendingStudents(targetStatus, state.targetDetails, users)}
         {switch state.targetDetails {
         | Some(targetDetails) => tabOptions(state, send, targetDetails, targetStatus)

--- a/app/javascript/shared/components/Link.res
+++ b/app/javascript/shared/components/Link.res
@@ -4,9 +4,9 @@ let metaKey = Webapi.Dom.KeyboardEvent.metaKey
 external unsafeAsKeyboardEvent: ReactEvent.Mouse.t => Webapi.Dom.KeyboardEvent.t = "%identity"
 
 let onConfirm = (href, onClick, event) => {
-  event |> ReactEvent.Mouse.preventDefault
+  ReactEvent.Mouse.preventDefault(event)
+  Belt.Option.mapWithDefault(onClick, (), onClick => onClick(event))
   ReasonReactRouter.push(href)
-  onClick |> OptionUtils.mapWithDefault(onClick => onClick(event), ())
 }
 
 let onCancel = event => event |> ReactEvent.Mouse.preventDefault


### PR DESCRIPTION
The quiz UI incorrectly caches questions in its own component state instead of reading it from the prop based on selected question index. When a user navigates using the router from one _quiz_ target to another, the selected question (usually the first) remains cached in the quiz component, causing the wrong question to appear on the linked target.

The reason this fix works is because it's wiping out the `targetDetails` on the parent component, causing the child quiz component to be unloaded before the new target details is loaded. This lets the quiz component spawn again, with a fixed state.

A _proper_ fix here would be to re-write the quiz component to not cache individual quiz questions.