### PR TITLE
Allows target _blank links to pass DOMPurify sanitization using the d…

### DIFF
--- a/app/javascript/shared/utils/DOMPurify.res
+++ b/app/javascript/shared/utils/DOMPurify.res
@@ -7,3 +7,26 @@ type options = {"ALLOWED_TAGS": array<string>}
 let sanitizedHTML = html => {"__html": sanitize(html)}
 
 let sanitizedHTMLOpt = (html, options) => {"__html": sanitizeOpt(html, options)}
+
+@module("dompurify") external addHook: (string, (Dom.node) => ()) => int = "addHook"
+
+let sanitizedHTMLHook = (entryPoint, hookFunction) => {
+  addHook(entryPoint, hookFunction)
+}
+
+%%raw(`
+  sanitizedHTMLHook('afterSanitizeAttributes', function(node) {
+      // set all elements owning target to target=_blank
+      if ('target' in node) {
+          node.setAttribute('target','_blank');
+          // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+          node.setAttribute('rel', 'noopener noreferrer');
+      }
+      // set non-HTML/MathML links to xlink:show=new
+      if (!node.hasAttribute('target')
+          && (node.hasAttribute('xlink:href')
+              || node.hasAttribute('href'))) {
+          node.setAttribute('xlink:show', 'new');
+      }
+  });
+`)


### PR DESCRIPTION
…emo code here https://github.com/cure53/DOMPurify/blob/main/demos/hooks-target-blank-demo.html

## Proposed Changes

- Makes all markdown links open in a new tab. Addresses #827 

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
