### PR TITLE
Implement click-to-copy IDs in the student report page

### DIFF
--- a/app/frontend/courses/students/components/CoursesStudents__StudentOverlay.res
+++ b/app/frontend/courses/students/components/CoursesStudents__StudentOverlay.res
@@ -494,6 +494,26 @@ let onAddCoachNotesCB = (studentId, setState, _) => {
   getStudentDetails(studentId, setState)
 }
 
+let ids = student => {
+  <div className="text-center mt-1">
+    <ClickToCopy
+      copy={StudentInfo.user(student)->UserDetails.id}
+      className="inline-block hover:text-primary-500">
+      <span className="text-xs"> {"User ID "->str} </span>
+      <span className="font-semibold text-sm underline text-primary-500">
+        {`#${StudentInfo.user(student)->UserDetails.id}`->str}
+      </span>
+    </ClickToCopy>
+    <ClickToCopy
+      copy={StudentInfo.id(student)} className="ml-2 inline-block hover:text-primary-500">
+      <span className="text-xs"> {"Student ID "->str} </span>
+      <span className="font-semibold text-sm underline text-primary-500">
+        {`#${StudentInfo.id(student)}`->str}
+      </span>
+    </ClickToCopy>
+  </div>
+}
+
 @react.component
 let make = (~studentId, ~userId) => {
   let (state, setState) = React.useState(() => initialState)
@@ -540,6 +560,7 @@ let make = (~studentId, ~userId) => {
               <p className="text-sm font-semibold text-center mt-1">
                 {student->StudentInfo.user->UserDetails.fullTitle |> str}
               </p>
+              {ids(student)}
               {inactiveWarning(student)}
             </div>
             {levelProgressBar(

--- a/app/frontend/shared/components/ClickToCopy.res
+++ b/app/frontend/shared/components/ClickToCopy.res
@@ -1,0 +1,28 @@
+let str = React.string
+
+type state = ReadyToCopy | Copied
+
+let performCopy = (_copy, setState, _event) => {
+  // Do more things.
+  %raw(`navigator.clipboard.writeText(_copy)`)->ignore
+  setState(_ => Copied)
+}
+
+let refresh = (setState, _event) => setState(_ => ReadyToCopy)
+
+@react.component
+let make = (~copy, ~tooltipPosition=#Top, ~className="", ~tooltipClassName=?, ~children) => {
+  let (state, setState) = React.useState(() => ReadyToCopy)
+
+  let tip = switch state {
+  | ReadyToCopy => "Copy to clipboard"
+  | Copied => "Copied!"
+  }->str
+
+  <div
+    className={"cursor-pointer " ++ className}
+    onClick={performCopy(copy, setState)}
+    onMouseLeave={refresh(setState)}>
+    <Tooltip className=?tooltipClassName position=tooltipPosition tip> {children} </Tooltip>
+  </div>
+}


### PR DESCRIPTION
This is a mitigation for #1144.