### PR TITLE
Removes maxLength constraint in curriculum editor markdown blocks so …

### DIFF
--- a/app/graphql/types/markdown_block_type.rb
+++ b/app/graphql/types/markdown_block_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MarkdownBlockType < Types::BaseObject
     field :markdown, String, null: false
+    field :markdown_content_block_maximum_length, Integer, null: false
   end
 end

--- a/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__MarkdownBlockEditor.res
+++ b/app/javascript/schools/courses/components/curriculum_editor/CurriculumEditor__MarkdownBlockEditor.res
@@ -10,7 +10,6 @@ let make = (~markdown, ~contentBlock, ~updateContentBlockCB) =>
   <MarkdownEditor
     value=markdown
     profile=Markdown.Permissive
-    maxLength=10000
     onChange={onChange(contentBlock, updateContentBlockCB)}
     dynamicHeight=true
   />

--- a/app/javascript/shared/components/MarkdownEditor.res
+++ b/app/javascript/shared/components/MarkdownEditor.res
@@ -616,7 +616,7 @@ let make = (
   ~onChange,
   ~profile,
   ~textareaId=?,
-  ~maxLength=1000,
+  ~maxLength=?,
   ~defaultMode=Windowed(#Editor),
   ~placeholder=?,
   ~tabIndex=?,
@@ -718,7 +718,7 @@ let make = (
             ?placeholder
             ariaLabel="Markdown editor"
             rows=4
-            maxLength
+            ?maxLength
             onSelect={onSelect(send)}
             onChange={onChangeWrapper(onChange)}
             id=state.id

--- a/app/queries/update_markdown_content_block_mutator.rb
+++ b/app/queries/update_markdown_content_block_mutator.rb
@@ -3,7 +3,7 @@ class UpdateMarkdownContentBlockMutator < ApplicationQuery
   include ContentBlockEditable
 
   property :id, validates: { presence: true }
-  property :markdown, validates: { length: { maximum: 10_000 } }
+  property :markdown, validates: { presence: true }
 
   validate :must_be_a_markdown_block
   validate :must_be_latest_version


### PR DESCRIPTION
…that longer trainings can be accommodated.

## Proposed Changes

- Removes the `maxLength` constraint on MarkdownBlocks within the Curriculum Editor.

We do live Q&A calls each week with our students. These calls can last 2 hours or more. We get transcripts of the call recordings and the transcripts are typically longer than 10,000 characters. This change will allow us to include our Q&A call transcripts in a single markdown block for easy searching by our students.

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
