### PR TITLE
Fix bug in closing content editor when block with unsaved changes are deleted 

### DIFF
--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentEditor.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__ContentEditor.res
@@ -58,6 +58,7 @@ let reducer = (state, action) =>
       contentBlocks: state.contentBlocks |> Js.Array.filter(contentBlock =>
         contentBlock |> ContentBlock.id != contentBlockId
       ),
+      dirtyContentBlockIds: state.dirtyContentBlockIds->Belt.Set.String.remove(contentBlockId),
     }
   | MoveContentBlockUp(contentBlock) => {
       ...state,

--- a/spec/system/school/courses/target_content_editor_spec.rb
+++ b/spec/system/school/courses/target_content_editor_spec.rb
@@ -495,7 +495,7 @@ feature 'Target Content Editor', js: true do
         "div[aria-label='Editor for content block #{fourth_block.id}']"
       )
 
-      # Closing editor should be confirmed.
+      # Closing editor should not be confirmed.
       find('button[title="Close Editor"').click
 
       expect(page).not_to have_selector(

--- a/spec/system/school/courses/target_content_editor_spec.rb
+++ b/spec/system/school/courses/target_content_editor_spec.rb
@@ -481,6 +481,27 @@ feature 'Target Content Editor', js: true do
       )
       expect(ContentBlock.count).to eq(3)
     end
+
+    scenario 'admin deletes a content block with unsaved changes' do
+      sign_in_user school_admin.user,
+                   referrer: content_school_course_target_path(course, target)
+
+      within("div[aria-label='Editor for content block #{fourth_block.id}']") do
+        fill_in 'Title', with: 'A new title'
+        accept_confirm { find('button[title="Delete"]').click }
+      end
+
+      expect(page).not_to have_selector(
+        "div[aria-label='Editor for content block #{fourth_block.id}']"
+      )
+
+      # Closing editor should be confirmed.
+      find('button[title="Close Editor"').click
+
+      expect(page).not_to have_selector(
+        "div[aria-label='Editor for content block #{first_block.id}']"
+      )
+    end
   end
 
   scenario 'course author edits the content of a target' do


### PR DESCRIPTION
## Proposed Changes
Fix dirty state on deleting new content blocks with unsaved changes or when existing blocks are deleted with unsaved changes.

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~Check if route, query, or mutation authorization looks correct.~
  - Add tests for authorization, if required.
- [ ] ~Ensure that UI text is kept in I18n files.~
- [ ] ~Update developer and product docs, where applicable.~
- [ ] ~Prep screenshot or demo video for changelog entry, and attach it to issue.~
- [ ] ~Check if new tables or columns that have been added need to be handled in the following services:~
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] ~Check if changes in _packaged_ components have been published to `npm`.~
- [ ] ~Add development seeds for new tables.~
- [ ] ~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~
