### PR TITLE
delete "of the" from two error msgs

### DIFF
--- a/app/forms/courses/bulk_import_students_form.rb
+++ b/app/forms/courses/bulk_import_students_form.rb
@@ -33,7 +33,7 @@ module Courses
 
       return unless invalid
 
-      errors[:base] << 'One or more of the entries have an invalid email address'
+      errors[:base] << 'One or more entries have an invalid email address'
     end
 
     def students_must_have_unique_email
@@ -61,7 +61,7 @@ module Courses
           valid_string?(string: r['team_name'], max_length: 50, optional: true)
       end
 
-      errors[:base] << 'One or more of the entries have invalid strings'
+      errors[:base] << 'One or more entries have invalid strings'
     end
   end
 end


### PR DESCRIPTION
it's not necessary to specify "of the" when referring to these entries for either error scenario. less words = better readability for the user