### PR TITLE
Redirect to user profile edit page if Discord account linking is required

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 16.13.0
-ruby 2.7.6
+ruby 2.7.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.7.6'
+ruby '2.7.7'
 
 source 'https://rubygems.org'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     motion-markdown-it (8.4.1.2)
       linkify-it-rb (~> 2.0)
@@ -336,6 +337,9 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.10.1)
     nio4r (2.5.8)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -601,6 +605,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -691,7 +696,7 @@ DEPENDENCIES
   whenever (~> 1.0)
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 2.7.7p221
 
 BUNDLED WITH
    2.3.11

--- a/app/controllers/concerns/discord_account_requirable.rb
+++ b/app/controllers/concerns/discord_account_requirable.rb
@@ -5,7 +5,7 @@ module DiscordAccountRequirable
     return if current_user.discord_account_connected?
 
     if course.discord_account_required?
-      redirect_to edit_user_path(discord_account_required: course.id)
+      redirect_to edit_user_path(course_requiring_discord: course.id)
     end
   end
 end

--- a/app/controllers/concerns/discord_account_requirable.rb
+++ b/app/controllers/concerns/discord_account_requirable.rb
@@ -1,0 +1,11 @@
+# This module expects that the controller has a `course` method that returns
+# the course for which Discord account requirement is being enforced.
+module DiscordAccountRequirable
+  def require_discord_account
+    return if current_user.discord_account_connected?
+
+    if course.discord_account_required?
+      redirect_to edit_user_path(discord_account_required: course.id)
+    end
+  end
+end

--- a/app/controllers/concerns/discord_account_requirable.rb
+++ b/app/controllers/concerns/discord_account_requirable.rb
@@ -2,6 +2,8 @@
 # the course for which Discord account requirement is being enforced.
 module DiscordAccountRequirable
   def require_discord_account
+    return if current_user.blank?
+
     return if current_user.discord_account_connected?
 
     if course.discord_account_required?

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,10 +1,12 @@
 class CoursesController < ApplicationController
   include RecaptchaVerifiable
+  include DiscordAccountRequirable
 
   before_action :authenticate_user!,
                 except: %i[show apply process_application curriculum]
 
   before_action :preview_or_authenticate, only: %i[curriculum]
+  before_action :require_discord_account, only: %i[curriculum report]
 
   # GET /courses/:id/curriculum
   def curriculum
@@ -82,6 +84,10 @@ class CoursesController < ApplicationController
   end
 
   private
+
+  def course
+    @course ||= Course.find(params[:id])
+  end
 
   def preview_or_authenticate
     course = find_course

--- a/app/controllers/targets_controller.rb
+++ b/app/controllers/targets_controller.rb
@@ -1,8 +1,10 @@
 class TargetsController < ApplicationController
   include CamelizeKeys
   include StringifyIds
+  include DiscordAccountRequirable
 
   before_action :preview_or_authenticate
+  before_action :require_discord_account, only: %i[show]
 
   # GET /targets/:id/(:slug)
   def show
@@ -32,6 +34,10 @@ class TargetsController < ApplicationController
   end
 
   private
+
+  def course
+    @course ||= Target.find(params[:id]).course
+  end
 
   def preview_or_authenticate
     target = Target.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,18 +11,18 @@ class UsersController < ApplicationController
     @user = authorize(current_user)
 
     @course_requiring_discord_account =
-      if params[:discord_account_required].present? &&
+      if params[:course_requiring_discord].present? &&
            !current_user.discord_account_connected?
         course =
-          current_user.courses.find_by(id: params[:discord_account_required])
+          current_user.courses.find_by(id: params[:course_requiring_discord])
 
-        session[:discord_account_required] = course.id if course.present?
+        session[:course_requiring_discord] = course.id if course.present?
         course
-      elsif session.key?(:discord_account_required)
+      elsif session.key?(:course_requiring_discord)
         course =
-          current_user.courses.find_by(id: session[:discord_account_required])
+          current_user.courses.find_by(id: session[:course_requiring_discord])
 
-        session.delete(:discord_account_required)
+        session.delete(:course_requiring_discord)
         course
       end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,22 @@ class UsersController < ApplicationController
 
   def edit
     @user = authorize(current_user)
+
+    @course_requiring_discord_account =
+      if params[:discord_account_required].present? &&
+           !current_user.discord_account_connected?
+        course =
+          current_user.courses.find_by(id: params[:discord_account_required])
+
+        session[:discord_account_required] = course.id if course.present?
+        course
+      elsif session.key?(:discord_account_required)
+        course =
+          current_user.courses.find_by(id: session[:discord_account_required])
+
+        session.delete(:discord_account_required)
+        course
+      end
   end
 
   # GET /users/delete_account

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -231,4 +231,8 @@ class User < ApplicationRecord
       title.presence || affiliation.presence
     end
   end
+
+  def discord_account_connected?
+    discord_user_id.present?
+  end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,9 +6,32 @@
 <script id="user-edit__props" type="application/json">
   <%= presenter.props_to_json.html_safe %>
 </script>
-<% if Rails.application.secrets.sso[:discord][:key].present? && discord_config.configured?%>
+<% if Rails.application.secrets.sso[:discord][:key].present? && discord_config.configured? %>
   <div class="container mx-auto px-3 py-8 max-w-5xl">
-    <div class="bg-white shadow rounded-lg">
+    <% if @course_requiring_discord_account.present? %>
+      <% if current_user.discord_account_connected? %>
+        <div class="bg-green-100 border-l-4 border-green-400 p-4">
+          <div class="flex items-center">
+            <i class="fas fa-check-circle text-green-400 text-4xl"></i>
+            <div class="ml-3">
+              <h3 class="text-lg font-semibold"><%= t('.course_discord_requirement_met.heading_html', course_path: curriculum_course_path(@course_requiring_discord_account)) %></h3>
+              <p class="text-sm text-green-900"><%= t('.course_discord_requirement_met.description_html', school_name: current_school.name, course_path: curriculum_course_path(@course_requiring_discord_account)) %></p>
+            </div>
+          </div>
+        </div>
+      <% else %>
+        <div class="bg-orange-100 border-l-4 border-orange-400 p-4">
+          <div class="flex items-center">
+            <i class="fas fa-exclamation-triangle text-orange-400 text-4xl"></i>
+            <div class="ml-3">
+              <h3 class="text-lg font-semibold"><%= t('.course_requires_discord_account.heading') %></h3>
+              <p class="text-sm text-orange-900"><%= t('.course_requires_discord_account.description_html', course_name: @course_requiring_discord_account.name) %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+    <div class="bg-white shadow rounded-lg mt-4 ">
       <div class="flex flex-col md:flex-row">
         <% if current_user.discord_user_id.blank? %>
           <div class="flex flex-col justify-between w-full md:w-1/3 bg-primary-50 px-4 py-5 sm:p-6">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2434,11 +2434,14 @@ en:
       submissions_reviewed: submissions reviewed
       title: Overview
   services:
-    team_up:
-      must_be_on_the_same_level: Students must belong to the same level for teaming up
     discord:
       community_message_service:
-        post_topic_created: "**%{user_name}** created a new discussion:\n%{topic_url}\n> %{topic_title}"
+        post_topic_created: |-
+          **%{user_name}** created a new discussion:
+          %{topic_url}
+          > %{topic_title}
+    team_up:
+      must_be_on_the_same_level: Students must belong to the same level for teaming up
   shared:
     _no: "No"
     _yes: "Yes"
@@ -2548,6 +2551,12 @@ en:
       link_expired: That link has expired or is invalid. Please try again.
       title: Edit User
     edit:
+      course_discord_requirement_met:
+        heading_html: All done! Let's <a class="underline" href="%{course_path}">take you back to the course</a>.
+        description_html: Your Discord account has been linked to your %{school_name} account. You can now <a class="underline" href="%{course_path}">continue browsing the course curriculum</a>.
+      course_requires_discord_account:
+        heading: Wait a second! You need to link your Discord account first.
+        description_html: The <em>%{course_name}</em> course you're trying to access requires that you link a Discord account to your profile. Use the button below to link your Discord account and continue with the course.
       discord_connect: Join Our Discord Community
       discord_connected_account: Go to Discord Community
       discord_connected_message: <li>Your nickname on the Discord server will be kept in sync with your name here.</li><li>You've been assigned additional roles on Discord.</li>
@@ -2572,11 +2581,11 @@ en:
           invalid_request: Your browser made an invalid request.
     sessions:
       auth_callback:
-        error: "Invalid login credentials"
-        invalid_session: "We were unable to verify whether it was you who asked to be signed in. Please try to sign in again."
-        success: "Your Discord account has been linked successfully. Your access to our Discord server will be updated shortly."
-        discord_link_error: "We were unable to link your Discord account. Please try again."
-        discord_already_linked: "Your Discord account is already linked to another account. Please unlink it from that account first."
+        discord_already_linked: Your Discord account is already linked to another account. Please unlink it from that account first.
+        discord_link_error: We were unable to link your Discord account. Please try again.
+        error: Invalid login credentials
+        invalid_session: We were unable to verify whether it was you who asked to be signed in. Please try to sign in again.
+        success: Your Discord account has been linked successfully. Your access to our Discord server will be updated shortly.
       email_sent:
         image_alt: An email flying into to your inbox
         magic_link:

--- a/db/migrate/20221124124958_add_discord_account_required_to_courses.rb
+++ b/db/migrate/20221124124958_add_discord_account_required_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDiscordAccountRequiredToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :discord_account_required, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_08_062525) do
+ActiveRecord::Schema.define(version: 2022_11_24_124958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -204,6 +204,7 @@ ActiveRecord::Schema.define(version: 2022_11_08_062525) do
     t.string "processing_url"
     t.jsonb "highlights", default: []
     t.bigint "default_cohort_id"
+    t.boolean "discord_account_required", default: false
     t.index ["default_cohort_id"], name: "index_courses_on_default_cohort_id"
     t.index ["school_id"], name: "index_courses_on_school_id"
   end

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -222,7 +222,9 @@ feature "Student's view of Course Curriculum", js: true do
 
     scenario 'student visits the course curriculum page' do
       sign_in_user student.user, referrer: curriculum_course_path(course)
-      expect(page).to have_text('You have only limited access to the course now. You are allowed preview the content but cannot complete any target.')
+      expect(page).to have_text(
+        'You have only limited access to the course now. You are allowed preview the content but cannot complete any target.'
+      )
     end
   end
 
@@ -580,6 +582,24 @@ feature "Student's view of Course Curriculum", js: true do
       click_button "L7: #{level_without_targets.name}"
 
       expect(page).to have_content("There's no published content on this level")
+    end
+  end
+
+  context 'when a course requires a Discord connection' do
+    let(:course) { create :course, discord_account_required: true }
+
+    scenario 'student without a connected Discord account is redirected to the user profile edit page' do
+      sign_in_user student.user, referrer: curriculum_course_path(course)
+
+      expect(page).to have_content('Edit your profile')
+    end
+
+    scenario 'student with a connected Discord account is shown the curriculum' do
+      student.user.update!(discord_user_id: 'DISCORD_USER_ID')
+
+      sign_in_user student.user, referrer: curriculum_course_path(course)
+
+      expect(page).to have_content(course.name)
     end
   end
 end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'User Edit', js: true do
   include UserSpecHelper
   include NotificationHelper
+  include ConfigHelper
 
   let(:student) { create :founder }
   let(:user) { student.user }
@@ -145,6 +146,53 @@ feature 'User Edit', js: true do
 
       expect(page).to have_text('Profile updated successfully!')
       expect(user.reload.valid_password?(new_password)).to eq(true)
+    end
+  end
+
+  context 'when the user is required to connect a Discord account for a course' do
+    let(:course) { student.course }
+
+    around do |example|
+      with_secret(sso: { discord: { key: 'DISCORD_KEY' } }) { example.run }
+    end
+
+    before do
+      course.update!(discord_account_required: true)
+      course.school.update(
+        configuration: {
+          discord: {
+            server_id: 'DISCORD_SERVER_ID',
+            bot_token: 'DISCORD_BOT_TOKEN'
+          }
+        }
+      )
+    end
+
+    scenario 'user is prompted to connect a Discord account; afterwards is shown link to course' do
+      sign_in_user(
+        user,
+        referrer: edit_user_path(discord_account_required: course.id)
+      )
+
+      expect(page).to have_text('You need to link your Discord account first')
+
+      # Visiting the page after setting the Discord user should show a CTA to return to the course..
+      user.update!(discord_user_id: 'DISCORD_USER_ID')
+
+      visit(edit_user_path)
+
+      expect(page).to have_link(
+        'take you back to the course',
+        href: curriculum_course_path(course)
+      )
+
+      # Visiting the page again should not show the prompt.
+      visit(edit_user_path)
+
+      expect(page).not_to have_link(
+        'take you back to the course',
+        href: curriculum_course_path(course)
+      )
     end
   end
 end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -171,7 +171,7 @@ feature 'User Edit', js: true do
     scenario 'user is prompted to connect a Discord account; afterwards is shown link to course' do
       sign_in_user(
         user,
-        referrer: edit_user_path(discord_account_required: course.id)
+        referrer: edit_user_path(course_requiring_discord: course.id)
       )
 
       expect(page).to have_text('You need to link your Discord account first')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,24 +4652,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109":
-  version: 1.0.30001373
-  resolution: "caniuse-lite@npm:1.0.30001373"
-  checksum: cd2f027e2fcf66ed3b0e3eccec89df871f951f2e7600944fae2c3f6f1c37ac82392e573c279e15bf851b75f9696472e38d33fd52d964819ffb8af7af4078ceba
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001332":
-  version: 1.0.30001346
-  resolution: "caniuse-lite@npm:1.0.30001346"
-  checksum: 951590454ffa4e2e7b772558dc593cd08604b44c83741e1188166298f54c34387f4bf34f5141a35de4a43028c012484240ad15c896e48bf4eac70dd7076a4449
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001399":
-  version: 1.0.30001419
-  resolution: "caniuse-lite@npm:1.0.30001419"
-  checksum: 7a4dc2794a6773574b5aebcd1c9c0d56159654821714152d8a0b04e261e1522bfd3d86589b8406ce81c7bf5b706118b73b2cb85d577ae433e303dd48ac9ff65f
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001332, caniuse-lite@npm:^1.0.30001399":
+  version: 1.0.30001434
+  resolution: "caniuse-lite@npm:1.0.30001434"
+  checksum: 7c9d2641e8e8f3ddf9af14c4ce47266a9d8fd1fc0243626049ff1b2eca4bf02938ff440813cc3feae3fa8d851ec8d1b9718044340c8d09bb4372d92d4f6b519c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds a `discord_account_required` flag to the `courses` table which causes a student to be redirected to `edit_user_path` if they haven't linked their Discord account with the school account.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
