### PR TITLE
Add Markdown support for target checklist

### DIFF
--- a/app/frontend/courses/curricula/components/CoursesCurriculum__SubmissionItem.res
+++ b/app/frontend/courses/curricula/components/CoursesCurriculum__SubmissionItem.res
@@ -32,7 +32,7 @@ let placeholder = (id, checklistItem) => {
     </div>
     <label htmlFor=id className="font-semibold text-sm pl-2 tracking-wide">
       <MarkdownBlock
-        profile=Markdown.AreaOfText
+        profile=Markdown.Permissive
         markdown={title ++ (optional ? " (" ++ ts("optional") ++ ")" : "")}
       />
     </label>

--- a/app/frontend/schools/courses/components/curriculum_editor/CurriculumEditor__TargetChecklistItemEditor.res
+++ b/app/frontend/schools/courses/components/curriculum_editor/CurriculumEditor__TargetChecklistItemEditor.res
@@ -5,8 +5,7 @@ let str = React.string
 let t = I18n.t(~scope="components.CurriculumEditor__TargetChecklistItemEditor")
 let ts = I18n.ts
 
-let updateTitle = (checklistItem, updateChecklistItemCB, event) => {
-  let title = ReactEvent.Form.target(event)["value"]
+let updateTitle = (checklistItem, updateChecklistItemCB, title) => {
   let newChecklistItem = checklistItem |> ChecklistItem.updateTitle(title)
   updateChecklistItemCB(newChecklistItem)
 }
@@ -214,16 +213,14 @@ let make = (
         </div>
       </div>
       <div
-        className="flex items-center text-sm bg-white border border-gray-300 rounded py-2 px-3 mt-2 focus:outline-none focus:bg-white focus:border-primary-300">
-        <textarea
-          maxLength=500
-          rows=2
-          name={"checklist-item-" ++ ((index + 1 |> string_of_int) ++ "-title")}
-          placeholder={t("describe_step")}
-          className="flex-grow appearance-none bg-transparent border-none leading-relaxed focus:outline-none resize-y rounded-md"
-          onChange={updateTitle(checklistItem, updateChecklistItemCB)}
-          value={checklistItem |> ChecklistItem.title}
-        />
+        className="py-2 mt-2 ">
+      <MarkdownEditor
+        textareaId={"checklist-item-" ++ ((index + 1 |> string_of_int) ++ "-title")}
+        placeholder={t("describe_step")}
+        value={checklistItem -> ChecklistItem.title}
+        onChange={updateTitle(checklistItem, updateChecklistItemCB)}
+        profile=Markdown.Permissive
+      />
       </div>
       <div>
         <School__InputGroupError


### PR DESCRIPTION
## Proposed Changes
- [X] Added markdown editor in target checklist 
- [x] Updated the preview to use `Markdown.Permissive` profile for rendering
- [ ] Update spec 

### Editor 
![image](https://user-images.githubusercontent.com/14979190/183398711-7d510a83-7ef6-496b-aad0-e41d04be6c17.png)

### Preview 
![image](https://user-images.githubusercontent.com/14979190/183398613-3f68d782-6c2e-4cc9-9000-1847b5882ce5.png)

@pupilfirst/developers
