### PR TITLE
Fixed a minor typo in user_roles.md

### DIFF
--- a/docs/user_roles.md
+++ b/docs/user_roles.md
@@ -5,6 +5,6 @@ There are four kinds of users within Pupilfirst:
 1. **School Admins:** They manage the school, and have full access to the school administration interface.
 2. **Coaches:** They can review submissions from students or teams that they are assigned to, monitor their progress, and have access to all communities in the school.
 3. **Course Authors:** They can edit the content of courses that they're assigned to.
-4. **Students:** The have access to one or more courses and can submit work on targets. They also have access to commnunities that they're courses are linked to.
+4. **Students:** The have access to one or more courses and can submit work on targets. They also have access to commnunities that their courses are linked to.
 
 To learn more about what each of these roles can do with Pupilfirst, browse their topic under the headings _Administration_, _Coaching_, and _Learning_.


### PR DESCRIPTION
I was going through the [documentation](https://docs.pupilfirst.com/#/user_roles) and just found a minor typo so thought of making a PR.

### Proposed Changes

- Change - ```In the Students user role, point number 4. changing the word they're to their.```

@pupilfirst/developers