### PR TITLE
Prevent delivery of emails to bounced addresses

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -81,9 +81,13 @@ class UserMailer < SchoolMailer
     @school = user.school
     @inactivity_months = inactivity_months
     @sign_in_url = sign_in_url
+
     simple_mail(
       user.email,
-      I18n.t('mailers.user.account_deletion_notification.subject')
+      I18n.t(
+        'mailers.user.account_deletion_notification.subject',
+        school_name: @school.name
+      )
     )
   end
 end

--- a/spec/services/users/inactivity_notification_and_deletion_service_spec.rb
+++ b/spec/services/users/inactivity_notification_and_deletion_service_spec.rb
@@ -61,9 +61,15 @@ describe Users::InactivityNotificationAndDeletionService do
 
         # Check emails of all users
         open_email(inactive_user_school_1.email)
+
         expect(
           inactive_user_school_1.reload.account_deletion_notification_sent_at
         ).to_not eq(nil)
+
+        expect(current_email.subject).to eq(
+          "Your account in #{school_1.name} will be deleted in 30 days"
+        )
+
         expect(sanitize_html(current_email.body)).to include(
           'https://school1.host/users/sign_in'
         )

--- a/spec/system/bounced_emails_spec.rb
+++ b/spec/system/bounced_emails_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+feature 'Prevent mail delivery to bounced addresses' do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create :user }
+
+  context "when the user's email address is not a bounced address" do
+    scenario 'the email can delivered now' do
+      UserMailer.account_deletion_notification(user, 'http://example.com', 24)
+        .deliver_now
+
+      open_email(user.email)
+
+      expect(current_email.subject).to eq(
+        "Your account in #{user.school.name} will be deleted in 30 days"
+      )
+    end
+
+    scenario 'the email can delivered later' do
+      UserMailer.account_deletion_notification(user, 'http://example.com', 24)
+        .deliver_later
+
+      open_email(user.email)
+
+      expect(current_email.subject).to eq(
+        "Your account in #{user.school.name} will be deleted in 30 days"
+      )
+    end
+  end
+
+  context 'when the user has a bounce report' do
+    let!(:bounce_report) { create :bounce_report, email: user.email }
+
+    scenario 'user cannot be sent an email now' do
+      UserMailer.account_deletion_notification(user, 'http://example.com', 24)
+        .deliver_now
+
+      open_email(user.email)
+
+      expect(current_email).to be_nil
+    end
+
+    scenario 'user cannot be sent an email later' do
+      UserMailer.account_deletion_notification(user, 'http://example.com', 24)
+        .deliver_later
+
+      open_email(user.email)
+
+      expect(current_email).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Proposed Changes

This updates the base class `SchoolMailer` to skip delivery of email if the address is recorded in the `bounce_reports` table.

This PR also includes an unrelated fix to a mistake in the subject line composition for the _inactive user account deletion notification_ email.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
