### PR TITLE
Handle auto-accepted submissions in webhook deliveries

### DIFF
--- a/app/services/timeline_events/create_webhook_data_service.rb
+++ b/app/services/timeline_events/create_webhook_data_service.rb
@@ -31,7 +31,7 @@ module TimelineEvents
     end
 
     def evaluation
-      return {} if @submission.pending_review?
+      return {} if evaluation_criteria.empty? || @submission.pending_review?
 
       {
         evaluator: @submission.evaluator.name,
@@ -48,19 +48,20 @@ module TimelineEvents
     end
 
     def target
-      @target ||= @submission.target
+      @submission.target
     end
 
     def evaluation_criteria
-      @submission.evaluation_criteria.map do |ec|
-        {
-          id: ec.id,
-          name: ec.name,
-          max_grade: ec.max_grade,
-          pass_grade: ec.pass_grade,
-          grade_labels: ec.grade_labels
-        }
-      end
+      @evaluation_criteria ||=
+        @submission.evaluation_criteria.map do |ec|
+          {
+            id: ec.id,
+            name: ec.name,
+            max_grade: ec.max_grade,
+            pass_grade: ec.pass_grade,
+            grade_labels: ec.grade_labels
+          }
+        end
     end
 
     def files


### PR DESCRIPTION
## Proposed Changes

This fixes a crash in webhook deliveries related to the recently merged #1247. The crash came to be because this webhook delivery was only attempted for timeline events created using the `createSubmission` mutation which, prior to #1247, only dealt with manually evaluated submissions.