### PR TITLE
Create a new profile for running spec on github code spaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=2.7-bullseye
+ARG VARIANT=2.7
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
 
 # Install Rails

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         # Update 'VARIANT' to pick a version of Ruby: 3, 3.0, 2, 2.7, 2.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: "2.7-bullseye"
+        VARIANT: "2.7"
         # Optional Node.js version to install
         NODE_VERSION: "lts/*"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,6 +125,17 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new app, browser: :chrome, capabilities: [options]
 end
 
+Capybara.register_driver :headless_chrome_codespaces do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--window-size=1920,1080')
+  options.add_argument("--no-sandbox");
+  options.add_argument('use-fake-ui-for-media-stream')
+  options.add_argument('use-fake-device-for-media-stream')
+  options.headless!
+
+  Capybara::Selenium::Driver.new app, browser: :chrome, capabilities: [options]
+end
+
 Capybara.register_driver :firefox do |app|
   Capybara::Selenium::Driver.new(app, browser: :firefox)
 end


### PR DESCRIPTION
## Proposed Changes
`rspec` will fail to run on GitHub codespaces throwing the following error. 
![image (3)](https://user-images.githubusercontent.com/14979190/162907548-1cd89659-f03a-4c33-9520-213690e29925.png)

The fix tries to add a new profile for chrome that sets `--no-sandbox` flag while running `rspec` 

Base image version was also moved to `2.7` from `2.7-bullseye` to avoid installing additional libs for spec setup. 
@pupilfirst/developers
