### PR TITLE
Show last seen status  for users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -281,7 +281,7 @@ class ApplicationController < ActionController::Base
                   }
 
   def set_last_seen_at
-    current_user.update(last_seen_at: Time.current)
+    current_user.update!(last_seen_at: Time.current)
     session[:last_seen_at] = Time.current
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -269,4 +269,19 @@ class ApplicationController < ActionController::Base
   def redirect_to_primary_domain
     observable_redirect_to "#{request.ssl? ? 'https' : 'http'}://#{current_school.domains.primary.fqdn}#{request.path}"
   end
+
+  before_action :set_last_seen_at,
+                if:
+                  proc {
+                    user_signed_in? &&
+                      (
+                        session[:last_seen_at] == nil ||
+                          session[:last_seen_at] < 15.minutes.ago
+                      )
+                  }
+
+  def set_last_seen_at
+    current_user.update(last_seen_at: Time.current)
+    session[:last_seen_at] = Time.current
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -276,12 +276,12 @@ class ApplicationController < ActionController::Base
                     user_signed_in? &&
                       (
                         session[:last_seen_at] == nil ||
-                          session[:last_seen_at] < 15.minutes.ago
+                          Time.zone.parse(session[:last_seen_at]) < 15.minutes.ago
                       )
                   }
 
   def set_last_seen_at
     current_user.update!(last_seen_at: Time.current)
-    session[:last_seen_at] = Time.current
+    session[:last_seen_at] = Time.current.iso8601
   end
 end

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -32,7 +32,7 @@ module Types
         .batch do |user_ids, loader|
           User
             .where(id: user_ids)
-            .each { |user| loader.call(user.id, user.last_seen_at) }
+            .each { |user| loader.call(user.id, user.last_seen_at || user.current_sign_in_at) }
         end
     end
 

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -4,6 +4,7 @@ module Types
     field :name, String, null: false
     field :title, String, null: false
     field :avatar_url, String, null: true
+    field :last_seen_at, GraphQL::Types::ISO8601DateTime, null: true
     field :user_tags, [String], null: false
 
     def avatar_url
@@ -22,6 +23,16 @@ module Types
                 loader.call(user.id, url)
               end
             end
+        end
+    end
+
+    def last_seen_at
+      BatchLoader::GraphQL
+        .for(object.user_id)
+        .batch do |user_ids, loader|
+          User
+            .where(id: user_ids)
+            .each { |user| loader.call(user.id, user.last_seen_at) }
         end
     end
 

--- a/app/javascript/courses/students/components/CoursesStudents__Root.res
+++ b/app/javascript/courses/students/components/CoursesStudents__Root.res
@@ -159,6 +159,7 @@ module TeamsQuery = %graphql(`
             title
             avatarUrl
             userTags
+            lastSeenAt
           }
           coachUserIds
           accessEndsAt

--- a/app/javascript/courses/students/components/CoursesStudents__StudentOverlay.res
+++ b/app/javascript/courses/students/components/CoursesStudents__StudentOverlay.res
@@ -46,6 +46,7 @@ module StudentDetailsQuery = %graphql(`
             title
             avatarUrl
             userTags
+            lastSeenAt
           }
           coachUserIds
         }
@@ -501,7 +502,9 @@ let make = (~courseId, ~studentId, ~levels, ~userId, ~teamCoaches, ~onAddCoachNo
           className="w-full relative md:w-3/5 bg-gray-100 md:border-l pb-6 2xl:pb-12 md:overflow-y-auto">
           <div
             className="sticky top-0 bg-gray-100 pt-2 md:pt-4 px-4 md:px-8 2xl:px-16 2xl:pt-10 z-30">
-            <ul role="tablist" className="flex flex-1 md:flex-none p-1 md:p-0 space-x-1 md:space-x-0 text-center rounded-lg justify-between md:justify-start bg-gray-300 md:bg-transparent">
+            <ul
+              role="tablist"
+              className="flex flex-1 md:flex-none p-1 md:p-0 space-x-1 md:space-x-0 text-center rounded-lg justify-between md:justify-start bg-gray-300 md:bg-transparent">
               <li
                 tabIndex=0
                 role="tab"

--- a/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
+++ b/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
@@ -75,8 +75,13 @@ let showStudent = (team, levels, teamCoaches) => {
             <span className="pl-2 border-l border-gray-400 italic">
               {switch student->TeamInfo.lastSeenAt {
               | Some(date) =>
-                str(t("last_seen") ++ date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()))
-              | None => React.null
+                t(
+                  ~variables=[
+                    ("time_string", date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ())),
+                  ],
+                  "last_seen",
+                )->str
+              | None => t("no_last_seen")->str
               }}
             </span>
           </div>
@@ -135,11 +140,16 @@ let showTeam = (team, levels, teamCoaches) =>
                   <span className="pl-2 border-l border-gray-400 italic">
                     {switch student->TeamInfo.lastSeenAt {
                     | Some(date) =>
-                      str(
-                        t("last_seen") ++
-                        date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()),
-                      )
-                    | None => React.null
+                      t(
+                        ~variables=[
+                          (
+                            "time_string",
+                            date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()),
+                          ),
+                        ],
+                        "last_seen",
+                      )->str
+                    | None => t("no_last_seen")->str
                     }}
                   </span>
                 </div>

--- a/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
+++ b/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
@@ -1,4 +1,5 @@
 %raw(`require("./CoursesStudents__Root.css")`)
+let t = I18n.t(~scope="components.CoursesStudents__TeamsList")
 
 open CoursesStudents__Types
 
@@ -76,7 +77,7 @@ let showStudent = (team, levels, teamCoaches) => {
             <span className="leading-normal pt-px">
               {switch student->TeamInfo.lastSeenAt {
               | Some(date) =>
-                str("| Last seen: " ++ date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()))
+                str(t("last_seen") ++ date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()))
               | None => React.null
               }}
             </span>
@@ -137,7 +138,7 @@ let showTeam = (team, levels, teamCoaches) =>
                     {switch student->TeamInfo.lastSeenAt {
                     | Some(date) =>
                       str(
-                        "| Last seen: " ++
+                        t("last_seen") ++
                         date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()),
                       )
                     | None => React.null

--- a/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
+++ b/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
@@ -77,6 +77,16 @@ let showStudent = (team, levels, teamCoaches) => {
               {studentTags(student)} {teamTags(team)}
             </span>
           </div>
+          <div className="text-gray-700 font-semibold text-xs leading-snug flex items-start">
+            <span className="leading-normal pt-px">
+              {str("Last seen at: ")}
+              {switch student->TeamInfo.lastSeenAt {
+                | Some (date) => date -> DateFns.formatDistanceToNowStrict(~addSuffix=true, ())->str
+                | None => React.null
+                }
+                }
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
+++ b/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
@@ -70,11 +70,9 @@ let showStudent = (team, levels, teamCoaches) => {
           <p className="font-semibold inline-block leading-snug">
             {student |> TeamInfo.studentName |> str}
           </p>
-          <div className="text-gray-700 font-semibold text-xs leading-snug flex items-start">
-            <span className="leading-normal pt-px">
-              {student |> TeamInfo.studentTitle |> str}
-            </span>
-            <span className="leading-normal pt-px">
+          <div className="py-px text-gray-700 text-xs leading-snug flex items-start">
+            <span className="font-semibold pr-2"> {student |> TeamInfo.studentTitle |> str} </span>
+            <span className="pl-2 border-l border-gray-400 italic">
               {switch student->TeamInfo.lastSeenAt {
               | Some(date) =>
                 str(t("last_seen") ++ date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()))
@@ -130,11 +128,11 @@ let showTeam = (team, levels, teamCoaches) =>
                 <p className="font-semibold inline-block leading-snug ">
                   {student |> TeamInfo.studentName |> str}
                 </p>
-                <div className="flex">
-                  <span className="text-gray-700 font-semibold text-xs mt-px leading-snug ">
+                <div className="py-px text-gray-700 text-xs leading-snug flex items-start">
+                  <span className="font-semibold pr-2">
                     {student |> TeamInfo.studentTitle |> str}
                   </span>
-                  <span className="text-gray-700 font-semibold text-xs mt-px leading-snug">
+                  <span className="pl-2 border-l border-gray-400 italic">
                     {switch student->TeamInfo.lastSeenAt {
                     | Some(date) =>
                       str(

--- a/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
+++ b/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
@@ -74,18 +74,15 @@ let showStudent = (team, levels, teamCoaches) => {
               {student |> TeamInfo.studentTitle |> str}
             </span>
             <span className="font-normal ml-2 flex flex-wrap">
-              {studentTags(student)} {teamTags(team)}
+              {switch student->TeamInfo.lastSeenAt {
+              | Some(date) =>
+                str("| Last seen: " ++ date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()))
+              | None => React.null
+              }}
             </span>
           </div>
           <div className="text-gray-700 font-semibold text-xs leading-snug flex items-start">
-            <span className="leading-normal pt-px">
-              {str("Last seen at: ")}
-              {switch student->TeamInfo.lastSeenAt {
-                | Some (date) => date -> DateFns.formatDistanceToNowStrict(~addSuffix=true, ())->str
-                | None => React.null
-                }
-                }
-            </span>
+            {studentTags(student)} {teamTags(team)}
           </div>
         </div>
       </div>

--- a/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
+++ b/app/javascript/courses/students/components/CoursesStudents__TeamsList.res
@@ -73,7 +73,7 @@ let showStudent = (team, levels, teamCoaches) => {
             <span className="leading-normal pt-px">
               {student |> TeamInfo.studentTitle |> str}
             </span>
-            <span className="font-normal ml-2 flex flex-wrap">
+            <span className="leading-normal pt-px">
               {switch student->TeamInfo.lastSeenAt {
               | Some(date) =>
                 str("| Last seen: " ++ date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()))
@@ -129,9 +129,21 @@ let showTeam = (team, levels, teamCoaches) =>
                 <p className="font-semibold inline-block leading-snug ">
                   {student |> TeamInfo.studentName |> str}
                 </p>
-                <p className="text-gray-700 font-semibold text-xs mt-px leading-snug ">
-                  {student |> TeamInfo.studentTitle |> str}
-                </p>
+                <div className="flex">
+                  <span className="text-gray-700 font-semibold text-xs mt-px leading-snug ">
+                    {student |> TeamInfo.studentTitle |> str}
+                  </span>
+                  <span className="text-gray-700 font-semibold text-xs mt-px leading-snug">
+                    {switch student->TeamInfo.lastSeenAt {
+                    | Some(date) =>
+                      str(
+                        "| Last seen: " ++
+                        date->DateFns.formatDistanceToNowStrict(~addSuffix=true, ()),
+                      )
+                    | None => React.null
+                    }}
+                  </span>
+                </div>
                 {studentTags(student)}
               </div>
             </div>

--- a/app/javascript/courses/students/types/CoursesStudents__TeamInfo.res
+++ b/app/javascript/courses/students/types/CoursesStudents__TeamInfo.res
@@ -4,6 +4,7 @@ type student = {
   title: string,
   avatarUrl: option<string>,
   userTags: array<string>,
+  lastSeenAt: option<Js.Date.t>,
 }
 
 type t = {
@@ -40,6 +41,8 @@ let studentAvatarUrl = student => student.avatarUrl
 
 let studentTags = (student: student) => student.userTags
 
+let lastSeenAt = student => student.lastSeenAt
+
 let droppedOutAt = t => t.droppedOutAt
 
 let accessEndsAt = t => t.accessEndsAt
@@ -50,12 +53,13 @@ let studentWithId = (studentId, t) =>
     "Could not find student with ID " ++ (studentId ++ (" in team with ID " ++ t.id)),
   )
 
-let makeStudent = (~id, ~name, ~title, ~avatarUrl, ~userTags) => {
+let makeStudent = (~id, ~name, ~title, ~avatarUrl, ~userTags, ~lastSeenAt) => {
   id: id,
   name: name,
   title: title,
   avatarUrl: avatarUrl,
   userTags: userTags,
+  lastSeenAt: lastSeenAt,
 }
 
 let make = (
@@ -87,6 +91,7 @@ let makeFromJS = teamDetails => {
         ~title=student["title"],
         ~avatarUrl=student["avatarUrl"],
         ~userTags=student["userTags"],
+        ~lastSeenAt=student["lastSeenAt"]->Belt.Option.map(DateFns.decodeISO),
       ),
     teamDetails["students"],
   )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -548,7 +548,7 @@ en:
     CoursesReview__SubmissionInfoCard:
       submission_hash: "Submission #"
     CoursesStudents__TeamsList:
-      last_seen: "| Last seen: "
+      last_seen: "Last seen "
     CoursesStudents__StudentOverlay:
       access_ended_at: This student's access to the course ended on %{date}.
       attempted: " Attempted"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,6 +547,8 @@ en:
       submitted_by_team: "Submitted by team "
     CoursesReview__SubmissionInfoCard:
       submission_hash: "Submission #"
+    CoursesStudents__TeamsList:
+      last_seen: "| Last seen: "
     CoursesStudents__StudentOverlay:
       access_ended_at: This student's access to the course ended on %{date}.
       attempted: " Attempted"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,7 +549,7 @@ en:
       submission_hash: "Submission #"
     CoursesStudents__TeamsList:
       last_seen: "Last seen %{time_string}"
-      no_last_seen: "Last seen long time ago"
+      no_last_seen: "This student has never signed in"
     CoursesStudents__StudentOverlay:
       access_ended_at: This student's access to the course ended on %{date}.
       attempted: " Attempted"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -548,7 +548,8 @@ en:
     CoursesReview__SubmissionInfoCard:
       submission_hash: "Submission #"
     CoursesStudents__TeamsList:
-      last_seen: "Last seen "
+      last_seen: "Last seen %{time_string}"
+      no_last_seen: "Last seen long time ago"
     CoursesStudents__StudentOverlay:
       access_ended_at: This student's access to the course ended on %{date}.
       attempted: " Attempted"

--- a/db/migrate/20220425072002_add_last_seen_at_to_users.rb
+++ b/db/migrate/20220425072002_add_last_seen_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSeenAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :last_seen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_31_123330) do
+ActiveRecord::Schema.define(version: 2022_04_25_072002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -738,6 +738,7 @@ ActiveRecord::Schema.define(version: 2022_03_31_123330) do
     t.string "locale", default: "en"
     t.jsonb "webpush_subscription", default: {}
     t.string "login_token_digest"
+    t.datetime "last_seen_at"
     t.index ["api_token_digest"], name: "index_users_on_api_token_digest", unique: true
     t.index ["delete_account_token_digest"], name: "index_users_on_delete_account_token_digest", unique: true
     t.index ["email", "school_id"], name: "index_users_on_email_and_school_id", unique: true

--- a/docs/developers/docs/using_docker.md
+++ b/docs/developers/docs/using_docker.md
@@ -7,7 +7,99 @@ sidebar_label: Using Docker
 Docker images for the LMS can be found on [our official Docker Hub account: pupilfirst/pupilfirst](https://hub.docker.com/r/pupilfirst/pupilfirst).
 
 These images are automatically built using Github CI on [our Github repo](https://github.com/pupilfirst/pupilfirst).
-For more instructions regarding the use of this image, please refer to documentation on the Docker Hub repository.
 
 These images are ideal for quickly and easily deploying the LMS to targets such as
 [Digital Ocean's App Platform](https://www.digitalocean.com/products/app-platform).
+
+## Environment variables
+
+There are several environment variables you'll need to set up to get the application fully functional:
+
+### Essential
+
+#### Basic configuration
+
+```
+ASSET_HOST=https://assets.mydomain.com
+DATABASE_URL=postgresql://username:password@host:port/database?sslmode=require
+DEFAULT_SENDER_EMAIL_ADDRESS=noreply@mydomain.com
+GRAPH_API_RATE_LIMIT=10
+I18N_AVAILABLE_LOCALES=en,ru
+I18N_DEFAULT_LOCALE=en
+RAILS_ENV=production
+RAILS_LOG_TO_STDOUT=true
+RAILS_SERVE_STATIC_FILES=true
+SECRET_KEY_BASE=generate_using_rails_secret
+```
+
+#### Postmark
+
+```
+POSTMARK_API_TOKEN
+POSTMARK_HOOK_ID
+POSTMARK_HOOK_SECRET
+```
+
+Generate these variables using [these instructions](/docs/heroku#sending-emails-with-postmark).
+
+#### AWS
+
+```
+AWS_ACCESS_KEY_ID=access_key_id_from_aws
+AWS_SECRET_ACCESS_KEY=secret_access_key_from_aws
+AWS_REGION=bucket_region_name
+AWS_BUCKET=bucket_name_from_aws
+```
+
+#### Google Recaptcha
+
+```
+RECAPTCHA_V3_SITE_KEY
+RECAPTCHA_V3_SECRET_KEY
+RECAPTCHA_V2_SITE_KEY
+RECAPTCHA_V2_SECRET_KEY
+```
+
+Generate these variables using [these instructions](/docs/heroku#sending-emails-with-postmark).
+
+#### Webpush Notifications
+
+```
+VAPID_PUBLIC_KEY
+VAPID_PRIVATE_KEY
+```
+
+Generate these variables using [these instructions](/docs/heroku#webpush-notifications).
+
+### Optional
+
+#### Cloudfront
+
+```
+CLOUDFRONT_PRIVATE_KEY_BASE_64_ENCODED=cloudfront_private_key_from_aws
+CLOUDFRONT_HOST=cloudfront_host_from_aws
+CLOUDFRONT_KEY_PAIR_ID=cloudfront_key_pair_id_from_aws
+CLOUDFRONT_EXPIRY=expiry_in_seconds
+```
+
+Generate these variables using [these instructions](/docs/heroku#content-delivery-network).
+
+#### Sign in with OAuth
+
+```
+GOOGLE_OAUTH2_CLIENT_ID
+GOOGLE_OAUTH2_CLIENT_SECRET
+FACEBOOK_KEY
+FACEBOOK_SECRET
+GITHUB_KEY
+GITHUB_SECRET
+```
+
+Generate these variables using [these instructions](/docs/heroku#signing-in-with-oauth).
+
+#### Rollbar
+
+```
+ROLLBAR_CLIENT_TOKEN
+ROLLBAR_SERVER_TOKEN
+```

--- a/docs/developers/docs/using_docker.md
+++ b/docs/developers/docs/using_docker.md
@@ -20,9 +20,9 @@ There are several environment variables you'll need to set up to get the applica
 #### Basic configuration
 
 ```
-ASSET_HOST=https://assets.mydomain.com
+ASSET_HOST=https://fully-qualified.domain-name.com
 DATABASE_URL=postgresql://username:password@host:port/database?sslmode=require
-DEFAULT_SENDER_EMAIL_ADDRESS=noreply@mydomain.com
+DEFAULT_SENDER_EMAIL_ADDRESS=noreply@domain-name.com
 GRAPH_API_RATE_LIMIT=10
 I18N_AVAILABLE_LOCALES=en,ru
 I18N_DEFAULT_LOCALE=en
@@ -50,6 +50,8 @@ AWS_SECRET_ACCESS_KEY=secret_access_key_from_aws
 AWS_REGION=bucket_region_name
 AWS_BUCKET=bucket_name_from_aws
 ```
+
+Generate these variables using [these instructions](/docs/heroku#file-storage-using-aws).
 
 #### Google Recaptcha
 

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -1780,6 +1780,20 @@
               "deprecationReason": null
             },
             {
+              "name": "lastSeenAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [
@@ -12368,6 +12382,20 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastSeenAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -74,6 +74,11 @@ feature 'Course students list', js: true do
       expect(page).to have_text('Last seen 3 days ago')
     end
 
+    # Check the last seen for the second student
+    within("div[aria-label='Info of team #{team_2.name}']") do
+      expect(page).to have_text('Last seen long time ago')
+    end
+
     # Check levels of few teams
     within("div[aria-label='team level info: #{team_1.id}']") do
       expect(page).to have_text('1')

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -31,7 +31,7 @@ feature 'Course students list', js: true do
 
   before do
     create :faculty_course_enrollment, faculty: course_coach, course: course
-    team_2.founders.first.user.update!(last_seen_at: 3.minutes.ago)
+    team_1.founders.first.user.update!(last_seen_at: 3.minutes.ago)
 
     10.times do
       create :startup,

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -31,8 +31,8 @@ feature 'Course students list', js: true do
 
   before do
     create :faculty_course_enrollment, faculty: course_coach, course: course
-    team_1.founders.first.user.update!(last_seen_at: 3.minutes.ago)
-    team_2.founders.first.user.update!(current_sign_in_at: 3.days.ago)
+    team_2.founders.first.user.update!(last_seen_at: 3.minutes.ago)
+    team_1.founders.first.user.update!(current_sign_in_at: 3.days.ago)
 
     10.times do
       create :startup,
@@ -73,13 +73,6 @@ feature 'Course students list', js: true do
     # Check the last seen for the first student
     within("div[aria-label='Info of team #{team_1.name}']") do
       expect(page).to have_text('Last seen 3 minutes ago')
-    end
-
-    # Check the last seen is not updated before 15 minutes
-    travel_to(10.minutes.from_now) do
-      within("div[aria-label='Info of team #{team_1.name}']") do
-        expect(page).to have_text('Last seen 13 minutes ago')
-      end
     end
 
     # Check the last seen as current sign in value
@@ -134,6 +127,15 @@ feature 'Course students list', js: true do
     expect(page).to have_text("Percentage: #{percentage_students_in_l2}")
     expect(page).to have_text('Teams: 2')
     expect(page).to have_text("Students: #{students_in_l2}")
+  end
+
+  scenario 'coach list students after 10 minutes' do
+    travel_to(10.minutes.from_now) do
+      sign_in_user course_coach.user, referrer: students_course_path(course)
+      expect(page).to have_text('Last seen 13 minutes ago')
+      # within("div[aria-label='Info of team #{team_1.name}']") do
+      # end
+    end
   end
 
   scenario 'coach searches for and filters students by level' do

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -27,11 +27,10 @@ feature 'Course students list', js: true do
   let!(:team_4) { create :startup, level: level_3, name: 'Blueberry' }
   let!(:team_5) { create :startup, level: level_3, name: 'Cherry' }
   let!(:team_6) { create :startup, level: level_3, name: 'Elderberry' }
-  let(:first_student) { team_1.founders.first.user }
 
   before do
     create :faculty_course_enrollment, faculty: course_coach, course: course
-    first_student.update!(last_seen_at: 3.days.ago)
+    team_1.founders.first.user.update!(last_seen_at: 3.minutes.ago)
 
     10.times do
       create :startup,
@@ -71,7 +70,7 @@ feature 'Course students list', js: true do
 
     # Check the last seen for the first student
     within("div[aria-label='Info of team #{team_1.name}']") do
-      expect(page).to have_text('Last seen 3 days ago')
+      expect(page).to have_text('Last seen 3 minutes ago')
     end
 
     # Check the last seen for the second student

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -32,7 +32,6 @@ feature 'Course students list', js: true do
   before do
     create :faculty_course_enrollment, faculty: course_coach, course: course
     team_2.founders.first.user.update!(last_seen_at: 3.minutes.ago)
-    team_1.founders.first.user.update!(current_sign_in_at: 3.days.ago)
 
     10.times do
       create :startup,
@@ -73,11 +72,6 @@ feature 'Course students list', js: true do
     # Check the last seen for the first student
     within("div[aria-label='Info of team #{team_1.name}']") do
       expect(page).to have_text('Last seen 3 minutes ago')
-    end
-
-    # Check the last seen as current sign in value
-    within("div[aria-label='Info of team #{team_2.name}']") do
-      expect(page).to have_text('Last seen 3 days ago')
     end
 
     # Check the last seen for the second student
@@ -127,15 +121,6 @@ feature 'Course students list', js: true do
     expect(page).to have_text("Percentage: #{percentage_students_in_l2}")
     expect(page).to have_text('Teams: 2')
     expect(page).to have_text("Students: #{students_in_l2}")
-  end
-
-  scenario 'coach list students after 10 minutes' do
-    travel_to(10.minutes.from_now) do
-      sign_in_user course_coach.user, referrer: students_course_path(course)
-      expect(page).to have_text('Last seen 13 minutes ago')
-      # within("div[aria-label='Info of team #{team_1.name}']") do
-      # end
-    end
   end
 
   scenario 'coach searches for and filters students by level' do

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 feature 'Course students list', js: true do
   include UserSpecHelper
   include MarkdownEditorHelper
-  include ActiveSupport::Testing::TimeHelpers
 
   # The basics
   let!(:school) { create :school, :current }

--- a/spec/system/courses/students_spec.rb
+++ b/spec/system/courses/students_spec.rb
@@ -27,11 +27,11 @@ feature 'Course students list', js: true do
   let!(:team_4) { create :startup, level: level_3, name: 'Blueberry' }
   let!(:team_5) { create :startup, level: level_3, name: 'Cherry' }
   let!(:team_6) { create :startup, level: level_3, name: 'Elderberry' }
-  let(:first_student) { Founder.where(startup: team_1).first.user }
+  let(:first_student) { team_1.founders.first.user }
 
   before do
     create :faculty_course_enrollment, faculty: course_coach, course: course
-    first_student.update!(last_seen_at: Date.today - 3)
+    first_student.update!(last_seen_at: 3.days.ago)
 
     10.times do
       create :startup,
@@ -70,8 +70,9 @@ feature 'Course students list', js: true do
     end
 
     # Check the last seen for the first student
-    expect(page).to have_text(first_student.name)
-    expect(page).to have_text('Last seen: 3 days ago')
+    within("div[aria-label='Info of team #{team_1.name}']") do
+      expect(page).to have_text('Last seen: 3 days ago')
+    end
 
     # Check levels of few teams
     within("div[aria-label='team level info: #{team_1.id}']") do


### PR DESCRIPTION
## Proposed Changes

- Add `last_seen_at` property to users table.
- Show the last seen status for the students
![image](https://user-images.githubusercontent.com/42417893/165602486-c1f66a20-cff0-4703-9a4a-ee434d3921e5.png)
The last seen status will be updated every 15 mins for the authenticated user.

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
