### PR TITLE
Fix the styles effected by rtl

### DIFF
--- a/app/frontend/admin/courses/calendars_index/CalendarsIndex__DatePicker.res
+++ b/app/frontend/admin/courses/calendars_index/CalendarsIndex__DatePicker.res
@@ -112,10 +112,10 @@ let daysOfMonth = (selectedMonth, selectedDate, dayStatuses) => {
 
         selectedDateAsString == dayAsString || dayStatus->ArrayUtils.isEmpty
           ? React.null
-          : <div className="flex justify-center mt-1 space-x-1">
+          : <div className="flex justify-center mt-1">
               {dayStatus
               ->Js.Array2.map(color => {
-                <span className={`h-1.5 w-1.5 bg-${color}-500 rounded-full`} />
+                <span className={`h-1.5 w-1.5 bg-${color}-500 rounded-full ms-0.5`} />
               })
               ->React.array}
             </div>

--- a/app/frontend/admin/courses/calendars_index/CalendarsIndex__DatePicker.res
+++ b/app/frontend/admin/courses/calendars_index/CalendarsIndex__DatePicker.res
@@ -99,7 +99,7 @@ let daysOfMonth = (selectedMonth, selectedDate, dayStatuses) => {
     <button
       key=dayAsString
       onClick={_ => reloadPage(dayAsString)}
-      className={"courses-calendar__date-grid-button " ++ (
+      className={"courses-calendar__date-grid-button flex flex-col items-center justify-center pt-3 " ++ (
         selectedDateAsString == dayAsString
           ? "courses-calendar__date-grid-button--is-selected"
           : "hover:text-primary-500 hover:bg-primary-100 focus:bg-primary-100 focus:ring-2 focus:ring-focusColor-500 transition"
@@ -107,19 +107,21 @@ let daysOfMonth = (selectedMonth, selectedDate, dayStatuses) => {
       <div className="flex justify-center">
         <time dateTime=dayAsString> {day->string_of_int->str} </time>
       </div>
-      {
-        let dayStatus = parsedStatuses->Js.Dict.get(dayAsString)->Belt.Option.getWithDefault([])
+      <div className="h-3 flex items-center">
+        {
+          let dayStatus = parsedStatuses->Js.Dict.get(dayAsString)->Belt.Option.getWithDefault([])
 
-        selectedDateAsString == dayAsString || dayStatus->ArrayUtils.isEmpty
-          ? React.null
-          : <div className="flex justify-center mt-1">
-              {dayStatus
-              ->Js.Array2.map(color => {
-                <span className={`h-1.5 w-1.5 bg-${color}-500 rounded-full ms-0.5`} />
-              })
-              ->React.array}
-            </div>
-      }
+          selectedDateAsString == dayAsString || dayStatus->ArrayUtils.isEmpty
+            ? React.null
+            : <div className="flex gap-0.5">
+                {dayStatus
+                ->Js.Array2.map(color => {
+                  <div className={`h-1.5 w-1.5 bg-${color}-500 rounded-full`} />
+                })
+                ->React.array}
+              </div>
+        }
+      </div>
     </button>
   })
   ->React.array

--- a/app/frontend/admin/courses/calendars_index/CalendarsIndex__DatePicker.res
+++ b/app/frontend/admin/courses/calendars_index/CalendarsIndex__DatePicker.res
@@ -104,7 +104,9 @@ let daysOfMonth = (selectedMonth, selectedDate, dayStatuses) => {
           ? "courses-calendar__date-grid-button--is-selected"
           : "hover:text-primary-500 hover:bg-primary-100 focus:bg-primary-100 focus:ring-2 focus:ring-focusColor-500 transition"
       )}>
-      <time dateTime=dayAsString> {day->string_of_int->str} </time>
+      <div className="flex justify-center">
+        <time dateTime=dayAsString> {day->string_of_int->str} </time>
+      </div>
       {
         let dayStatus = parsedStatuses->Js.Dict.get(dayAsString)->Belt.Option.getWithDefault([])
 

--- a/app/frontend/courses/curricula/components/CoursesCurriculum__LevelSelector.res
+++ b/app/frontend/courses/curricula/components/CoursesCurriculum__LevelSelector.res
@@ -3,7 +3,7 @@ open CoursesCurriculum__Types
 let str = React.string
 
 let levelZeroSelectorClasses = isSelected => {
-  let defaultClasses = "w-1/2 px-4 py-2 focus:outline-none text-sm font-semibold "
+  let defaultClasses = "w-1/2 px-4 py-2 focus:outline-none text-sm font-semibold flex items-center justify-center "
   defaultClasses ++ (
     isSelected ? "bg-primary-100 text-primary-500 hover:bg-primary-100 hover:text-primary-500" : ""
   )

--- a/app/frontend/courses/review/components/CoursesReview__Editor.res
+++ b/app/frontend/courses/review/components/CoursesReview__Editor.res
@@ -559,7 +559,7 @@ let gradePillHeader = (evaluationCriteriaName, selectedGrade, gradeLabels) =>
 
 let gradePillClasses = (selectedGrade, currentGrade, passgrade, send) => {
   let defaultClasses =
-    "course-review-editor__grade-pill border-gray-300 py-1 px-2 text-sm flex-1 font-semibold transition " ++
+    "course-review-editor__grade-pill border-gray-300 flex items-center justify-center py-1 ps-1 pe-1 text-sm flex-1 font-semibold transition" ++
     switch send {
     | Some(_) =>
       "cursor-pointer hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-inset focus:ring-focusColor-500 " ++ (

--- a/app/frontend/courses/review/components/CoursesReview__Editor.res
+++ b/app/frontend/courses/review/components/CoursesReview__Editor.res
@@ -559,7 +559,7 @@ let gradePillHeader = (evaluationCriteriaName, selectedGrade, gradeLabels) =>
 
 let gradePillClasses = (selectedGrade, currentGrade, passgrade, send) => {
   let defaultClasses =
-    "course-review-editor__grade-pill border-gray-300 flex items-center justify-center py-1 ps-1 pe-1 text-sm flex-1 font-semibold transition" ++
+    "course-review-editor__grade-pill border-gray-300 flex items-center justify-center py-1 ps-1 pe-1 text-sm flex-1 font-semibold transition " ++
     switch send {
     | Some(_) =>
       "cursor-pointer hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-inset focus:ring-focusColor-500 " ++ (

--- a/app/frontend/courses/review/components/CoursesReview__Editor.res
+++ b/app/frontend/courses/review/components/CoursesReview__Editor.res
@@ -559,7 +559,7 @@ let gradePillHeader = (evaluationCriteriaName, selectedGrade, gradeLabels) =>
 
 let gradePillClasses = (selectedGrade, currentGrade, passgrade, send) => {
   let defaultClasses =
-    "course-review-editor__grade-pill border-gray-300 flex items-center justify-center py-1 ps-1 pe-1 text-sm flex-1 font-semibold transition " ++
+    "course-review-editor__grade-pill border-gray-300 flex items-center justify-center py-1 px-2 text-sm flex-1 font-semibold transition " ++
     switch send {
     | Some(_) =>
       "cursor-pointer hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-inset focus:ring-focusColor-500 " ++ (

--- a/app/frontend/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDetailsEditor.res
+++ b/app/frontend/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDetailsEditor.res
@@ -619,7 +619,8 @@ let methodOfCompletionButton = (methodOfCompletion, state, send, index) => {
     <button
       onClick={updateMethodOfCompletion(methodOfCompletion |> methodOfCompletionSelection, send)}
       className={methodOfCompletionButtonClasses(selected)}>
-      <div className="mb-1"> <img className="w-12 h-12" src=icon /> </div> {buttonString |> str}
+      <div className="mb-1"> <img className="w-12 h-12" src=icon /> </div>
+      <div className="text-center"> {buttonString |> str} </div>
     </button>
   </div>
 }

--- a/app/frontend/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDetailsEditor.res
+++ b/app/frontend/schools/courses/components/curriculum_editor/CurriculumEditor__TargetDetailsEditor.res
@@ -414,8 +414,7 @@ let evaluationCriteriaEditor = (state, evaluationCriteria, send) => {
     |> Js.Array.map(SelectableEvaluationCriterion.make)
   <div id="evaluation_criteria" className="mb-6">
     <label
-      className="block tracking-wide text-sm font-semibold me-6 mb-2"
-      htmlFor="evaluation_criteria">
+      className="block tracking-wide text-sm font-semibold me-6 mb-2" htmlFor="evaluation_criteria">
       <span className="me-2"> <i className="fas fa-list rtl:rotate-180 text-base" /> </span>
       {t("select_criterion_label") |> str}
     </label>
@@ -557,9 +556,7 @@ let targetGroupOnSelect = (state, send, targetGroups, selectable) => {
 
 let targetGroupEditor = (state, targetGroups, levels, send) =>
   <div id="target_group_id" className="mb-6">
-    <label
-      className="block tracking-wide text-sm font-semibold me-6 mb-2"
-      htmlFor="target_group">
+    <label className="block tracking-wide text-sm font-semibold me-6 mb-2" htmlFor="target_group">
       <span className="me-2"> <i className="fas fa-list rtl:rotate-180 text-base" /> </span>
       {t("target_group") |> str}
     </label>
@@ -668,8 +665,7 @@ let questionCanBeRemoved = state => state.quiz |> Js.Array.length > 1
 let quizEditor = (state, send) =>
   <div>
     <label
-      className="block tracking-wide text-sm font-semibold me-6 mb-3"
-      htmlFor="Quiz question 1">
+      className="block tracking-wide text-sm font-semibold me-6 mb-3" htmlFor="Quiz question 1">
       <span className="me-2"> <i className="fas fa-list rtl:rotate-180 text-base" /> </span>
       {t("prepare_quiz") |> str}
     </label>
@@ -980,7 +976,7 @@ let make = (
                     value=state.title
                   />
                   <School__InputGroupError
-                    message={ts("enter_valid_title")} active={!hasValidTitle}
+                    message={t("enter_valid_title")} active={!hasValidTitle}
                   />
                 </div>
               </div>
@@ -992,8 +988,7 @@ let make = (
               )}
               <div className="flex items-center mb-6">
                 <label
-                  className="block tracking-wide text-sm font-semibold me-6"
-                  htmlFor="evaluated">
+                  className="block tracking-wide text-sm font-semibold me-6" htmlFor="evaluated">
                   <span className="me-2">
                     <i className="fas fa-list rtl:rotate-180 text-base" />
                   </span>
@@ -1078,12 +1073,9 @@ let make = (
                     <i className="fas fa-list rtl:rotate-180 text-base" />
                   </span>
                   {t("completion_instructions.label") |> str}
-                  <span className="ms-1 text-xs font-normal">
-                    {ts("optional_braces") |> str}
-                  </span>
+                  <span className="ms-1 text-xs font-normal"> {ts("optional_braces") |> str} </span>
                 </label>
-                <HelpIcon
-                  link={t("completion_instructions.help_url")} className="ms-1">
+                <HelpIcon link={t("completion_instructions.help_url")} className="ms-1">
                   {t("completion_instructions.help") |> str}
                 </HelpIcon>
                 <div className="ms-6">
@@ -1102,8 +1094,7 @@ let make = (
               <div className="flex max-w-3xl mx-auto px-3 justify-between items-center">
                 <div className="flex items-center shrink-0">
                   <label
-                    className="block tracking-wide text-sm font-semibold me-3"
-                    htmlFor="archived">
+                    className="block tracking-wide text-sm font-semibold me-3" htmlFor="archived">
                     <span className="me-2">
                       <i className="fas fa-list rtl:rotate-180 text-base" />
                     </span>


### PR DESCRIPTION
Fixed the styles that are effected

Changes

- Grade pill button
- Calendar date button
- Centered the `level 0`  text 
- Method Completion text 

----

Fixed, a translation which is previously referring to the wrong locale and generating missing error

> Grade pill button

**Previous**

![image](https://user-images.githubusercontent.com/53794102/234904285-934ca2bd-3b7a-4497-a1df-4d3559ecda62.png)


**After fix**

![image](https://user-images.githubusercontent.com/53794102/234903913-55a6129d-5ed1-46ca-a836-4606eae8957d.png)

> Calendar date button

**Previous**

![image](https://user-images.githubusercontent.com/53794102/234903416-acbbe9b7-1452-4281-97b5-154e5b722c9c.png)

**After fix**

![image](https://user-images.githubusercontent.com/53794102/234903308-6e57be6d-731e-4e0b-8e19-a24b022b5d8d.png)

> Level 0 title

**Previous**

![image](https://user-images.githubusercontent.com/53794102/234954227-de55c7d0-ba62-47e6-976b-37205f368f64.png)

**After fix**

![image](https://user-images.githubusercontent.com/53794102/234954511-468e8ee0-4d8b-4c85-a378-8e8b6dd5fb1c.png)

> Method completion text

**Previous**
![image](https://user-images.githubusercontent.com/53794102/234970902-f23cb882-eda4-43f4-9f1c-444c52ef8d23.png)

**After Fix**
![image](https://user-images.githubusercontent.com/53794102/234971492-071017ac-eab8-4a17-9b30-03e024d93c7e.png)


@pupilfirst/developers