### PR TITLE
Avoid redirecting inactive students for Discord linking

### DIFF
--- a/app/controllers/concerns/discord_account_requirable.rb
+++ b/app/controllers/concerns/discord_account_requirable.rb
@@ -6,6 +6,16 @@ module DiscordAccountRequirable
 
     return if current_user.discord_account_connected?
 
+    # Redirect only if the user is an active student in the course.
+    unless current_user
+             .founders
+             .joins(cohort: :course)
+             .where(courses: { id: course.id })
+             .merge(Cohort.active)
+             .exists?
+      return
+    end
+
     if course.discord_account_required?
       redirect_to edit_user_path(course_requiring_discord: course.id)
     end

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -601,5 +601,13 @@ feature "Student's view of Course Curriculum", js: true do
 
       expect(page).to have_content(course.name)
     end
+
+    scenario 'inactive student without a connection Discord account should not be redirected' do
+      cohort.update(ends_at: 1.day.ago)
+
+      sign_in_user student.user, referrer: curriculum_course_path(course)
+
+      expect(page).to have_content('The course has ended')
+    end
   end
 end


### PR DESCRIPTION
This is a fix for the recently merged #1196 - inactive students shouldn't be required to link their Discord account to see course curriculum.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
