### PR TITLE
Fix video upload size limit for non-basic Vimeo plans

### DIFF
--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentBlockCreator.res
@@ -1,14 +1,13 @@
 exception FormNotFound(string)
 
-%bs.raw(`require("./CurriculumEditor__ContentBlockCreator.css")`)
+%raw(`require("./CurriculumEditor__ContentBlockCreator.css")`)
 
 open CurriculumEditor__Types
 
 let str = React.string
 let t = I18n.t(~scope="components.CurriculumEditor__ContentBlockCreator")
 
-module CreateMarkdownContentBlock = %graphql(
-  `
+module CreateMarkdownContentBlock = %graphql(`
     mutation CreateMarkdownContentBlockMutation($targetId: ID!, $aboveContentBlockId: ID) {
       createMarkdownContentBlock(targetId: $targetId, aboveContentBlockId: $aboveContentBlockId) {
         contentBlock {
@@ -16,11 +15,9 @@ module CreateMarkdownContentBlock = %graphql(
         }
       }
     }
-  `
-)
+  `)
 
-module CreateEmbedContentBlock = %graphql(
-  `
+module CreateEmbedContentBlock = %graphql(`
     mutation CreateEmbedContentBlockMutation($targetId: ID!, $aboveContentBlockId: ID, $url: String!, $requestSource: EmbedRequestSource!) {
       createEmbedContentBlock(targetId: $targetId, aboveContentBlockId: $aboveContentBlockId, url: $url, requestSource: $requestSource) {
         contentBlock {
@@ -28,11 +25,9 @@ module CreateEmbedContentBlock = %graphql(
         }
       }
     }
-  `
-)
+  `)
 
-module CreateVimeoVideo = %graphql(
-  `
+module CreateVimeoVideo = %graphql(`
     mutation CreateVimeoVideo($targetId: ID!, $size: Int!, $title: String, $description: String) {
       createVimeoVideo(targetId: $targetId, size: $size, title: $title, description: $description) {
         vimeoVideo {
@@ -41,8 +36,7 @@ module CreateVimeoVideo = %graphql(
         }
       }
     }
-  `
-)
+  `)
 
 type ui =
   | Hidden
@@ -210,14 +204,14 @@ let button = (target, aboveContentBlock, send, addContentBlockCB, blockType) => 
 }
 
 let embedUrlRegexes = [
-  %bs.re("/https:\\/\\/.*slideshare\\.net/"),
-  %bs.re("/https:\\/\\/.*vimeo\\.com/"),
-  %bs.re("/https:\\/\\/.*youtube\\.com/"),
-  %bs.re("/https:\\/\\/.*youtu\\.be/"),
-  %bs.re("/https:\\/\\/docs\\.google\\.com\\/presentation/"),
-  %bs.re("/https:\\/\\/docs\\.google\\.com\\/document/"),
-  %bs.re("/https:\\/\\/docs\\.google\\.com\\/spreadsheets/"),
-  %bs.re("/https:\\/\\/docs\\.google\\.com\\/forms/"),
+  %re("/https:\\/\\/.*slideshare\\.net/"),
+  %re("/https:\\/\\/.*vimeo\\.com/"),
+  %re("/https:\\/\\/.*youtube\\.com/"),
+  %re("/https:\\/\\/.*youtu\\.be/"),
+  %re("/https:\\/\\/docs\\.google\\.com\\/presentation/"),
+  %re("/https:\\/\\/docs\\.google\\.com\\/document/"),
+  %re("/https:\\/\\/docs\\.google\\.com\\/spreadsheets/"),
+  %re("/https:\\/\\/docs\\.google\\.com\\/forms/"),
 ]
 
 let validEmbedUrl = url => Belt.Array.some(embedUrlRegexes, regex => regex->Js.Re.test_(url))
@@ -385,14 +379,14 @@ let maxVideoSize = vimeoPlan => {
   switch vimeoPlan {
   | Some(plan) =>
     switch plan {
-    | VimeoPlan.Basic => 500 * 1024 * 1024
+    | VimeoPlan.Basic => 500.0 *. 1024.0 *. 1024.0
     | Plus
     | Pro
     | Business
     | Premium =>
-      5000 * 1024 * 1024
+      5.0 *. 1024.0 *. 1024.0 *. 1024.0
     }
-  | None => FileUtils.defaultVideoMaxSize
+  | None => float_of_int(FileUtils.defaultVideoMaxSize)
   }
 }
 
@@ -433,7 +427,7 @@ let handleFileInputChange = (
       FileUtils.isInvalid(~image=true, file) ? Some(t("image.invalid_image_warning")) : None
     | #VideoEmbed =>
       let maxVideoSize = maxVideoSize(vimeoPlan)
-      switch (FileUtils.isVideo(file), FileUtils.hasValidSize(~maxSize=maxVideoSize, file)) {
+      switch (FileUtils.isVideo(file), FileUtils.hasValidFloatSize(~maxSize=maxVideoSize, file)) {
       | (false, true | false) => Some(t("video.invalid_format_warning"))
       | (true, false) =>
         Some(

--- a/app/javascript/shared/utils/FileUtils.res
+++ b/app/javascript/shared/utils/FileUtils.res
@@ -3,6 +3,8 @@ let defaultVideoMaxSize = 500 * 1024 * 1024
 
 let hasValidSize = (~maxSize, file) => file["size"] <= maxSize
 
+let hasValidFloatSize = (~maxSize: float, file) => file["size"] <= maxSize
+
 let isImage = file =>
   switch file["_type"] {
   | "image/jpeg"


### PR DESCRIPTION
## Proposed Changes

This fixes the file size limit for Vimeo uploads when a non-basic plan is in use.

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled.~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
