### PR TITLE
Allow for different primary and seconday nav item names in admin layout

### DIFF
--- a/app/frontend/layouts/school_router/components/SchoolRouter__LeftNav.res
+++ b/app/frontend/layouts/school_router/components/SchoolRouter__LeftNav.res
@@ -27,7 +27,7 @@ let imageContainerClasses = shrunk => {
 let topNavButtonContents = page => {
   [
     <PfIcon key="icon" className={"if i-" ++ Page.icon(page) ++ "-light if-fw text-lg"} />,
-    <span key="content" className="ms-2"> {Page.name(page)->str} </span>,
+    <span key="content" className="ms-2"> {Page.primaryNavName(page)->str} </span>,
   ]->React.array
 }
 
@@ -46,9 +46,11 @@ let showLink = (selectedPage, selectedCourse, page, classes, title, contents) =>
 
 let topLink = (selectedPage, selectedCourse, page) => {
   let defaultClasses = "school-admin-navbar__primary-nav-link py-3 px-2 mb-1"
+
   let classes =
     defaultClasses ++ (selectedPage == page ? " school-admin-navbar__primary-nav-link--active" : "")
-  let title = Page.shrunk(selectedPage) ? Some(Page.name(page)) : None
+
+  let title = Page.shrunk(selectedPage) ? Some(Page.primaryNavName(page)) : None
 
   showLink(selectedPage, selectedCourse, page, classes, title, topNavButtonContents(page))
 }
@@ -62,8 +64,8 @@ let secondaryNavOption = (selectedPage, selectedCourse, page) => {
         : " font-medium text-gray-500"
     )
 
-  <div key={Page.name(page)}>
-    {showLink(selectedPage, selectedCourse, page, classes, None, Page.name(page)->str)}
+  <div key={Page.secondaryNavName(page)}>
+    {showLink(selectedPage, selectedCourse, page, classes, None, Page.secondaryNavName(page)->str)}
   </div>
 }
 
@@ -151,7 +153,9 @@ let make = (~school, ~courses, ~selectedPage, ~currentUser) => {
           <ul>
             {[Page.Courses, SchoolCoaches, Communities, Settings(Customization)]
             ->Js.Array2.map(page =>
-              <li key={Page.name(page)}> {topLink(selectedPage, selectedCourse, page)} </li>
+              <li key={Page.primaryNavName(page)}>
+                {topLink(selectedPage, selectedCourse, page)}
+              </li>
             )
             ->React.array}
             <li>

--- a/app/frontend/layouts/school_router/components/SchoolRouter__LeftSecondaryNav.res
+++ b/app/frontend/layouts/school_router/components/SchoolRouter__LeftSecondaryNav.res
@@ -24,8 +24,8 @@ let secondaryNavOption = (selectedPage, selectedCourse, page) => {
         : " font-medium text-gray-500"
     )
 
-  <div key={Page.name(page)}>
-    {showLink(selectedPage, selectedCourse, page, classes, None, Page.name(page)->str)}
+  <div key={Page.secondaryNavName(page)}>
+    {showLink(selectedPage, selectedCourse, page, classes, None, Page.secondaryNavName(page)->str)}
   </div>
 }
 

--- a/app/frontend/layouts/school_router/types/SchoolRouter__Page.res
+++ b/app/frontend/layouts/school_router/types/SchoolRouter__Page.res
@@ -98,15 +98,22 @@ let path = (~courseId=?, t) => {
   }
 }
 
-let name = t => {
+let primaryNavName = t =>
   switch t {
   | SchoolCoaches => tr("nav.main.coaches")
+  | Settings(_) => tr("nav.main.settings")
+  | Courses => tr("nav.main.courses")
+  | Communities => tr("nav.main.communities")
+  | SelectedCourse(_) => "Invalid"
+  }
+
+let secondaryNavName = t =>
+  switch t {
   | Settings(settingsPages) =>
     switch settingsPages {
-    | Customization => tr("nav.main.customization")
-    | Admins => tr("nav.main.admins")
+    | Customization => tr("nav.settings.customization")
+    | Admins => tr("nav.settings.admins")
     }
-  | Courses => tr("nav.main.courses")
   | SelectedCourse(coursePages) =>
     switch coursePages {
     | Students => tr("nav.course.students")
@@ -121,9 +128,10 @@ let name = t => {
     | Cohorts => tr("nav.course.cohorts")
     | Calendars => tr("nav.course.calendar")
     }
-  | Communities => tr("nav.main.communities")
+  | Courses
+  | Communities
+  | SchoolCoaches => "Invalid"
   }
-}
 
 let icon = t => {
   switch t {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1439,13 +1439,14 @@ en:
           students: Students
           teams: Teams
         main:
-          admins: Admins
           coaches: Coaches
           communities: Communities
           courses: Courses
-          customization: Customization
           overview: Overview
           settings: Settings
+        settings:
+          admins: Admins
+          customization: Customization
     School__SearchableTagList:
       add_new_tag: Add new tag
       pick_tag: Pick tag

--- a/spec/system/school/navbar_spec.rb
+++ b/spec/system/school/navbar_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'School Admin Navbar', js: true do
+feature "School Admin Navbar", js: true do
   include UserSpecHelper
 
   let(:school_1) { create :school, :current }
@@ -16,17 +16,17 @@ feature 'School Admin Navbar', js: true do
   # And another in a different school.
   let!(:course_3) { create :course, school: school_2 }
 
-  scenario 'school admin visits the admin interface' do
+  scenario "school admin visits the admin interface" do
     sign_in_user school_admin.user, referrer: school_path
 
     # User should be on the school admin overview page.
-    expect(current_path).to eq('/school')
+    expect(current_path).to eq("/school")
 
     # There should be additional links on the navbar.
-    expect(page).to have_link('Coaches', href: '/school/coaches')
-    expect(page).to have_link('Customization', href: '/school/customize')
-    expect(page).to have_link('Courses', href: '/school/courses')
-    expect(page).to have_link('Communities', href: '/school/communities')
+    expect(page).to have_link("Coaches", href: "/school/coaches")
+    expect(page).to have_link("Settings", href: "/school/customize")
+    expect(page).to have_link("Courses", href: "/school/courses")
+    expect(page).to have_link("Communities", href: "/school/communities")
 
     # Links to the student page for all courses in school should also be there.
     expect(page).to have_link(
@@ -49,28 +49,28 @@ feature 'School Admin Navbar', js: true do
     # Courses from other schools should not be listed.
     expect(page).not_to have_link(course_3.name)
 
-    click_button 'Show user controls'
+    click_button "Show user controls"
 
     # There should also be a link to Sign Out
-    expect(page).to have_link('Sign Out')
+    expect(page).to have_link("Sign Out")
 
     # Check out the settings submenu.
-    click_link('Customization')
-    expect(page).to have_link('Customization', href: '/school/customize')
+    click_link("Settings")
+    expect(page).to have_link("Customization", href: "/school/customize")
 
     # Check out the course submenu.
     find('a[title="Courses"]').click
     click_link(course_1.name)
     expect(page).to have_link(
-      'Students',
+      "Students",
       href: "/school/courses/#{course_1.id}/students?status=Active"
     )
     expect(page).to have_link(
-      'Coaches',
+      "Coaches",
       href: "/school/courses/#{course_1.id}/coaches"
     )
     expect(page).to have_link(
-      'Curriculum',
+      "Curriculum",
       href: "/school/courses/#{course_1.id}/curriculum"
     )
 
@@ -87,15 +87,15 @@ feature 'School Admin Navbar', js: true do
     click_link course_2.name
 
     expect(page).to have_link(
-      'Curriculum',
+      "Curriculum",
       href: "/school/courses/#{course_2.id}/curriculum"
     )
 
     # Navbar should also include links to dashboard page
-    expect(page).to have_link('Dashboard', href: '/dashboard')
+    expect(page).to have_link("Dashboard", href: "/dashboard")
   end
 
-  scenario 'school admin visits an ended course' do
+  scenario "school admin visits an ended course" do
     sign_in_user school_admin.user,
                  referrer: school_course_students_path(course_ended)
 


### PR DESCRIPTION
This renames the top/primary nav link for the school settings option to _Settings_ instead of _Customization_. The inner link for the page which loads by default is still called _Customization_.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
