### PR TITLE
Make unlimited progression really unlimited

### DIFF
--- a/app/javascript/courses/curricula/types/CoursesCurriculum__TargetStatus.res
+++ b/app/javascript/courses/curricula/types/CoursesCurriculum__TargetStatus.res
@@ -137,7 +137,11 @@ let compute = (preview, team, course, levels, targetGroups, targets, submissions
       | SubmissionRejected => Rejected
       | SubmissionMissing =>
         if ct.levelNumber > studentLevelNumber && ct.targetReviewed {
-          Locked(LevelLocked)
+          let progressionBehavior = course |> Course.progressionBehavior
+          switch progressionBehavior {
+          | #Unlimited => Pending
+          | _ => Locked(LevelLocked)
+          }
         } else if !(ct.prerequisiteTargetIds |> allTargetsComplete(targetCache)) {
           Locked(PrerequisitesIncomplete)
         } else {

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -78,6 +78,10 @@ class Course < ApplicationRecord
     progression_behavior == PROGRESSION_BEHAVIOR_STRICT
   end
 
+  def unlimited?
+    progression_behavior == PROGRESSION_BEHAVIOR_UNLIMITED
+  end
+
   def archived?
     archived_at.present?
   end

--- a/app/queries/concerns/authorize_student.rb
+++ b/app/queries/concerns/authorize_student.rb
@@ -18,7 +18,10 @@ module AuthorizeStudent
 
   # Students can complete a live target if they're non-reviewed, or if they've reached the target's level for reviewed targets.
   def target_can_be_completed?
-    target.live? && (target.evaluation_criteria.empty? || target.level.number <= team.level.number)
+    target.live? && (
+      course.unlimited? ||
+      (target.evaluation_criteria.empty? || target.level.number <= team.level.number)
+    )
   end
 
   def student

--- a/app/services/targets/status_service.rb
+++ b/app/services/targets/status_service.rb
@@ -44,7 +44,7 @@ module Targets
         elsif @founder.startup.access_ends_at&.past?
           STATUS_ACCESS_LOCKED
         elsif target_level_number > founder_level_number && target_reviewed?
-          STATUS_LEVEL_LOCKED
+          @target.course.unlimited? ? nil : STATUS_LEVEL_LOCKED
         else
           prerequisites_incomplete? ? STATUS_PREREQUISITE_LOCKED : nil
         end

--- a/spec/services/targets/status_service_spec.rb
+++ b/spec/services/targets/status_service_spec.rb
@@ -51,6 +51,19 @@ describe Targets::StatusService do
           end
         end
 
+        context 'when the target is reviewed by a coach but course has unlimited progression behavior' do
+          let(:course) { create :course, :unlimited }
+          let(:evaluation_criterion) { create :evaluation_criterion, course: course }
+
+          before do
+            founder_target_1.evaluation_criteria << evaluation_criterion
+          end
+
+          it 'returns :pending' do
+            expect(subject.status).to eq(Targets::StatusService::STATUS_PENDING)
+          end
+        end
+
         it 'returns :pending for auto-verified target' do
           expect(subject.status).to eq(Targets::StatusService::STATUS_PENDING)
         end


### PR DESCRIPTION
## Proposed Changes

- Unlimited progression behaviour allows submissions even if previous level is not up
- to be consider: maybe this is another type of progression behavior?

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
