### PR TITLE
Fix hyperlink bug & typo in daily digest email

### DIFF
--- a/app/views/user_mailer/daily_digest.html.erb
+++ b/app/views/user_mailer/daily_digest.html.erb
@@ -13,7 +13,7 @@
   <% if @updates[:coach].present? %>
     <% pending_submissions_count = @updates[:coach].map { |s| s[:pending_submissions] }.sum %>
     <p style="margin-top: 10px;">
-      <%= t("mailers.user.daily_digest.body.main_html", article_pending_submissions_count: article(pending_submissions_count), pending_submissions_count: pending_submissions_count, courses_number: @updates[:coach].length.to_s) %>
+      <%= t("mailers.user.daily_digest.body.main_html", article_pending_submissions_count: article(pending_submissions_count), pending_submissions_count: pending_submissions_count) %>
     </p>
 
     <ul style="padding: 0; margin-top: 0; margin-left: 30px; list-style-type: circle;">

--- a/app/views/user_mailer/daily_digest.html.erb
+++ b/app/views/user_mailer/daily_digest.html.erb
@@ -1,11 +1,9 @@
-<%
-  school_name = @user.school.name
+<% school_name = @user.school.name
   recipient_name = @user.name
 
   def article(count)
     count > 1 ? t("shared.are") : t("shared.is")
-  end
-%>
+  end %>
 
 <% content_for :salutation do %>
   <%= t("shared.salutation_name", name: recipient_name) %>
@@ -21,7 +19,7 @@
     <ul style="padding: 0; margin-top: 0; margin-left: 30px; list-style-type: circle;">
       <% @updates[:coach].each do |stats| %>
         <li style="padding: 2px 0px;">
-          <%= link_to "#{stats[:course_name]}:", review_course_url(stats[:course_id]), style: 'color: #6025C0; border-radius: 8px; padding: 0px;' %>
+          <%= link_to "#{stats[:course_name]}:", review_course_url(stats[:course_id]), style: "color: #6025C0; border-radius: 8px; padding: 0px;" %>
           <span><strong><%= stats[:pending_submissions] %></strong>
             <% if stats[:is_team_coach] %>
               <%= stats[:pending_submissions_for_coach] == 0 ? t("mailers.user.daily_digest.body.assigned_none") : t("mailers.user.daily_digest.body.assigned", stats: stats[:pending_submissions_for_coach]) %>
@@ -74,7 +72,7 @@
   <% end %>
 
   <p style="font-size: 75%; margin-top: 15px;">
-    <%= t("mailers.user.daily_digest.body.control_emails", link_to: link_to(t("mailers.user.daily_digest.body.link_to"), edit_user_url)) %>
+    <%= t("mailers.user.daily_digest.body.control_emails_html", link_to: link_to(t("mailers.user.daily_digest.body.link_to"), edit_user_url)) %>
   </p>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1843,7 +1843,7 @@ en:
           asked: asked %{days_ago} days ago.
           assigned: (%{stats} assigned to you)
           assigned_none: (none of which are assigned to you)
-          control_emails: You can control these emails from %{link_to}.
+          control_emails_html: You can control these emails from %{link_to}.
           latest_topics: "Latest topics posted on your communities:"
           link_to: your profile edit page
           main_html: "There %{article_pending_submissions_count} <strong>%{pending_submissions_count}</strong> new submissions to review in %{courses_number} courses that you are a coach in:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1846,7 +1846,7 @@ en:
           control_emails_html: You can control these emails from %{link_to}.
           latest_topics: "Latest topics posted on your communities:"
           link_to: your profile edit page
-          main_html: "There %{article_pending_submissions_count} <strong>%{pending_submissions_count}</strong> new submissions to review in %{courses_number} courses that you are a coach in:"
+          main_html: "There %{article_pending_submissions_count} <strong>%{pending_submissions_count}</strong> new submissions to review in some courses that you are a coach in:"
           older: "Older, popular topics that have seen new activity:"
           replies: replies
           views: views

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2157,7 +2157,7 @@ ru:
           asked: спросил %{days_ago} дней назад.
           assigned: (%{stats} назначено вам)
           assigned_none: (из которых ни один не назначен вам)
-          control_emails: Вы можете управлять этими электронными письмами с %{link_to}.
+          control_emails_html: Вы можете управлять этими электронными письмами с %{link_to}.
           latest_topics: "Последние темы, опубликованные в ваших сообществах:"
           link_to: страница редактирования вашего профиля
           main_html: "Есть %{article_pending_submissions_count} <strong>%{pending_submissions_count}</strong> новых материалов для рассмотрения в %{courses_number} курсах, в которых вы являетесь ментором:"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2160,7 +2160,7 @@ ru:
           control_emails_html: Вы можете управлять этими электронными письмами с %{link_to}.
           latest_topics: "Последние темы, опубликованные в ваших сообществах:"
           link_to: страница редактирования вашего профиля
-          main_html: "Есть %{article_pending_submissions_count} <strong>%{pending_submissions_count}</strong> новых материалов для рассмотрения в %{courses_number} курсах, в которых вы являетесь ментором:"
+          main_html: "Есть %{article_pending_submissions_count} <strong>%{pending_submissions_count}</strong> новых материалов для рассмотрения на некоторых курсах, в которых вы являетесь тренером."
           older: "Старые, популярные темы, в которых появились новые действия:"
           replies: ответов
           views: просмотров

--- a/spec/services/daily_digest_service_spec.rb
+++ b/spec/services/daily_digest_service_spec.rb
@@ -231,7 +231,7 @@ describe DailyDigestService do
         expect(b).to include(course_2.name)
         expect(b).to include("There are 3")
         expect(b).to include("new submissions to review")
-        expect(b).to include("in 2 courses")
+        expect(b).to include("in some courses")
 
         # The email should include community updates, but only
         # from the courses where the coach is enrolled.


### PR DESCRIPTION
## Proposed Changes

- [x] Fix hyperlink error in a daily digest
- [x] Fix type (`1 courses` to `some courses`)

@pupilfirst/developers


## Preview 

![image](https://user-images.githubusercontent.com/76519654/179003822-82433296-7fe0-4611-b9b0-9d6272a452f2.png)
![image](https://user-images.githubusercontent.com/76519654/179003919-082def9a-446f-4c15-a24c-04d9c5577eb3.png)
