### PR TITLE
Fixed bug which resulted in showing incorrect level progression on organisations student page and added UI enhancements.

### DIFF
--- a/app/frontend/shared/components/LevelProgressBar.res
+++ b/app/frontend/shared/components/LevelProgressBar.res
@@ -20,6 +20,11 @@ let make = (~levels, ~currentLevelNumber, ~courseCompleted, ~className="") => {
   <div className>
     <div className="flex justify-between items-end">
       <h6 className="text-sm font-semibold"> {t("heading") |> str} </h6>
+      {courseCompleted
+        ? <p className="text-green-600 font-semibold">
+            {`🎉` |> str} <span className="text-xs ml-px"> {t("course_completed") |> str} </span>
+          </p>
+        : React.null}
     </div>
     <div className="h-12 flex items-center">
       <ul

--- a/app/presenters/organisations/student_presenter.rb
+++ b/app/presenters/organisations/student_presenter.rb
@@ -20,7 +20,9 @@ module Organisations
     def level_progress_bar_props
       {
         levels:
-          course.levels.map { |level| completed_level_ids.include?(level.id) },
+          course.levels
+                .where('number > ?', 0).order(:number)
+                .map { |level| completed_level_ids.include?(level.id) },
         currentLevelNumber: level.number,
         courseCompleted: student.completed_at.present?
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1151,6 +1151,7 @@ en:
       user_controls: Show user controls
     LevelProgressBar:
       heading: Level Progress
+      course_completed: Course Completed!
     MarkdownEditor:
       attach_file_label: Click here to attach a file.
       bold_insert: bold

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -985,6 +985,9 @@ ru:
       update_criterion: Критерий Обновления
     HelpIcon:
       read_more: Подробнее
+    LevelProgressBar:
+      heading: Прогресс Уровня
+      course_completed: Курс Пройден!
     MarkdownEditor:
       attach_file_label: Нажмите здесь, чтобы прикрепить файл.
       bold_insert: жирный


### PR DESCRIPTION
Fixes #1239 

## Proposed Changes

- The bug is caused because of `level 0` creation from backend and it is fixed by updating `query` in `student_presenter` in orgs. 

**Before** - Bug Reproduce

![image](https://user-images.githubusercontent.com/53794102/223200410-9c10d8b0-6eda-403b-bb3c-0c8308129e50.png)

----

![image](https://user-images.githubusercontent.com/53794102/223200578-96ba15e1-7f6b-43a3-a766-b97bf180c1d7.png)

----

**After fix**

![image](https://user-images.githubusercontent.com/53794102/223200719-412e84c1-73d8-4280-9ce3-08c8ca972135.png)

----

![image](https://user-images.githubusercontent.com/53794102/223200760-981cd6e1-57bf-4284-bb7b-5a48d59a9420.png)


---

**UI Enhancement**

![image](https://user-images.githubusercontent.com/53794102/223201770-0824c16a-0f30-453b-9cd9-4091e2af72fa.png)
 

@pupilfirst/developers

## Merge Checklist

- [x] Ensure that UI text is kept in I18n files.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
