### PR TITLE
Restore styling for error pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 env:
   PF_IMAGE_NAME: pupilfirst
   PF_VERSION: "2022.2"
+  YARN_CHECKSUM_BEHAVIOR: ignore
 jobs:
   tests:
     runs-on: ubuntu-18.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ COPY .yarnrc.docker.yml .yarnrc.yml
 COPY .yarn/releases .yarn/releases
 RUN corepack enable
 
-# Remove checksums on problematic JS packages.
-RUN sed '/83bc7758ab676cbb6cf1d12e23cb8125cb0c5c07c62d4e6fcaf6f9194cfafca675c4309e66a39594c60e176d3114bd45b09c9218721d42650554d17c84579d33/d' yarn.lock > yarn.lock
-
 RUN yarn install
 
 # Copy over remaining files and set up for precompilation.
@@ -46,10 +43,7 @@ RUN bundle exec i18n export
 # Compile ReScript files to JS.
 RUN yarn run re:build
 
-# Remove checksums (again) on problematic JS packages because...
-RUN sed '/83bc7758ab676cbb6cf1d12e23cb8125cb0c5c07c62d4e6fcaf6f9194cfafca675c4309e66a39594c60e176d3114bd45b09c9218721d42650554d17c84579d33/d' yarn.lock > yarn.lock
-
-# ...the assets:precompile step will run `yarn install` again.
+# Run Rails' asset  precompilation step.
 RUN bundle exec rails assets:precompile
 
 # With precompilation done, we can move onto the final stage.

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -16,7 +16,13 @@ class ErrorsController < ApplicationController
 
   # GET /errors/:error_type
   def simulate
-    valid_types = %w[internal_server_error not_acceptable not_found unprocessable_entity]
+    valid_types = %w[
+      internal_server_error
+      not_acceptable
+      not_found
+      unprocessable_entity
+      service_unavailable
+    ]
 
     if params[:error_type].in?(valid_types)
       render "errors/#{params[:error_type]}"

--- a/app/frontend/entrypoints/error.js
+++ b/app/frontend/entrypoints/error.js
@@ -1,0 +1,1 @@
+import "./tailwind";

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -4,7 +4,6 @@
   </picture>
   <div class="max-w-3xl mx-auto text-center px-4 pb-4">
     <h1><%= t(".went_wrong") %></h1>
-
     <p class="my-3 text-sm leading-normal">
       <%= t(".details") %>
     </p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -7,7 +7,6 @@
     <p class="mt-3 text-sm leading-normal">
       <%= t(".mistyped_moved") %>
     </p>
-
     <p class="mt-1 mb-3 text-sm leading-normal">
       <%= t(".try_homepage") %>
     </p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -4,7 +4,6 @@
   </picture>
   <div class="max-w-3xl mx-auto text-center px-4 pb-4">
     <h1><%= t(".invalid_request") %></h1>
-
     <p class="my-3 text-sm leading-normal">
       <%= t(".wasnt_valid") %>
     </p>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,6 +1,6 @@
 <% presenter = ErrorPresenter.new(self) %>
 <% content_for(:head) do %>
-  <title>Pupilfirst | <%= t("errors.#{params[:error_type]}.title") %></title>
+  <title>Pupilfirst | <%= t("errors.#{params[:error_type]}.title", default: 'Error') %></title>
   <%= vite_javascript_tag 'error', nonce: true %>
 <% end %>
 <% content_for(:wrapper) do %>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,15 +1,16 @@
 <% presenter = ErrorPresenter.new(self) %>
-
+<% content_for(:head) do %>
+  <title>Pupilfirst | <%= t("errors.#{params[:error_type]}.title") %></title>
+  <%= vite_javascript_tag 'error', nonce: true %>
+<% end %>
 <% content_for(:wrapper) do %>
   <%= yield %>
-
   <footer>
     <% if presenter.contact_email.present? %>
       <div class="container mx-auto px-4 text-center">
         <%= mail_to presenter.contact_email, t("views.footer.support"), class:'text-primary-500 hover:text-primary-600' %>
       </div>
     <% end %>
-
     <div class="container mx-auto p-4 text-center flex justify-center">
       <%= link_to ('/'), class:'text-primary-500 font-semibold text-xl' do %>
         <% if presenter.school_has_icon? %>
@@ -21,5 +22,4 @@
     </div>
   </footer>
 <% end %>
-
 <%= render template: 'layouts/tailwind' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1242,9 +1242,9 @@ en:
       update_images: Update Images
       updated_notification: Images have been updated successfully.
     SchoolCustomize__LinkComponent:
+      cancel_editing: Cancel Editing
       move_down: Move Down
       move_up: Move Up
-      cancel_editing: Cancel Editing
     SchoolCustomize__LinkEditor:
       add_new_link: Add a New Link
       adding_new_link: Adding new link...
@@ -1293,9 +1293,9 @@ en:
       featured_courses: Featured Courses
       hello_welcome: Hello, welcome to
       homepage: Home Page
-      reach_us_at: React us at
       icon: Icon
       privacy_policy: Privacy Policy
+      reach_us_at: React us at
       sitemap: Sitemap
       social: Social
       social_links_q: Add social media links?
@@ -1527,13 +1527,13 @@ en:
       mark_solution: Mark as solution
       mark_solution_confirm: Are you sure you want to mark this post as solution?
       marked_solution_icon: Marked as solution icon
-      show_replies_button:
-        one: 1 Reply
-        other: "%{count} Replies"
       new_reply_button: Reply
       options_post: Options for post
       replies_post: Replies to post
       show_replies: Show replies of post
+      show_replies_button:
+        one: 1 Reply
+        other: "%{count} Replies"
       solution: Solution
       solution_icon_label: Solution
       unmark_solution: Unmark as solution
@@ -1694,6 +1694,7 @@ en:
   errors:
     internal_server_error:
       details: Our server seem to have hit a snag while trying to process your request. We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try reloading the page.
+      title: Server Error
       went_wrong: We're sorry, but something went wrong.
     messages:
       content_type_invalid: has an invalid content type
@@ -1701,15 +1702,19 @@ en:
     not_acceptable:
       details: It looks like your browser requested a response in a format that our server cannot fulfil. We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try reloading the page.
       invalid_format: Your browser requested an invalid format.
+      title: Invalid Request
     not_found:
       mistyped_moved: You may have mistyped the address, or the page may have moved.
       not_exist: The page you were looking for doesn't exist!
+      title: Not Found
       try_homepage: Try heading back to our homepage?
     service_unavailable:
+      title: Timed out
       too_long: This page took too long to load.
       try_reloading: Could you please try reloading this page?
     unprocessable_entity:
       invalid_request: Your browser made an invalid request.
+      title: Invalid Request
       wasnt_valid: <em>Something</em> about the request that your browser sent wasn't valid. We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try reloading the page.
   faculty:
     index:
@@ -1935,8 +1940,8 @@ en:
     create_quiz_submission:
       responses_saved_notification: Your responses have been saved.
     create_school_link:
-      success_notification: A custom link has been added.
       blank_title_error: A title is required
+      success_notification: A custom link has been added.
     create_student_from_applicant:
       success_notification: Student created successfully.
     create_submission:
@@ -2007,9 +2012,6 @@ en:
       success_notification: Certificate details have been updated.
     update_course:
       success_notification: Course updated successfully!
-    update_school_link:
-      success_notification: Link updated successfully!
-      link_not_found_error: Unable to find link!
     update_course_author:
       author_name_updated_notification: The author's name has been updated.
       author_updated_notification: Author Updated
@@ -2021,6 +2023,9 @@ en:
       review_updated_notification: Review checklist updated successfully
     update_school:
       details_updated_notification: Details updated successfully!
+    update_school_link:
+      link_not_found_error: Unable to find link!
+      success_notification: Link updated successfully!
     update_target:
       checklist_items_exceeded_error: Checklist should have less than 15 items
       evaluation_criteria_course_error: Evaluation criteria must be from the same course as the target


### PR DESCRIPTION
## Proposed Changes

This restores styling for error pages, lost during the transition to Vite.

## Merge Checklist

- ~~Add specs that demonstrate bug / test a new feature.~~
- ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
