### PR TITLE
Add links to the completion tab for quiz and reviewed type targets

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,8 +127,8 @@ en:
         label: Course name
         placeholder: Type course name here
       create_course: Create Course
-      enable_public_signup_label: Enable public signup for this course?
       enable_public_preview_label: Allow public to view course curriculum?
+      enable_public_signup_label: Enable public signup for this course?
       feature_course_in_homepage_label: Feature course in school homepage?
       progression_behavior:
         help: This only applies if your course has milestone targets that requires students to submit their work for review by coaches.
@@ -222,6 +222,8 @@ en:
       completion_tab_take_quiz: Take Quiz
       completion_tab_visit_link: Visit Link to Complete
       discuss_tab: Discuss
+      learn_cta_submit_work: Submit work for review
+      learn_cta_take_quiz: Take a Quiz
       learn_tab: Learn
       next_target_button: Next Target
       pending_team_members_notice: 'You have team members who are yet to complete this target:'
@@ -519,8 +521,8 @@ en:
       unsubscribe: Unsubscribe
   courses:
     show:
-      preview_course: Preview Course
       continue_course: Continue Course
+      preview_course: Preview Course
   dashboard:
     dashboard:
       tour:

--- a/spec/system/targets/show_spec.rb
+++ b/spec/system/targets/show_spec.rb
@@ -94,6 +94,11 @@ feature 'Target Overlay', js: true do
     find('.course-overlay__body-tab-item', text: 'Complete').click
     # completion instructions should be show on complete section for evaluated targets
     expect(page).to have_text(target_l1.completion_instructions)
+
+    # There should also be a link to the completion section at the bottom of content.
+    find('.course-overlay__body-tab-item', text: 'Learn').click
+    find('a', text: 'Submit work for review').click
+
     long_answer = Faker::Lorem.sentence
 
     replace_markdown long_answer
@@ -247,6 +252,10 @@ feature 'Target Overlay', js: true do
       # Completion instructions should be show on Take Quiz section for targets with quiz
       expect(page).to have_text('Instructions')
       expect(page).to have_text(quiz_target.completion_instructions)
+
+      # There should also be a link to the quiz at the bottom of content.
+      find('.course-overlay__body-tab-item', text: 'Learn').click
+      find('a', text: 'Take a Quiz').click
 
       # Question one
       expect(page).to have_content(/Question #1/i)
@@ -456,6 +465,7 @@ feature 'Target Overlay', js: true do
 
       expect(page).to have_content('The course has ended and submissions are disabled for all targets!')
       expect(page).not_to have_selector('.course-overlay__body-tab-item', text: 'Complete')
+      expect(page).not_to have_selector('a', text: 'Submit work for review')
     end
 
     scenario 'student views a submitted target' do
@@ -495,6 +505,7 @@ feature 'Target Overlay', js: true do
 
       expect(page).to have_content('Your access to this course has ended.')
       expect(page).not_to have_selector('.course-overlay__body-tab-item', text: 'Complete')
+      expect(page).not_to have_selector('a', text: 'Submit work for review')
     end
   end
 


### PR DESCRIPTION
## Proposed Changes

This adds links to the bottom of target content, for quiz and reviewed type targets, that takes the user to the completion tab.

It was noted that many students often scroll to the bottom of the page on such targets and then continue to the next target without completing / attempting such targets. This is because the _Next Target_ link is prominently displayed, but the CTA for _this_ particular target is not.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- [ ] ~~Update developer and product docs, where applicable.~~
- [x] Prep screenshot or demo video for changelog entry, and attach it: [Cloudinary Link](https://res.cloudinary.com/sv-co/video/upload/v1618325161/pupilfirst_changelog/2021/submission_quiz_bottom_links_nmuy5a.mov)
- [ ] ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- [ ] ~~Check if changes in _packaged_ components have been published to `npm`.~~
- [ ] ~~Add development seeds for new tables.~~
