### PR TITLE
Reduce animation speed to zero in test env

### DIFF
--- a/app/views/layouts/tailwind.html.erb
+++ b/app/views/layouts/tailwind.html.erb
@@ -41,6 +41,14 @@
     <%= stylesheet_pack_tag 'layouts/tailwind', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'IconFirstPack', media: 'all' %>
 
+    <% if Rails.env.test? %>
+      <style>
+        * {
+          animation-duration: 0s !important;
+        }
+      </style>
+    <% end %>
+
     <!-- Scripts -->
     <%= javascript_pack_tag 'layouts/tailwind', nonce: true %>
 


### PR DESCRIPTION
@pupilfirst/designers This should help avoid [failures in the test env](https://github.com/pupilfirst/pupilfirst/runs/6467133653?check_suite_focus=true) that seem to be caused by the test browser's inability to accurately click elements that might be in motion.