### PR TITLE
Preserve filters in students index

### DIFF
--- a/app/frontend/courses/students/components/CoursesStudents__StudentOverlay.res
+++ b/app/frontend/courses/students/components/CoursesStudents__StudentOverlay.res
@@ -24,7 +24,10 @@ let initialState = {
   submissions: Unloaded,
 }
 
-let closeOverlay = courseId => RescriptReactRouter.push("/courses/" ++ (courseId ++ "/students"))
+let closeOverlay = courseId => {
+  let search = Webapi.Dom.window->Webapi.Dom.Window.location->Webapi.Dom.Location.search
+  RescriptReactRouter.push("/courses/" ++ (courseId ++ "/students") ++ search)
+}
 
 module UserDetailsFragment = UserDetails.Fragment
 module LevelFragment = Shared__Level.Fragment

--- a/app/frontend/courses/students/components/CoursesStudents__StudentsList.res
+++ b/app/frontend/courses/students/components/CoursesStudents__StudentsList.res
@@ -53,6 +53,7 @@ let showStudent = student => {
     href={"/students/" ++ (student->StudentInfo.id ++ "/report")}
     key={student->StudentInfo.id}
     ariaLabel={"Student " ++ student->StudentInfo.user->UserDetails.name}
+    includeSearch={true}
     className="flex md:flex-row justify-between bg-white mt-4 rounded-lg shadow cursor-pointer hover:border-primary-500 hover:text-primary-500 hover:shadow-md focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-focusColor-500">
     <div className="flex flex-col justify-center md:flex-row ">
       <div className="flex w-full items-start md:items-center p-3 md:px-4 md:py-5">
@@ -93,7 +94,7 @@ let showStudent = student => {
       className="flex items-center gap-6 justify-end md:justify-between p-3 md:p-4">
       <CoursesStudents__PersonalCoaches
         title={<div className="mb-1 font-semibold text-gray-800 text-tiny uppercase">
-          {t("personal_coaches") -> str}
+          {t("personal_coaches")->str}
         </div>}
         className="hidden md:inline-block"
         coaches={StudentInfo.personalCoaches(student)}
@@ -106,10 +107,10 @@ let showStudent = student => {
 @react.component
 let make = (~students) =>
   <div>
-    {  ArrayUtils.isEmpty(students)
+    {ArrayUtils.isEmpty(students)
       ? <div className="course-review__reviewed-empty text-lg font-semibold text-center py-4">
           <h4 className="py-4 mt-4 bg-gray-200 text-gray-800 font-semibold">
-            {t("no_students") -> str}
+            {t("no_students")->str}
           </h4>
         </div>
       : students->Js.Array2.map(showStudent)->React.array}

--- a/app/frontend/shared/components/Link.res
+++ b/app/frontend/shared/components/Link.res
@@ -27,6 +27,12 @@ let handleOnClick = (href, confirm, onClick, event) => {
   }
 }
 
+let link = (href, includeReferrer) => {
+  let ref = Webapi.Dom.window->Webapi.Dom.Window.location->Webapi.Dom.Location.search
+
+  includeReferrer ? `${href}${ref}` : href
+}
+
 @react.component
 let make = (
   ~href,
@@ -37,18 +43,19 @@ let make = (
   ~onClick=?,
   ~title=?,
   ~children,
+  ~includeSearch=false,
   ~disabled=false,
   ~props=?,
 ) => {
   let switchProps = Belt.Option.getWithDefault(props, Js.Obj.empty())
   <Spread props={switchProps}>
     <a
-      href
+      href={link(href, includeSearch)}
       ?ariaLabel
       ?className
       ?id
       ?title
-      onClick={handleOnClick(href, confirm, onClick)}
+      onClick={handleOnClick(link(href, includeSearch), confirm, onClick)}
       disabled>
       children
     </a>

--- a/app/frontend/shared/components/Link.res
+++ b/app/frontend/shared/components/Link.res
@@ -27,10 +27,9 @@ let handleOnClick = (href, confirm, onClick, event) => {
   }
 }
 
-let link = (href, includeReferrer) => {
-  let ref = Webapi.Dom.window->Webapi.Dom.Window.location->Webapi.Dom.Location.search
-
-  includeReferrer ? `${href}${ref}` : href
+let link = (href, includeSearch) => {
+  let search = Webapi.Dom.window->Webapi.Dom.Window.location->Webapi.Dom.Location.search
+  includeSearch ? `${href}${search}` : href
 }
 
 @react.component


### PR DESCRIPTION
A minor fix that will preserve the filters selected on the student's page while navigating to the inner pages. 