### PR TITLE
Fix active state of buttons in curriculum editor

### DIFF
--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDetailsEditor.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDetailsEditor.res
@@ -572,10 +572,10 @@ let targetGroupEditor = (state, targetGroups, levels, send) =>
   </div>
 
 let methodOfCompletionButtonClasses = value => {
-  let defaultClasses = "target-editor__completion-button relative flex flex-col items-center bg-white border border-gray-400 hover:bg-gray-200 text-sm font-semibold focus:outline-none rounded p-4"
+  let defaultClasses = "target-editor__completion-button relative flex flex-col items-center bg-white border hover:bg-gray-200 text-sm font-semibold focus:outline-none rounded p-4"
   value
     ? defaultClasses ++ " target-editor__completion-button--selected bg-gray-200 text-primary-500 border-primary-500"
-    : defaultClasses ++ " opacity-75 text-gray-900"
+    : defaultClasses ++ " border-gray-400 opacity-75 text-gray-900"
 }
 
 let methodOfCompletionSelection = polyMethodOfCompletion =>

--- a/app/javascript/schools/shared/shared.css
+++ b/app/javascript/schools/shared/shared.css
@@ -299,8 +299,8 @@
   @apply rounded-r;
 }
 
-.toggle-button__button:nth-child(n + 2) {
-  @apply -ml-px;
+.toggle-button__button:not(:last-of-type) {
+  border-right-color: transparent;
 }
 
 .toggle-button__button:hover {
@@ -312,7 +312,11 @@
 }
 
 .toggle-button__button--active {
-  @apply bg-primary-100 text-primary-600 border-primary-500 z-10;
+  @apply bg-primary-100 text-primary-600 border-primary-500;
+}
+
+.toggle-button__button--active:not(:last-of-type) {
+  border-right-color: currentColor;
 }
 
 .target-group__container > :not(:last-child):before {

--- a/app/javascript/schools/shared/shared.css
+++ b/app/javascript/schools/shared/shared.css
@@ -300,7 +300,7 @@
 }
 
 .toggle-button__button:nth-child(n + 2) {
-  @apply -ml-px border-gray-400;
+  @apply -ml-px;
 }
 
 .toggle-button__button:hover {
@@ -312,7 +312,7 @@
 }
 
 .toggle-button__button--active {
-  @apply bg-primary-100 text-primary-600;
+  @apply bg-primary-100 text-primary-600 border-primary-500 z-10;
 }
 
 .target-group__container > :not(:last-child):before {


### PR DESCRIPTION
## Proposed Changes
- This fixes (issue #625) the active state of buttons in the curriculum editor.

![Screenshot from 2021-12-21 12-14-50](https://user-images.githubusercontent.com/26390669/146886036-136e755b-a853-4c85-bc43-e151ffb5a52e.png)

- Also adds border-primary to the active option of "How do you want the student to complete the target?" which was missing.

**_previous state_**
![Screenshot from 2021-12-21 12-13-28](https://user-images.githubusercontent.com/26390669/146886096-98678188-fa08-4bd6-833f-6c0364b8b679.png)

**_Change_**
![Screenshot from 2021-12-21 12-14-28](https://user-images.githubusercontent.com/26390669/146886360-20ef2e5d-f7d0-4fd8-bf95-83b9ed84d7b0.png)



@pupilfirst/developers
