### PR TITLE
fix: Add spacing between nav links in the footer

### DIFF
--- a/app/frontend/schools/settings/components/SchoolCustomize__Root.res
+++ b/app/frontend/schools/settings/components/SchoolCustomize__Root.res
@@ -81,7 +81,9 @@ let sitemap = links =>
     <div className="flex flex-wrap">
       {links
       ->Js.Array2.map(((id, title, _, _)) =>
-        <div className="w-1/3 pe-4 mt-3 text-xs font-semibold" key=id> {title->str} </div>
+        <div className="w-1/3 pe-4 mt-3 text-xs font-semibold break-words" key=id>
+          {title->str}
+        </div>
       )
       ->React.array}
     </div>
@@ -106,7 +108,7 @@ let address = a =>
   switch a {
   | Some(a) =>
     <div
-      className="text-xs font-semibold mt-3 leading-normal"
+      className="text-xs font-semibold mt-3 leading-normal break-words"
       dangerouslySetInnerHTML={Markdown.toSafeHTML(a, Markdown.Permissive)}
     />
   | None =>
@@ -323,11 +325,7 @@ let make = (~authenticityToken, ~customizations, ~schoolName, ~schoolAbout) => {
               |> Customizations.filterLinks(~header=true)
               |> Customizations.unpackLinks,
             )}
-            {editIcon(
-              "ms-3",
-              showEditor(LinksEditor(HeaderLink), send),
-              t("edit_header_links"),
-            )}
+            {editIcon("ms-3", showEditor(LinksEditor(HeaderLink), send), t("edit_header_links"))}
           </div>
         </div>
       </div>
@@ -441,11 +439,7 @@ let make = (~authenticityToken, ~customizations, ~schoolName, ~schoolAbout) => {
                   className="p-3 bg-gray-100 border border-dashed border-gray-500 rounded h-full">
                   <div className="flex items-center">
                     <span className="uppercase font-bold text-sm"> {t("contact")->str} </span>
-                    {editIcon(
-                      "ms-3",
-                      showEditor(ContactsEditor, send),
-                      t("edit_contact_details"),
-                    )}
+                    {editIcon("ms-3", showEditor(ContactsEditor, send), t("edit_contact_details"))}
                   </div>
                   {address(state.customizations |> Customizations.address)}
                   {emailAddress(state.customizations |> Customizations.emailAddress)}

--- a/app/views/layouts/_student_footer.html.erb
+++ b/app/views/layouts/_student_footer.html.erb
@@ -17,7 +17,7 @@
                 link_to(
                   nav_link[:title],
                   nav_link[:url],
-                  { class: 'no-underline pt-2 pb-1 block hover:text-primary-500 focus:outline-none focus:text-primary-500' }.merge(
+                  { class: 'no-underline break-words mx-2 pt-2 pb-1 block hover:text-primary-500 focus:outline-none focus:text-primary-500' }.merge(
                     nav_link[:custom] ? { target: '_blank', rel: 'noopener' } : {},
                   ),
                 )


### PR DESCRIPTION
## Issue
when there are long words in the footer's nav links they interfere with each other 

## before
![Screenshot 2023-05-08 at 15 13 05](https://user-images.githubusercontent.com/61790587/236848743-fa67f28d-86c3-4499-95fc-702e49fa7c14.png)

## After changes

![Screenshot 2023-05-08 at 15 13 37](https://user-images.githubusercontent.com/61790587/236848806-d81c9845-7885-41b8-90fe-bcf8a86398f5.png)
