### PR TITLE
Add User ID to student data exports

### DIFF
--- a/app/services/course_exports/prepare_students_export_service.rb
+++ b/app/services/course_exports/prepare_students_export_service.rb
@@ -148,6 +148,7 @@ module CourseExports
           user = student.user
 
           [
+            user.id,
             { formula: student_report_link(student) },
             user.email,
             user.name,
@@ -161,7 +162,8 @@ module CourseExports
 
       [
         [
-          'ID',
+          'User ID',
+          'Student ID',
           'Email Address',
           'Name',
           'Level',

--- a/spec/services/course_exports/prepare_students_export_service_spec.rb
+++ b/spec/services/course_exports/prepare_students_export_service_spec.rb
@@ -196,7 +196,8 @@ describe CourseExports::PrepareStudentsExportService do
         title: 'Students',
         rows: [
           [
-            'ID',
+            'User ID',
+            'Student ID',
             'Email Address',
             'Name',
             'Level',
@@ -208,6 +209,7 @@ describe CourseExports::PrepareStudentsExportService do
             'Criterion B (2,3) - Average'
           ],
           [
+            student_1.user_id,
             report_link_formula(student_1),
             student_1.email,
             student_1.name,
@@ -230,6 +232,7 @@ describe CourseExports::PrepareStudentsExportService do
               .to_s
           ],
           [
+            student_2.user_id,
             report_link_formula(student_2),
             student_2.email,
             student_2.name,
@@ -362,7 +365,8 @@ describe CourseExports::PrepareStudentsExportService do
             title: 'Students',
             rows: [
               [
-                'ID',
+                'User ID',
+                'Student ID',
                 'Email Address',
                 'Name',
                 'Level',
@@ -374,6 +378,7 @@ describe CourseExports::PrepareStudentsExportService do
                 'Criterion B (2,3) - Average'
               ],
               [
+                student_1.user_id,
                 report_link_formula(student_1),
                 student_1.email,
                 student_1.name,
@@ -396,6 +401,7 @@ describe CourseExports::PrepareStudentsExportService do
                   .to_s
               ],
               [
+                student_3_access_ended.user_id,
                 report_link_formula(student_3_access_ended),
                 student_3_access_ended.email,
                 student_3_access_ended.name,
@@ -408,6 +414,7 @@ describe CourseExports::PrepareStudentsExportService do
                 nil
               ],
               [
+                student_4_dropped_out.user_id,
                 report_link_formula(student_4_dropped_out),
                 student_4_dropped_out.email,
                 student_4_dropped_out.name,


### PR DESCRIPTION
The student data export spreadsheet's _Students_ page, now starts with a `User ID` column. This also renames the existing `ID` column to `Student ID`.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~