### PR TITLE
Fixed styling of `CourseResourcesFilter` items on schools - teams, students, cohorts page

### DIFF
--- a/app/frontend/admin/courses/CohortsIndex__Root.res
+++ b/app/frontend/admin/courses/CohortsIndex__Root.res
@@ -192,8 +192,6 @@ let renderLoadMore = (send, courseId, params, cursor) => {
   </div>
 }
 
-
-
 @react.component
 let make = (~courseId, ~search) => {
   let params = Webapi.Url.URLSearchParams.make(search)
@@ -213,28 +211,23 @@ let make = (~courseId, ~search) => {
             <span className="inline-block pl-2"> {str(t("add_new_cohort"))} </span>
           </Link>
         </div>
-        <div className="sticky top-0 my-6">
-          <div className="border rounded-lg mx-auto bg-white ">
-            <div>
-              <div className="flex w-full items-start p-4">
-                <CourseResourcesFilter
-                  courseId
-                  filters={makeFilters()}
-                  search={search}
-                  sorter={CourseResourcesFilter.makeSorter(
-                    "sort_by",
-                    [
-                      t("filter.name"),
-                      t("filter.first_created"),
-                      t("filter.last_created"),
-                      t("filter.last_ending"),
-                    ],
-                    t("filter.last_created"),
-                  )}
-                />
-              </div>
-            </div>
-          </div>
+        <div
+          className="p-5 mt-6 bg-white rounded-md border border-gray-300 md:sticky md:top-0 z-10">
+          <CourseResourcesFilter
+            courseId
+            filters={makeFilters()}
+            search={search}
+            sorter={CourseResourcesFilter.makeSorter(
+              "sort_by",
+              [
+                t("filter.name"),
+                t("filter.first_created"),
+                t("filter.last_created"),
+                t("filter.last_ending"),
+              ],
+              t("filter.last_created"),
+            )}
+          />
         </div>
         {PagedCohorts.renderView(
           ~pagedItems=state.cohorts,

--- a/app/frontend/admin/courses/StudentsIndex__Root.res
+++ b/app/frontend/admin/courses/StudentsIndex__Root.res
@@ -130,12 +130,12 @@ let showTag = (~value=?, key, text, color, params) => {
 }
 
 let studentsList = (params, students) => {
-  <div className="space-y-4">
+  <div>
     {students
     ->Js.Array2.map(student => {
       <div
         key={StudentInfo.id(student)}
-        className="student-container h-full flex items-center bg-white">
+        className="student-container h-full flex items-center bg-white mt-4">
         <div
           className="py-4 px-4 flex gap-4 flex-1 items-center text-left justify-between rounded-md shadow">
           <div className="flex">
@@ -222,7 +222,12 @@ let makeFilters = () => {
     CourseResourcesFilter.makeFilter("user_tags", t("filter.user_tag"), DataLoad(#UserTag), "blue"),
     CourseResourcesFilter.makeFilter("email", t("filter.search_by_email"), Search, "gray"),
     CourseResourcesFilter.makeFilter("name", t("filter.search_by_name"), Search, "gray"),
-    CourseResourcesFilter.makeFilter("status", "Status", CustomArray(["Active", "Ended", "Dropped"]), "orange"),
+    CourseResourcesFilter.makeFilter(
+      "status",
+      "Status",
+      CustomArray(["Active", "Ended", "Dropped"]),
+      "orange",
+    ),
   ]
 }
 
@@ -250,7 +255,7 @@ let make = (~courseId, ~search) => {
 
   <>
     <Helmet> <title> {str(t("title"))} </title> </Helmet>
-    <div className="bg-gray-50 pt-8 min-h-full">
+    <div className="bg-gray-50 pt-8 min-h-full ">
       <div className="max-w-4xl 2xl:max-w-5xl mx-auto px-4">
         <div className="flex justify-between items-end gap-2">
           <p className="font-semibold pl-1 capitalize"> {t("students")->str} </p>
@@ -261,29 +266,24 @@ let make = (~courseId, ~search) => {
             </Link>
           </div>
         </div>
-        <div className="sticky top-0 my-6">
-          <div className="border rounded-lg mx-auto bg-white ">
-            <div>
-              <div className="flex w-full items-start p-4">
-                <CourseResourcesFilter
-                  courseId
-                  filters={makeFilters()}
-                  search={search}
-                  sorter={CourseResourcesFilter.makeSorter(
-                    "sort_by",
-                    [
-                      t("sorter.name"),
-                      t("sorter.first_created"),
-                      t("sorter.last_created"),
-                      t("sorter.first_updated"),
-                      t("sorter.last_updated"),
-                    ],
-                    t("sorter.last_created"),
-                  )}
-                />
-              </div>
-            </div>
-          </div>
+        <div
+          className="p-5 mt-6 bg-white rounded-md border border-gray-300 md:sticky md:top-0 z-10 ">
+          <CourseResourcesFilter
+            courseId
+            filters={makeFilters()}
+            search={search}
+            sorter={CourseResourcesFilter.makeSorter(
+              "sort_by",
+              [
+                t("sorter.name"),
+                t("sorter.first_created"),
+                t("sorter.last_created"),
+                t("sorter.first_updated"),
+                t("sorter.last_updated"),
+              ],
+              t("sorter.last_created"),
+            )}
+          />
         </div>
         {PagedStudents.renderView(
           ~pagedItems=state.students,

--- a/app/frontend/admin/courses/StudentsIndex__Root.res
+++ b/app/frontend/admin/courses/StudentsIndex__Root.res
@@ -267,7 +267,7 @@ let make = (~courseId, ~search) => {
           </div>
         </div>
         <div
-          className="p-5 mt-6 bg-white rounded-md border border-gray-300 md:sticky md:top-0 z-10 ">
+          className="p-5 mt-6 bg-white rounded-md border border-gray-300 md:sticky md:top-0 z-10">
           <CourseResourcesFilter
             courseId
             filters={makeFilters()}

--- a/app/frontend/admin/courses/TeamsIndex__Root.res
+++ b/app/frontend/admin/courses/TeamsIndex__Root.res
@@ -198,23 +198,18 @@ let make = (~courseId, ~search) => {
             <span className="inline-block pl-2"> {str(t("create_team"))} </span>
           </Link>
         </div>
-        <div className="sticky top-0 my-6">
-          <div className="border rounded-lg mx-auto bg-white ">
-            <div>
-              <div className="flex w-full items-start p-4">
-                <CourseResourcesFilter
-                  courseId
-                  filters={makeFilters()}
-                  search={search}
-                  sorter={CourseResourcesFilter.makeSorter(
-                    "sort_by",
-                    [t("sorter.name"), t("sorter.first_created"), t("sorter.last_created")],
-                    t("sorter.last_created"),
-                  )}
-                />
-              </div>
-            </div>
-          </div>
+        <div
+          className="p-5 mt-6 bg-white rounded-md border border-gray-300 md:sticky md:top-0 z-10">
+          <CourseResourcesFilter
+            courseId
+            filters={makeFilters()}
+            search={search}
+            sorter={CourseResourcesFilter.makeSorter(
+              "sort_by",
+              [t("sorter.name"), t("sorter.first_created"), t("sorter.last_created")],
+              t("sorter.last_created"),
+            )}
+          />
         </div>
         {PagedTeams.renderView(
           ~pagedItems=state.teams,


### PR DESCRIPTION
## Proposed Changes

closes #1255 

- Fixed styling of `CourseResourcesFilter`

![image](https://user-images.githubusercontent.com/53794102/226132589-e509e34e-609b-43c4-ad98-4ba0aa210879.png)

![image](https://user-images.githubusercontent.com/53794102/226132607-0b25d657-0fff-4fb2-98af-a0120eb20c24.png)

![image](https://user-images.githubusercontent.com/53794102/226132639-ffeeee4a-ca03-4a1d-a644-0c161a097e89.png)



@pupilfirst/developers
