### PR TITLE
Fix misalignment of cross icon in chips

### DIFF
--- a/app/javascript/schools/courses/components/StudentsEditor__Root.res
+++ b/app/javascript/schools/courses/components/StudentsEditor__Root.res
@@ -309,7 +309,7 @@ let make = (
                             {selectedStudent |> SelectedStudent.name |> str}
                           </span>
                           <button
-                            className="flex h-full text-xs text-red-700 px-2 py-px border-l focus:outline-none bg-gray-100 hover:bg-red-400 hover:text-white "
+                            className="flex items-center h-full text-xs text-red-700 px-2 py-px border-l focus:outline-none bg-gray-100 hover:bg-red-700 hover:text-white "
                             onClick={_ =>
                               deselectStudent(send, selectedStudent |> SelectedStudent.id)}>
                             <Icon className="if i-times-regular" />


### PR DESCRIPTION
## Proposed Changes

This fixes (issue #858) misalignment of cross icon in chips.

![Screenshot from 2021-12-21 17-42-24](https://user-images.githubusercontent.com/26390669/146928557-d455a988-9656-45d6-898d-d6bfde17b7bf.png)



@pupilfirst/developers