### PR TITLE
Add syntax highlighting support for JSX and TSX

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -87,6 +87,7 @@ module.exports = function (api) {
         {
           languages: [
             "javascript",
+            "jsx",
             "json",
             "markup",
             "css",
@@ -98,6 +99,7 @@ module.exports = function (api) {
             "csharp",
             "php",
             "typescript",
+            "tsx",
             "cpp",
             "c",
             "go",

--- a/docs/served/markdown_editor.md
+++ b/docs/served/markdown_editor.md
@@ -413,6 +413,7 @@ This is the comprehensive list of languages and scripts that we support syntax
 highlighting on, within fenced code-blocks.
 
 - `javascript` (`js`)
+- `jsx`
 - `json` (`webmanifest`)
 - `markup` (`html`, `xml`, `svg`, `mathml`)
 - `css`
@@ -424,6 +425,7 @@ highlighting on, within fenced code-blocks.
 - `csharp` (`cs`, `dotnet`)
 - `php`
 - `typescript` (`ts`)
+- `tsx`
 - `cpp`
 - `c`
 - `go`


### PR DESCRIPTION
## Proposed Changes

This adds `jsx` and `tsx` to the list of _languages_ that we enable with the PrismJS syntax highlighter.

## Merge Checklist

- ~~Add specs that demonstrate bug / test a new feature.~~
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- [x] Update developer and product docs, where applicable.
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services.~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
