### PR TITLE
Add the New Relic browser timing header manually along with a nonce

### DIFF
--- a/app/views/layouts/tailwind.html.erb
+++ b/app/views/layouts/tailwind.html.erb
@@ -11,6 +11,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <%= ::NewRelic::Agent.browser_timing_header(content_security_policy_nonce) if Rails.env.production? && Rails.application.secrets.new_relic_license_key.present? %>
     <link rel="manifest" href="/manifest.json" />
     <% if content_for?(:viewport) %>
       <%= yield :viewport %>

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -27,6 +27,11 @@ common:
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  # Automatic-injection of browser monitoring to be disabled because it must be enabled manually,
+  # injecting nonce via template file. For more details, see https://github.com/newrelic/newrelic-ruby-agent/pull/673
+  browser_monitoring:
+    auto_instrument: false
+
   application_logging:
     # If `true`, all logging-related features for the agent can be enabled or disabled
     # independently. If `false`, all logging-related features are disabled.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -54,6 +54,8 @@ common: &common
     evaluator_ids: <%= ENV.fetch('BOT_EVALUATOR_IDS', '').split(',') %>
     evaluator_repeat_rejection_alert_threshold: <%= ENV.fetch('BOT_EVALUATOR_REPEAT_REJECTION_ALERT_THRESHOLD', '4').to_i %>
   max_upload_file_size: <%= ENV.fetch('MAX_UPLOAD_FILE_SIZE', 5242880).to_i %>
+  new_relic_license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
+
 development:
   secret_key_base: "2ab04e6d7919f4f9fd1e25d41455aa26ad21c2a8d053bc00ac02db4d424d97e0716105c620907e6d829329fe275d52673117d432d6d00c9052bec26a82b2de3f"
   <<: *common


### PR DESCRIPTION
This follows instructions in https://github.com/newrelic/newrelic-ruby-agent/pull/673 to disable automatic injection of the browser script, and instead to inject it manually along with a nonce to satisfy CSP.

## Merge Checklist

- ~~Add specs that demonstrate bug / test a new feature.~~
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
