### PR TITLE
Move 'Next Question' button to the bottom of quiz question block

### DIFF
--- a/app/frontend/courses/curricula/components/CoursesCurriculum__Quiz.res
+++ b/app/frontend/courses/curricula/components/CoursesCurriculum__Quiz.res
@@ -115,7 +115,7 @@ let make = (~target, ~targetDetails, ~addSubmissionCB, ~preview) => {
     | None => React.null
     | Some(answer) =>
       <div
-        className="quiz-root__answer-submit-section text-center py-4 border-t border-gray-300 fixed z-10 left-0 right-0 bottom-0 w-full">
+        className="quiz-root__answer-submit-section flex justify-center rounded-b-lg text-center p-4 border-t border-gray-200 w-full">
         {currentQuestion |> QuizQuestion.isLastQuestion(quizQuestions)
           ? <button
               disabled={saving || preview}

--- a/app/frontend/courses/review/components/SubmissionChecklistItemShow.res
+++ b/app/frontend/courses/review/components/SubmissionChecklistItemShow.res
@@ -114,9 +114,6 @@ let statusButton = (index, status, callback, checklist) =>
     </button>
   </div>
 
-let cardHeaderClasses = pending =>
-  "text-sm font-medium flex items-center justify-between " ++ (pending ? "" : "bg-white rounded")
-
 let cardBodyClasses = pending => "pl-7 md:pl-8 " ++ (pending ? "" : "rounded-b")
 
 @react.component
@@ -124,8 +121,8 @@ let make = (~index, ~checklistItem, ~updateChecklistCB, ~checklist, ~pending) =>
   let status = ChecklistItem.status(checklistItem)
 
   <div ariaLabel={ChecklistItem.title(checklistItem)}>
-    <div className={cardHeaderClasses(pending)}>
-      <div className="flex flex-1 items-start justify-between">
+    <div className="text-sm font-medium flex items-center justify-between ">
+      <div className="flex flex-1 items-start space-x-2">
         <div className="flex items-start">
           <PfIcon className={kindIconClasses(ChecklistItem.result(checklistItem))} />
           <MarkdownBlock


### PR DESCRIPTION
## Proposed Changes

- Move the `next question` button to the bottom of the quiz question block.
![Screenshot 2022-10-08 at 8 18 03 PM](https://user-images.githubusercontent.com/16238306/194713294-4a705a3e-d787-476b-bd2a-09a35bc674dd.png)
@pupilfirst/developers

## Merge Checklist

- ~~Add specs that demonstrate bug / test a new feature.~~
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
