### PR TITLE
Force overflow to auto on label element

### DIFF
--- a/app/frontend/courses/curricula/components/CoursesCurriculum__SubmissionItem.res
+++ b/app/frontend/courses/curricula/components/CoursesCurriculum__SubmissionItem.res
@@ -28,7 +28,7 @@ let placeholder = (id, checklistItem) => {
   let optional = checklistItem |> ChecklistItem.optional
   <div className="flex items-start">
     <PfIcon className={kindIconClasses(checklistItem->ChecklistItem.result)} />
-    <label htmlFor=id className="font-semibold text-sm pl-2 tracking-wide">
+    <label htmlFor=id className="font-semibold text-sm pl-2 tracking-wide overflow-auto">
       <MarkdownBlock
         profile=Markdown.Permissive
         markdown={title ++ (optional ? " (" ++ ts("optional") ++ ")" : "")}


### PR DESCRIPTION
This fixes a small visual issue in the submission questionnaire. When one of the questions contains a pre-formatted text block of width greater than the max allowed by the container, the `<label>` element for the questions overflows and pushes out the width of the parent.

![label_overflow](https://user-images.githubusercontent.com/98546/218263614-33174209-75c3-4758-888a-6000d8908ff8.png)

I'm unsure why this element seems to be defaulting to `overflow: visible`. Manually setting it to `overflow: auto` seems to fix the issue.