### PR TITLE
Show a custom page when Discord account linking is required

### DIFF
--- a/app/assets/images/users/discord_account_required/connected_pf.svg
+++ b/app/assets/images/users/discord_account_required/connected_pf.svg
@@ -1,0 +1,111 @@
+<svg width="354" height="603" viewBox="0 0 354 603" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="#F2FFF4"/>
+<mask id="mask0_51_206" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="354" height="603">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="url(#paint0_linear_51_206)"/>
+</mask>
+<g mask="url(#mask0_51_206)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379786 586.375L-0.379761 0.5L0.620239 0.5L0.620214 586.375L-0.379786 586.375Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.9553 614.365L43.9553 0.5L44.9553 0.5L44.9553 614.365L43.9553 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.2904 614.365L88.2904 0.5L89.2904 0.5L89.2904 614.365L88.2904 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M132.625 614.365L132.625 0.5L133.625 0.5L133.625 614.365L132.625 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M176.96 614.365L176.96 0.5L177.96 0.5L177.96 614.365L176.96 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M221.296 614.365L221.296 0.5L222.296 0.5L222.296 614.365L221.296 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M265.631 614.365L265.631 0.5L266.631 0.5L266.631 614.365L265.631 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M309.966 614.365L309.966 0.5L310.966 0.5L310.966 614.365L309.966 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 293.437L354.301 293.438L354.301 294.438L-0.379669 294.437L-0.379669 293.437Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 37.1172L354.301 37.1172L354.301 38.1172L-0.379669 38.1172L-0.379669 37.1172Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 330.055L354.301 330.055L354.301 331.055L-0.379669 331.055L-0.379669 330.055Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 73.7343L354.301 73.7344L354.301 74.7344L-0.379669 74.7343L-0.379669 73.7343Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 366.672L354.301 366.672L354.301 367.672L-0.379669 367.672L-0.379669 366.672Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 110.352L354.301 110.352L354.301 111.352L-0.379669 111.352L-0.379669 110.352Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 403.289L354.301 403.289L354.301 404.289L-0.379669 404.289L-0.379669 403.289Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 146.969L354.301 146.969L354.301 147.969L-0.379669 147.969L-0.379669 146.969Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 439.906L354.301 439.906L354.301 440.906L-0.379669 440.906L-0.379669 439.906Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 183.586L354.301 183.586L354.301 184.586L-0.379669 184.586L-0.379669 183.586Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 476.523L354.301 476.523L354.301 477.523L-0.379669 477.523L-0.379669 476.523Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 220.203L354.301 220.203L354.301 221.203L-0.379669 221.203L-0.379669 220.203Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 513.14L354.301 513.14L354.301 514.14L-0.379669 514.14L-0.379669 513.14Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 256.82L354.301 256.82L354.301 257.82L-0.379669 257.82L-0.379669 256.82Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 549.757L354.301 549.757L354.301 550.757L-0.379669 550.757L-0.379669 549.757Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 586.374L354.301 586.375L354.301 587.375L-0.379669 587.374L-0.379669 586.374Z" fill="#00BC1E" fill-opacity="0.1"/>
+</g>
+<g filter="url(#filter0_d_51_206)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M183.886 297.423C155.523 242.017 171.896 202.428 184.205 189.26L187.127 191.992C176.086 203.803 159.771 241.537 187.446 295.6C201.655 323.356 204.738 351.566 203.282 374.158C202.554 385.456 200.69 395.373 198.499 403.159C196.327 410.877 193.783 416.686 191.592 419.632L188.383 417.245C190.129 414.897 192.515 409.659 194.649 402.075C196.764 394.56 198.581 384.92 199.29 373.901C200.711 351.86 197.696 324.401 183.886 297.423Z" fill="url(#paint1_linear_51_206)"/>
+</g>
+<g filter="url(#filter1_di_51_206)">
+<path d="M180.728 426.138C181.079 425.067 182.213 424.538 183.259 424.956V424.956C184.305 425.373 184.869 426.58 184.518 427.651L182.247 434.567C181.896 435.638 180.763 436.167 179.716 435.749V435.749C178.67 435.332 178.106 434.125 178.458 433.055L180.728 426.138Z" fill="#6571FF"/>
+<path d="M187.625 428.891C187.976 427.82 189.109 427.291 190.156 427.709V427.709C191.202 428.127 191.766 429.333 191.414 430.404L189.144 437.321C188.793 438.391 187.659 438.921 186.613 438.503V438.503C185.567 438.085 185.003 436.879 185.355 435.808L187.625 428.891Z" fill="#6571FF"/>
+<path d="M179.971 419.778C181.235 415.442 185.775 412.951 190.111 414.215V414.215C194.447 415.479 196.938 420.019 195.674 424.355L193.928 430.345C193.705 431.109 192.905 431.549 192.14 431.326L179.206 427.555C178.441 427.332 178.002 426.532 178.225 425.768L179.971 419.778Z" fill="#6571FF"/>
+</g>
+<g filter="url(#filter2_di_51_206)">
+<path d="M219.36 442.539C213.126 438.138 206.268 434.536 198.906 431.887C197.678 433.438 196.19 435.552 195.122 437.254C187.263 434.625 179.266 433.242 171.129 433.104C170.695 431.143 169.979 428.647 169.334 426.773C161.502 426.794 153.824 427.89 146.472 429.951C129.135 448.603 121.875 468.461 120.237 488.992C128.132 497.454 136.215 503.163 144.399 507.399C147.053 504.782 149.509 501.936 151.73 498.873C148.811 497.125 146.072 495.118 143.541 492.899C144.389 492.464 145.226 492 146.041 491.515C161.889 502.702 180.649 505.946 199.127 500.697C199.74 501.429 200.372 502.146 201.017 502.84C197.877 504.086 194.615 505.056 191.279 505.722C192.344 509.344 193.691 512.857 195.32 516.215C204.46 514.975 213.999 512.314 224.279 506.987C230.51 483.936 228.122 462.603 219.36 442.539ZM156.976 482.546C151.793 481.649 148.393 476.001 149.427 470.018C150.462 464.035 155.473 459.832 160.747 460.744C166.021 461.657 169.422 467.305 168.295 473.281C167.268 479.266 162.25 483.458 156.976 482.546ZM191.839 488.576C186.656 487.679 183.255 482.031 184.29 476.047C185.325 470.064 190.335 465.862 195.609 466.774C200.883 467.686 204.284 473.335 203.157 479.311C202.122 485.294 197.113 489.488 191.839 488.576Z" fill="#6571FF"/>
+</g>
+<g filter="url(#filter3_di_51_206)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M181.771 135.45C187.849 134.937 193.638 138.137 196.439 143.559C199.24 148.982 198.499 155.56 194.562 160.223C190.625 164.886 184.267 166.716 178.454 164.859C172.642 163.003 168.519 157.825 168.011 151.742C167.675 147.755 168.937 143.798 171.518 140.743C174.099 137.688 177.787 135.784 181.771 135.45ZM179.258 105.647C200.936 103.823 221.552 121.578 233.13 133.969L233.114 133.97C239.351 140.642 240.207 150.721 235.182 158.348C225.815 172.51 208.472 193.46 186.803 195.284C181.649 195.665 176.469 195.078 171.53 193.556L170.2 177.756C182.582 183.601 197.345 180.392 206.184 169.932C215.023 159.473 215.732 144.376 207.912 133.133C200.092 121.889 185.695 117.307 172.82 121.964C159.945 126.62 151.806 139.352 152.981 152.999L155.78 186.258C146.599 180.561 138.661 173.097 132.931 166.971C126.689 160.292 125.84 150.203 130.878 142.575C140.246 128.422 157.58 107.472 179.258 105.647Z" fill="#965DF4"/>
+</g>
+<defs>
+<filter id="filter0_d_51_206" x="164.196" y="185.26" width="51.4128" height="246.372" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_206"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_206" result="shape"/>
+</filter>
+<filter id="filter1_di_51_206" x="167.167" y="407.887" width="39.8356" height="46.7593" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="5"/>
+<feGaussianBlur stdDeviation="5.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_206"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_206" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_206"/>
+</filter>
+<filter id="filter2_di_51_206" x="77.2369" y="401.773" width="193.535" height="175.442" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="18"/>
+<feGaussianBlur stdDeviation="21.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_206"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_206" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-4"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_206"/>
+</filter>
+<filter id="filter3_di_51_206" x="83.6049" y="93.5171" width="164.837" height="143.879" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-17" dy="15"/>
+<feGaussianBlur stdDeviation="13.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_206"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_206" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_206"/>
+</filter>
+<linearGradient id="paint0_linear_51_206" x1="177" y1="0.5" x2="177" y2="602.595" gradientUnits="userSpaceOnUse">
+<stop stop-color="#404EED"/>
+<stop offset="0.71875" stop-color="#6025C0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_51_206" x1="187.521" y1="190.626" x2="187.521" y2="396.695" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6025C0"/>
+<stop offset="1" stop-color="#6571FF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/app/assets/images/users/discord_account_required/connected_school.svg
+++ b/app/assets/images/users/discord_account_required/connected_school.svg
@@ -1,0 +1,111 @@
+<svg width="354" height="603" viewBox="0 0 354 603" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="#F2FFF4"/>
+<mask id="mask0_51_161" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="354" height="603">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="url(#paint0_linear_51_161)"/>
+</mask>
+<g mask="url(#mask0_51_161)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379786 586.375L-0.379761 0.5L0.620239 0.5L0.620214 586.375L-0.379786 586.375Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.9553 614.365L43.9553 0.5L44.9553 0.5L44.9553 614.365L43.9553 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.2904 614.365L88.2904 0.5L89.2904 0.5L89.2904 614.365L88.2904 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M132.625 614.365L132.625 0.5L133.625 0.5L133.625 614.365L132.625 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M176.96 614.365L176.96 0.5L177.96 0.5L177.96 614.365L176.96 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M221.296 614.365L221.296 0.5L222.296 0.5L222.296 614.365L221.296 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M265.631 614.365L265.631 0.5L266.631 0.5L266.631 614.365L265.631 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M309.966 614.365L309.966 0.5L310.966 0.5L310.966 614.365L309.966 614.365Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 293.437L354.301 293.437L354.301 294.437L-0.379669 294.437L-0.379669 293.437Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 37.1172L354.301 37.1172L354.301 38.1172L-0.379669 38.1172L-0.379669 37.1172Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 330.054L354.301 330.054L354.301 331.054L-0.379669 331.054L-0.379669 330.054Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 73.7343L354.301 73.7344L354.301 74.7344L-0.379669 74.7343L-0.379669 73.7343Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 366.672L354.301 366.672L354.301 367.672L-0.379669 367.672L-0.379669 366.672Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 110.352L354.301 110.352L354.301 111.352L-0.379669 111.352L-0.379669 110.352Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 403.289L354.301 403.289L354.301 404.289L-0.379669 404.289L-0.379669 403.289Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 146.969L354.301 146.969L354.301 147.969L-0.379669 147.969L-0.379669 146.969Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 439.906L354.301 439.906L354.301 440.906L-0.379669 440.906L-0.379669 439.906Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 183.586L354.301 183.586L354.301 184.586L-0.379669 184.586L-0.379669 183.586Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 476.523L354.301 476.523L354.301 477.523L-0.379669 477.523L-0.379669 476.523Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 220.203L354.301 220.203L354.301 221.203L-0.379669 221.203L-0.379669 220.203Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 513.14L354.301 513.14L354.301 514.14L-0.379669 514.14L-0.379669 513.14Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 256.82L354.301 256.82L354.301 257.82L-0.379669 257.82L-0.379669 256.82Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 549.757L354.301 549.757L354.301 550.757L-0.379669 550.757L-0.379669 549.757Z" fill="#00BC1E" fill-opacity="0.1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-0.379669 586.374L354.301 586.375L354.301 587.375L-0.379669 587.374L-0.379669 586.374Z" fill="#00BC1E" fill-opacity="0.1"/>
+</g>
+<g filter="url(#filter0_d_51_161)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M183.886 297.422C155.523 242.016 171.896 202.427 184.205 189.26L187.127 191.992C176.086 203.802 159.771 241.537 187.446 295.6C201.655 323.355 204.738 351.566 203.282 374.158C202.554 385.455 200.69 395.373 198.499 403.159C196.327 410.877 193.783 416.686 191.592 419.631L188.383 417.245C190.129 414.896 192.515 409.659 194.649 402.075C196.764 394.56 198.581 384.919 199.29 373.901C200.711 351.86 197.696 324.401 183.886 297.422Z" fill="url(#paint1_linear_51_161)"/>
+</g>
+<g filter="url(#filter1_di_51_161)">
+<path d="M180.728 426.137C181.079 425.067 182.213 424.538 183.259 424.955V424.955C184.305 425.373 184.869 426.58 184.518 427.65L182.247 434.567C181.896 435.638 180.763 436.167 179.716 435.749V435.749C178.67 435.331 178.106 434.125 178.458 433.054L180.728 426.137Z" fill="#6571FF"/>
+<path d="M187.625 428.891C187.976 427.82 189.109 427.291 190.156 427.709V427.709C191.202 428.127 191.766 429.333 191.414 430.404L189.144 437.321C188.793 438.391 187.659 438.92 186.613 438.503V438.503C185.567 438.085 185.003 436.878 185.355 435.808L187.625 428.891Z" fill="#6571FF"/>
+<path d="M179.971 419.778C181.235 415.442 185.775 412.951 190.111 414.215V414.215C194.447 415.479 196.938 420.019 195.674 424.355L193.928 430.345C193.705 431.109 192.905 431.548 192.14 431.325L179.206 427.555C178.441 427.332 178.002 426.532 178.225 425.768L179.971 419.778Z" fill="#6571FF"/>
+</g>
+<g filter="url(#filter2_di_51_161)">
+<path d="M219.36 442.539C213.126 438.138 206.268 434.536 198.906 431.887C197.678 433.438 196.19 435.552 195.122 437.254C187.263 434.625 179.266 433.242 171.129 433.104C170.695 431.143 169.979 428.647 169.334 426.773C161.502 426.794 153.824 427.89 146.472 429.951C129.135 448.603 121.875 468.461 120.237 488.992C128.132 497.454 136.215 503.163 144.399 507.399C147.053 504.782 149.509 501.936 151.73 498.873C148.811 497.125 146.072 495.118 143.541 492.899C144.389 492.464 145.226 492 146.041 491.515C161.889 502.702 180.649 505.946 199.127 500.697C199.74 501.429 200.372 502.146 201.017 502.84C197.877 504.086 194.615 505.056 191.279 505.722C192.344 509.344 193.691 512.857 195.32 516.215C204.46 514.975 213.999 512.314 224.279 506.987C230.51 483.936 228.122 462.603 219.36 442.539ZM156.976 482.546C151.793 481.649 148.393 476.001 149.427 470.018C150.462 464.035 155.473 459.832 160.747 460.744C166.021 461.657 169.422 467.305 168.295 473.281C167.268 479.266 162.25 483.458 156.976 482.546ZM191.839 488.576C186.656 487.679 183.255 482.031 184.29 476.047C185.325 470.064 190.335 465.862 195.609 466.774C200.883 467.686 204.284 473.335 203.157 479.311C202.122 485.294 197.113 489.488 191.839 488.576Z" fill="#6571FF"/>
+</g>
+<g filter="url(#filter3_di_51_161)">
+<path d="M133.686 116.354H146.935V122.204H219.802V116.354H233.051C233.863 116.353 234.651 116.073 235.282 115.562C235.913 115.05 236.349 114.337 236.518 113.542C236.687 112.747 236.578 111.919 236.209 111.195C235.84 110.471 235.234 109.895 234.492 109.564L184.809 87.4954C184.356 87.2943 183.865 87.1904 183.368 87.1904C182.872 87.1904 182.381 87.2943 181.927 87.4954L132.245 109.575C131.509 109.91 130.91 110.485 130.545 111.207C130.181 111.928 130.074 112.753 130.242 113.543C130.411 114.334 130.843 115.044 131.47 115.555C132.096 116.066 132.878 116.348 133.686 116.354ZM183.368 104.916C184.808 104.916 186.216 105.344 187.413 106.144C188.611 106.944 189.544 108.081 190.095 109.411C190.646 110.742 190.79 112.206 190.509 113.618C190.228 115.03 189.534 116.327 188.516 117.345C187.497 118.364 186.2 119.057 184.787 119.337C183.375 119.618 181.911 119.474 180.581 118.922C179.251 118.371 178.114 117.437 177.314 116.24C176.514 115.042 176.088 113.635 176.088 112.195C176.089 110.264 176.856 108.413 178.221 107.048C179.586 105.683 181.438 104.916 183.368 104.916ZM130.144 129.364C130.144 128.424 130.517 127.523 131.181 126.858C131.845 126.193 132.746 125.819 133.686 125.817H146.935V125.753H219.802V125.817H233.051C233.992 125.817 234.895 126.191 235.56 126.857C236.226 127.522 236.6 128.425 236.6 129.366C236.6 130.307 236.226 131.21 235.56 131.876C234.895 132.541 233.992 132.915 233.051 132.915H231.072V182.967H207.429V167.121C207.429 154.629 197.208 144.409 184.717 144.409C172.225 144.409 162.005 154.629 162.005 167.121V182.967H135.665V132.913H133.686C132.746 132.911 131.845 132.536 131.181 131.871C130.517 131.206 130.144 130.304 130.144 129.364ZM236.593 190.086C236.593 191.027 236.219 191.93 235.554 192.596C234.888 193.261 233.985 193.635 233.044 193.635H133.686C132.745 193.635 131.842 193.261 131.177 192.596C130.511 191.93 130.137 191.027 130.137 190.086C130.137 189.145 130.511 188.242 131.177 187.577C131.842 186.911 132.745 186.538 133.686 186.538H135.665V186.523L233.051 186.538C233.991 186.539 234.892 186.914 235.556 187.579C236.22 188.245 236.593 189.146 236.593 190.086Z" fill="#965DF4"/>
+</g>
+<defs>
+<filter id="filter0_d_51_161" x="164.196" y="185.26" width="51.4128" height="246.371" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_161" result="shape"/>
+</filter>
+<filter id="filter1_di_51_161" x="167.167" y="407.886" width="39.8356" height="46.7593" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="5"/>
+<feGaussianBlur stdDeviation="5.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_161" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_161"/>
+</filter>
+<filter id="filter2_di_51_161" x="77.2369" y="401.773" width="193.535" height="175.443" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="18"/>
+<feGaussianBlur stdDeviation="21.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_161" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-4"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_161"/>
+</filter>
+<filter id="filter3_di_51_161" x="86.1372" y="75.1904" width="160.462" height="160.445" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-17" dy="15"/>
+<feGaussianBlur stdDeviation="13.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_161" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_161"/>
+</filter>
+<linearGradient id="paint0_linear_51_161" x1="177" y1="0.5" x2="177" y2="602.595" gradientUnits="userSpaceOnUse">
+<stop stop-color="#404EED"/>
+<stop offset="0.71875" stop-color="#6025C0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_51_161" x1="187.521" y1="190.626" x2="187.521" y2="396.695" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6025C0"/>
+<stop offset="1" stop-color="#6571FF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/app/assets/images/users/discord_account_required/disconnected_pf.svg
+++ b/app/assets/images/users/discord_account_required/disconnected_pf.svg
@@ -1,0 +1,118 @@
+<svg width="354" height="603" viewBox="0 0 354 603" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="url(#paint0_linear_51_111)"/>
+<mask id="mask0_51_111" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="354" height="603">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="url(#paint1_linear_51_111)"/>
+</mask>
+<g mask="url(#mask0_51_111)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M40.0528 632.559L40.0528 0.5L41.0528 0.5L41.0528 632.559L40.0528 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M85.7018 632.559L85.7019 0.5L86.7019 0.5L86.7018 632.559L85.7018 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M131.351 632.559L131.351 0.5L132.351 0.5L132.351 632.559L131.351 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M177 632.559L177 0.5L178 0.5L178 632.559L177 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M222.649 632.559L222.649 0.5L223.649 0.5L223.649 632.559L222.649 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M268.298 632.559L268.298 0.5L269.298 0.5L269.298 632.559L268.298 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M313.947 632.559L313.947 0.5L314.947 0.5L314.947 632.559L313.947 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 302.12L359.596 302.12L359.596 303.12L-5.59619 303.12L-5.59619 302.12Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 38.2024L359.596 38.2024L359.596 39.2024L-5.59619 39.2024L-5.59619 38.2024Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 339.822L359.596 339.822L359.596 340.822L-5.59619 340.822L-5.59619 339.822Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 75.905L359.596 75.905L359.596 76.905L-5.59619 76.905L-5.59619 75.905Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 377.524L359.596 377.524L359.596 378.524L-5.59619 378.524L-5.59619 377.524Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 113.607L359.596 113.607L359.596 114.607L-5.59619 114.607L-5.59619 113.607Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 415.227L359.596 415.227L359.596 416.227L-5.59619 416.227L-5.59619 415.227Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 151.31L359.596 151.31L359.596 152.31L-5.59619 152.31L-5.59619 151.31Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 452.929L359.596 452.929L359.596 453.929L-5.59619 453.929L-5.59619 452.929Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 189.012L359.596 189.012L359.596 190.012L-5.59619 190.012L-5.59619 189.012Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 490.632L359.596 490.632L359.596 491.632L-5.59619 491.632L-5.59619 490.632Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 226.715L359.596 226.715L359.596 227.715L-5.59619 227.715L-5.59619 226.715Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 528.334L359.596 528.334L359.596 529.334L-5.59619 529.334L-5.59619 528.334Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 264.417L359.596 264.417L359.596 265.417L-5.59619 265.417L-5.59619 264.417Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 566.037L359.596 566.037L359.596 567.037L-5.59619 567.037L-5.59619 566.037Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 302.12L359.596 302.12L359.596 303.12L-5.59619 303.12L-5.59619 302.12Z" fill="#D1D5FF" fill-opacity="0.63"/>
+</g>
+<g filter="url(#filter0_d_51_111)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M183.886 297.423C155.523 242.017 171.896 202.428 184.205 189.26L187.127 191.992C176.086 203.803 159.771 241.537 187.446 295.6C215.653 350.702 207.178 386.452 198.674 397.888L195.464 395.502C202.707 385.761 211.717 351.79 183.886 297.423Z" fill="url(#paint2_linear_51_111)"/>
+</g>
+<g filter="url(#filter1_di_51_111)">
+<path d="M219.36 442.539C213.126 438.138 206.268 434.536 198.906 431.887C197.677 433.438 196.19 435.552 195.122 437.254C187.263 434.625 179.266 433.242 171.129 433.104C170.695 431.143 169.979 428.647 169.334 426.773C161.502 426.794 153.824 427.89 146.471 429.951C129.135 448.603 121.875 468.461 120.237 488.992C128.132 497.454 136.215 503.163 144.399 507.399C147.053 504.782 149.509 501.936 151.73 498.873C148.811 497.125 146.072 495.118 143.54 492.899C144.389 492.464 145.226 492 146.041 491.515C161.889 502.702 180.648 505.946 199.126 500.697C199.739 501.429 200.372 502.146 201.017 502.84C197.877 504.086 194.615 505.056 191.279 505.722C192.344 509.344 193.691 512.857 195.32 516.215C204.46 514.975 213.999 512.314 224.279 506.987C230.51 483.936 228.122 462.603 219.36 442.539ZM156.976 482.546C151.793 481.649 148.393 476.001 149.427 470.018C150.462 464.035 155.473 459.832 160.747 460.744C166.021 461.657 169.422 467.305 168.295 473.281C167.268 479.266 162.25 483.458 156.976 482.546ZM191.839 488.576C186.656 487.679 183.255 482.031 184.29 476.047C185.324 470.064 190.335 465.862 195.609 466.774C200.883 467.686 204.284 473.335 203.157 479.311C202.122 485.294 197.113 489.488 191.839 488.576Z" fill="#6874FF"/>
+</g>
+<g filter="url(#filter2_di_51_111)">
+<path d="M193.101 393.147C193.553 392.128 194.745 391.667 195.765 392.119V392.119C196.785 392.57 197.246 393.763 196.794 394.783L194.302 400.41C193.85 401.43 192.657 401.891 191.638 401.439V401.439C190.618 400.988 190.157 399.795 190.609 398.775L193.101 393.147Z" fill="#6571FF"/>
+<path d="M199.822 396.123C200.274 395.104 201.467 394.643 202.487 395.095V395.095C203.506 395.546 203.967 396.739 203.515 397.759L201.023 403.386C200.572 404.406 199.379 404.867 198.359 404.415V404.415C197.339 403.964 196.879 402.771 197.33 401.751L199.822 396.123Z" fill="#6571FF"/>
+<path d="M193.064 387.099C194.892 382.969 199.723 381.104 203.853 382.933V382.933C207.983 384.761 209.848 389.592 208.019 393.722L205.493 399.426C205.171 400.154 204.319 400.483 203.591 400.161L191.272 394.705C190.544 394.383 190.215 393.531 190.537 392.803L193.064 387.099Z" fill="#6571FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M166.357 402.013C166.236 401.194 166.802 400.431 167.622 400.31L179.415 398.568C180.234 398.447 180.997 399.013 181.118 399.833C181.239 400.653 180.673 401.415 179.853 401.536L168.06 403.278C167.241 403.399 166.478 402.833 166.357 402.013Z" fill="#6571FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M224.933 406.734C224.628 407.504 223.756 407.882 222.986 407.577L211.902 403.189C211.132 402.884 210.755 402.012 211.06 401.242C211.365 400.472 212.236 400.094 213.007 400.399L224.09 404.787C224.861 405.092 225.238 405.964 224.933 406.734Z" fill="#6571FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M167.851 388.152C168.193 387.398 169.082 387.063 169.836 387.405L180.694 392.327C181.448 392.669 181.783 393.558 181.441 394.313C181.099 395.067 180.21 395.402 179.455 395.06L168.598 390.138C167.843 389.796 167.509 388.907 167.851 388.152Z" fill="#6571FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M216.709 417.992C216.035 418.474 215.098 418.319 214.616 417.646L207.674 407.955C207.192 407.281 207.347 406.344 208.02 405.862C208.694 405.379 209.631 405.534 210.113 406.208L217.055 415.899C217.537 416.572 217.382 417.509 216.709 417.992Z" fill="#6571FF"/>
+<g filter="url(#filter3_di_51_111)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M181.771 135.45C187.849 134.937 193.638 138.137 196.439 143.559C199.24 148.982 198.499 155.56 194.562 160.223C190.625 164.886 184.267 166.716 178.454 164.859C172.642 163.003 168.519 157.825 168.011 151.742C167.675 147.755 168.937 143.798 171.518 140.743C174.099 137.688 177.787 135.784 181.771 135.45ZM179.258 105.647C200.936 103.823 221.552 121.578 233.13 133.969L233.114 133.97C239.351 140.642 240.207 150.721 235.182 158.348C225.815 172.51 208.472 193.46 186.803 195.284C181.649 195.665 176.469 195.078 171.53 193.556L170.2 177.756C182.582 183.601 197.345 180.392 206.184 169.932C215.023 159.473 215.732 144.376 207.912 133.133C200.092 121.889 185.695 117.307 172.82 121.964C159.945 126.62 151.806 139.352 152.981 152.999L155.78 186.258C146.599 180.561 138.661 173.097 132.931 166.971C126.689 160.292 125.84 150.203 130.878 142.575C140.246 128.422 157.58 107.472 179.258 105.647Z" fill="#965DF4"/>
+</g>
+<defs>
+<filter id="filter0_d_51_111" x="164.196" y="185.26" width="54.6502" height="224.628" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_111"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_111" result="shape"/>
+</filter>
+<filter id="filter1_di_51_111" x="77.2369" y="401.773" width="193.535" height="175.442" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="18"/>
+<feGaussianBlur stdDeviation="21.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_111"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_111" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-4"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_111"/>
+</filter>
+<filter id="filter2_di_51_111" x="179.414" y="376.23" width="40.308" height="44.3589" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="5"/>
+<feGaussianBlur stdDeviation="5.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_111"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_111" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_111"/>
+</filter>
+<filter id="filter3_di_51_111" x="83.6049" y="93.5171" width="164.837" height="143.879" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-17" dy="15"/>
+<feGaussianBlur stdDeviation="13.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_111"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_111" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_111"/>
+</filter>
+<linearGradient id="paint0_linear_51_111" x1="177" y1="0.5" x2="177" y2="602.595" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ECEBF9"/>
+<stop offset="1" stop-color="#EDF6FB"/>
+</linearGradient>
+<linearGradient id="paint1_linear_51_111" x1="177" y1="0.5" x2="177" y2="602.595" gradientUnits="userSpaceOnUse">
+<stop stop-color="#404EED"/>
+<stop offset="0.71875" stop-color="#6025C0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_51_111" x1="187.521" y1="190.626" x2="187.521" y2="396.695" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6025C0"/>
+<stop offset="1" stop-color="#6571FF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/app/assets/images/users/discord_account_required/disconnected_school.svg
+++ b/app/assets/images/users/discord_account_required/disconnected_school.svg
@@ -1,0 +1,118 @@
+<svg width="354" height="603" viewBox="0 0 354 603" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="url(#paint0_linear_51_50)"/>
+<mask id="mask0_51_50" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="354" height="603">
+<path d="M0.5 12.5C0.5 5.87255 5.87258 0.5 12.5 0.5H341.5C348.127 0.5 353.5 5.87258 353.5 12.5V590.595C353.5 597.222 348.127 602.595 341.5 602.595H12.5C5.87258 602.595 0.5 597.222 0.5 590.595V12.5Z" fill="url(#paint1_linear_51_50)"/>
+</mask>
+<g mask="url(#mask0_51_50)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M40.0528 632.559L40.0528 0.5L41.0528 0.5L41.0528 632.559L40.0528 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M85.7018 632.559L85.7019 0.5L86.7019 0.5L86.7018 632.559L85.7018 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M131.351 632.559L131.351 0.5L132.351 0.5L132.351 632.559L131.351 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M177 632.559L177 0.5L178 0.5L178 632.559L177 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M222.649 632.559L222.649 0.5L223.649 0.5L223.649 632.559L222.649 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M268.298 632.559L268.298 0.5L269.298 0.5L269.298 632.559L268.298 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M313.947 632.559L313.947 0.5L314.947 0.5L314.947 632.559L313.947 632.559Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 302.12L359.596 302.12L359.596 303.12L-5.59619 303.12L-5.59619 302.12Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 38.2024L359.596 38.2024L359.596 39.2024L-5.59619 39.2024L-5.59619 38.2024Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 339.822L359.596 339.822L359.596 340.822L-5.59619 340.822L-5.59619 339.822Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 75.905L359.596 75.905L359.596 76.905L-5.59619 76.905L-5.59619 75.905Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 377.524L359.596 377.524L359.596 378.524L-5.59619 378.524L-5.59619 377.524Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 113.607L359.596 113.607L359.596 114.607L-5.59619 114.607L-5.59619 113.607Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 415.227L359.596 415.227L359.596 416.227L-5.59619 416.227L-5.59619 415.227Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 151.31L359.596 151.31L359.596 152.31L-5.59619 152.31L-5.59619 151.31Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 452.929L359.596 452.929L359.596 453.929L-5.59619 453.929L-5.59619 452.929Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 189.012L359.596 189.012L359.596 190.012L-5.59619 190.012L-5.59619 189.012Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 490.632L359.596 490.632L359.596 491.632L-5.59619 491.632L-5.59619 490.632Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 226.715L359.596 226.715L359.596 227.715L-5.59619 227.715L-5.59619 226.715Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 528.334L359.596 528.334L359.596 529.334L-5.59619 529.334L-5.59619 528.334Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 264.417L359.596 264.417L359.596 265.417L-5.59619 265.417L-5.59619 264.417Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 566.036L359.596 566.036L359.596 567.036L-5.59619 567.036L-5.59619 566.036Z" fill="#D1D5FF" fill-opacity="0.63"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M-5.59619 302.119L359.596 302.119L359.596 303.119L-5.59619 303.119L-5.59619 302.119Z" fill="#D1D5FF" fill-opacity="0.63"/>
+</g>
+<g filter="url(#filter0_d_51_50)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M183.886 297.422C155.523 242.016 171.896 202.427 184.205 189.26L187.127 191.992C176.086 203.802 159.771 241.537 187.446 295.6C215.653 350.701 207.178 386.451 198.674 397.888L195.464 395.501C202.707 385.761 211.717 351.79 183.886 297.422Z" fill="url(#paint2_linear_51_50)"/>
+</g>
+<g filter="url(#filter1_di_51_50)">
+<path d="M133.686 116.354H146.935V122.204H219.802V116.354H233.051C233.863 116.353 234.651 116.073 235.282 115.562C235.913 115.05 236.349 114.337 236.518 113.542C236.687 112.747 236.578 111.919 236.209 111.195C235.84 110.471 235.234 109.895 234.492 109.564L184.809 87.4954C184.356 87.2943 183.865 87.1904 183.368 87.1904C182.872 87.1904 182.381 87.2943 181.927 87.4954L132.245 109.575C131.509 109.91 130.91 110.485 130.546 111.207C130.181 111.928 130.074 112.753 130.243 113.543C130.411 114.334 130.844 115.044 131.47 115.555C132.096 116.066 132.878 116.348 133.686 116.354ZM183.368 104.916C184.808 104.916 186.216 105.344 187.413 106.144C188.611 106.944 189.544 108.081 190.095 109.411C190.646 110.742 190.79 112.206 190.509 113.618C190.228 115.03 189.534 116.327 188.516 117.345C187.497 118.364 186.2 119.057 184.787 119.337C183.375 119.618 181.911 119.474 180.581 118.922C179.251 118.371 178.114 117.437 177.314 116.24C176.514 115.042 176.088 113.635 176.088 112.195C176.089 110.264 176.856 108.413 178.221 107.048C179.586 105.683 181.438 104.916 183.368 104.916ZM130.144 129.364C130.144 128.424 130.517 127.523 131.181 126.858C131.845 126.193 132.746 125.819 133.686 125.817H146.935V125.753H219.802V125.817H233.051C233.992 125.817 234.895 126.191 235.56 126.857C236.226 127.522 236.6 128.425 236.6 129.366C236.6 130.307 236.226 131.21 235.56 131.876C234.895 132.541 233.992 132.915 233.051 132.915H231.072V182.967H207.429V167.121C207.429 154.629 197.209 144.409 184.717 144.409C172.225 144.409 162.005 154.629 162.005 167.121V182.967H135.665V132.913H133.686C132.746 132.911 131.845 132.536 131.181 131.871C130.517 131.206 130.144 130.304 130.144 129.364ZM236.593 190.086C236.593 191.027 236.219 191.93 235.554 192.596C234.888 193.261 233.986 193.635 233.044 193.635H133.686C132.745 193.635 131.842 193.261 131.177 192.596C130.511 191.93 130.137 191.027 130.137 190.086C130.137 189.145 130.511 188.242 131.177 187.577C131.842 186.911 132.745 186.538 133.686 186.538H135.665V186.523L233.051 186.538C233.991 186.539 234.892 186.914 235.556 187.579C236.22 188.245 236.593 189.146 236.593 190.086Z" fill="#965DF4"/>
+</g>
+<g filter="url(#filter2_di_51_50)">
+<path d="M219.36 442.539C213.126 438.138 206.268 434.536 198.906 431.887C197.677 433.438 196.19 435.552 195.122 437.254C187.263 434.625 179.266 433.242 171.129 433.104C170.695 431.143 169.979 428.647 169.334 426.773C161.502 426.794 153.824 427.89 146.471 429.951C129.135 448.603 121.875 468.461 120.237 488.992C128.132 497.454 136.215 503.163 144.399 507.399C147.053 504.782 149.509 501.936 151.73 498.873C148.811 497.125 146.072 495.118 143.54 492.899C144.389 492.464 145.226 492 146.041 491.515C161.889 502.702 180.648 505.946 199.126 500.697C199.739 501.429 200.372 502.146 201.017 502.84C197.877 504.086 194.615 505.056 191.279 505.722C192.344 509.344 193.691 512.857 195.32 516.215C204.46 514.975 213.999 512.314 224.279 506.987C230.51 483.936 228.122 462.603 219.36 442.539ZM156.976 482.546C151.793 481.649 148.393 476.001 149.427 470.018C150.462 464.035 155.473 459.832 160.747 460.744C166.021 461.657 169.422 467.305 168.295 473.281C167.268 479.266 162.25 483.458 156.976 482.546ZM191.839 488.576C186.656 487.679 183.255 482.031 184.29 476.047C185.324 470.064 190.335 465.862 195.609 466.774C200.883 467.686 204.284 473.335 203.157 479.311C202.122 485.294 197.113 489.488 191.839 488.576Z" fill="#6874FF"/>
+</g>
+<g filter="url(#filter3_di_51_50)">
+<path d="M193.101 393.147C193.553 392.128 194.745 391.667 195.765 392.119V392.119C196.785 392.57 197.246 393.763 196.794 394.783L194.302 400.41C193.85 401.43 192.657 401.891 191.638 401.439V401.439C190.618 400.988 190.157 399.795 190.609 398.775L193.101 393.147Z" fill="#6571FF"/>
+<path d="M199.822 396.124C200.274 395.104 201.467 394.643 202.487 395.095V395.095C203.506 395.547 203.967 396.74 203.515 397.759L201.023 403.387C200.572 404.407 199.379 404.867 198.359 404.416V404.416C197.339 403.964 196.879 402.771 197.33 401.752L199.822 396.124Z" fill="#6571FF"/>
+<path d="M193.064 387.099C194.892 382.969 199.723 381.104 203.853 382.933V382.933C207.983 384.762 209.848 389.592 208.019 393.722L205.493 399.426C205.171 400.155 204.319 400.483 203.591 400.161L191.272 394.706C190.544 394.383 190.215 393.532 190.537 392.804L193.064 387.099Z" fill="#6571FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M166.357 402.013C166.236 401.194 166.802 400.431 167.622 400.31L179.415 398.569C180.234 398.447 180.997 399.014 181.118 399.833C181.239 400.653 180.673 401.415 179.853 401.536L168.06 403.278C167.241 403.399 166.478 402.833 166.357 402.013Z" fill="#6571FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M224.933 406.734C224.628 407.504 223.756 407.882 222.986 407.577L211.902 403.189C211.132 402.884 210.755 402.012 211.06 401.242C211.365 400.472 212.236 400.094 213.007 400.399L224.09 404.787C224.861 405.092 225.238 405.964 224.933 406.734Z" fill="#6571FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M167.851 388.152C168.193 387.398 169.082 387.063 169.836 387.405L180.694 392.327C181.448 392.669 181.783 393.558 181.441 394.313C181.099 395.067 180.21 395.402 179.455 395.06L168.598 390.138C167.843 389.796 167.509 388.907 167.851 388.152Z" fill="#6571FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M216.709 417.991C216.035 418.474 215.098 418.319 214.616 417.646L207.674 407.954C207.192 407.281 207.347 406.344 208.02 405.862C208.694 405.379 209.631 405.534 210.113 406.207L217.055 415.899C217.537 416.572 217.382 417.509 216.709 417.991Z" fill="#6571FF"/>
+<defs>
+<filter id="filter0_d_51_50" x="164.196" y="185.26" width="54.6502" height="224.628" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_50"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_50" result="shape"/>
+</filter>
+<filter id="filter1_di_51_50" x="86.1373" y="75.1904" width="160.462" height="160.445" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-17" dy="15"/>
+<feGaussianBlur stdDeviation="13.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_50"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_50" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_50"/>
+</filter>
+<filter id="filter2_di_51_50" x="77.2369" y="401.773" width="193.535" height="175.443" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="18"/>
+<feGaussianBlur stdDeviation="21.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_50"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_50" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-4"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_50"/>
+</filter>
+<filter id="filter3_di_51_50" x="179.414" y="376.23" width="40.308" height="44.3591" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="5"/>
+<feGaussianBlur stdDeviation="5.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_51_50"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_51_50" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_51_50"/>
+</filter>
+<linearGradient id="paint0_linear_51_50" x1="177" y1="0.5" x2="177" y2="602.595" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ECEBF9"/>
+<stop offset="1" stop-color="#EDF6FB"/>
+</linearGradient>
+<linearGradient id="paint1_linear_51_50" x1="177" y1="0.5" x2="177" y2="602.595" gradientUnits="userSpaceOnUse">
+<stop stop-color="#404EED"/>
+<stop offset="0.71875" stop-color="#6025C0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_51_50" x1="187.521" y1="190.626" x2="187.521" y2="396.695" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6025C0"/>
+<stop offset="1" stop-color="#6571FF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/app/controllers/concerns/discord_account_requirable.rb
+++ b/app/controllers/concerns/discord_account_requirable.rb
@@ -17,7 +17,9 @@ module DiscordAccountRequirable
     end
 
     if course.discord_account_required?
-      redirect_to edit_user_path(course_requiring_discord: course.id)
+      redirect_to discord_account_required_user_path(
+                    course_requiring_discord: course.id
+                  )
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -127,9 +127,6 @@ class UsersController < ApplicationController
 
         session.delete(:course_requiring_discord)
         course
-      else
-        redirect_to dashboard_path
-        return
       end
 
     render layout: "tailwind"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,24 +7,13 @@ class UsersController < ApplicationController
     @user = authorize(current_user)
   end
 
+  # GET /user/edit
   def edit
     @user = authorize(current_user)
 
-    @course_requiring_discord_account =
-      if params[:course_requiring_discord].present? &&
-           !current_user.discord_account_connected?
-        course =
-          current_user.courses.find_by(id: params[:course_requiring_discord])
-
-        session[:course_requiring_discord] = course.id if course.present?
-        course
-      elsif session.key?(:course_requiring_discord)
-        course =
-          current_user.courses.find_by(id: session[:course_requiring_discord])
-
-        session.delete(:course_requiring_discord)
-        course
-      end
+    if session.key?(:course_requiring_discord)
+      redirect_to discord_account_required_user_path
+    end
   end
 
   # GET /users/delete_account
@@ -118,5 +107,30 @@ class UsersController < ApplicationController
       flash[:error] = t(".link_expired")
       redirect_to edit_user_path
     end
+  end
+
+  # GET /user/discord_account_required?course_requiring_discord
+  def discord_account_required
+    @user = authorize(current_user)
+
+    @course_requiring_discord_account =
+      if params[:course_requiring_discord].present? &&
+           !current_user.discord_account_connected?
+        course =
+          current_user.courses.find_by(id: params[:course_requiring_discord])
+
+        session[:course_requiring_discord] = course.id if course.present?
+        course
+      elsif session.key?(:course_requiring_discord)
+        course =
+          current_user.courses.find_by(id: session[:course_requiring_discord])
+
+        session.delete(:course_requiring_discord)
+        course
+      else
+        redirect_to dashboard_path
+      end
+
+    render layout: "tailwind"
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -129,6 +129,7 @@ class UsersController < ApplicationController
         course
       else
         redirect_to dashboard_path
+        return
       end
 
     render layout: "tailwind"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -111,7 +111,7 @@ class UsersController < ApplicationController
 
   # GET /user/discord_account_required?course_requiring_discord
   def discord_account_required
-    @user = authorize(current_user)
+    authorize(current_user)
 
     @course_requiring_discord_account =
       if params[:course_requiring_discord].present? &&

--- a/app/frontend/shared/components/HelpIcon.res
+++ b/app/frontend/shared/components/HelpIcon.res
@@ -83,3 +83,32 @@ let make = (~className="", ~link=?, ~responsiveAlignment=NonResponsive(AlignCent
       : React.null}
   </div>
 }
+
+let makeFromJson = json => {
+  open Json.Decode
+
+  let responsiveAlignment = optional(
+    field("responsiveAlignment", string),
+    json,
+  )->Belt.Option.map(responsiveAlignment =>
+    switch responsiveAlignment {
+    | "nlr" => NonResponsive(AlignLeft)
+    | "nrc" => NonResponsive(AlignCenter)
+    | "nrr" => NonResponsive(AlignRight)
+    | "rlr" => Responsive(AlignLeft, AlignRight)
+    | "rrl" => Responsive(AlignRight, AlignLeft)
+    | "rlc" => Responsive(AlignLeft, AlignCenter)
+    | "rcl" => Responsive(AlignCenter, AlignLeft)
+    | "rrc" => Responsive(AlignRight, AlignCenter)
+    | "rcr" => Responsive(AlignCenter, AlignRight)
+    | _ => NonResponsive(AlignCenter)
+    }
+  )
+
+  make({
+    "className": optional(field("className", string), json),
+    "link": optional(field("className", string), json),
+    "responsiveAlignment": responsiveAlignment,
+    "children": <div dangerouslySetInnerHTML={{"__html": field("children", string, json)}} />,
+  })
+}

--- a/app/frontend/shared/components/HelpIcon.res
+++ b/app/frontend/shared/components/HelpIcon.res
@@ -107,7 +107,7 @@ let makeFromJson = json => {
 
   make({
     "className": optional(field("className", string), json),
-    "link": optional(field("className", string), json),
+    "link": optional(field("link", string), json),
     "responsiveAlignment": responsiveAlignment,
     "children": <div dangerouslySetInnerHTML={{"__html": field("children", string, json)}} />,
   })

--- a/app/frontend/shared/components/HelpIcon.res
+++ b/app/frontend/shared/components/HelpIcon.res
@@ -92,7 +92,7 @@ let makeFromJson = json => {
     json,
   )->Belt.Option.map(responsiveAlignment =>
     switch responsiveAlignment {
-    | "nlr" => NonResponsive(AlignLeft)
+    | "nrl" => NonResponsive(AlignLeft)
     | "nrc" => NonResponsive(AlignCenter)
     | "nrr" => NonResponsive(AlignRight)
     | "rlr" => Responsive(AlignLeft, AlignRight)

--- a/app/frontend/shared/reComponentLoader.js
+++ b/app/frontend/shared/reComponentLoader.js
@@ -10,6 +10,7 @@ import { makeFromJson as MarkdownBlock } from "~/shared/components/MarkdownBlock
 import { makeFromJson as SimpleMarkdownEditor } from "~/shared/components/SimpleMarkdownEditor.bs.js";
 import { makeFromJson as SelectLink } from "~/shared/components/SelectLink.bs.js";
 import { makeFromJson as SimpleMultiSelectInline } from "~/shared/components/SimpleMultiSelectInline.bs.js";
+import { makeFromJson as HelpIcon } from "~/shared/components/HelpIcon.bs.js";
 
 const selectComponent = (name) => {
   switch (name) {
@@ -31,6 +32,8 @@ const selectComponent = (name) => {
       return SimpleMultiSelectInline;
     case "SelectLink":
       return SelectLink;
+    case "HelpIcon":
+      return HelpIcon;
     default:
       throw new Error(`Unknown component name: ${name}`);
   }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -8,4 +8,9 @@ class UserPolicy < ApplicationPolicy
     # All users can edit their profile.
     true
   end
+
+  def discord_account_required?
+    # All users can visit the Discord account requirement page.
+    true
+  end
 end

--- a/app/presenters/users/discord_account_required_presenter.rb
+++ b/app/presenters/users/discord_account_required_presenter.rb
@@ -1,0 +1,11 @@
+module Users
+  class DiscordAccountRequiredPresenter < EditPresenter
+    def image_path
+      prefix =
+        current_user.discord_account_connected? ? "connected" : "disconnected"
+
+      suffix = current_school.name.include?("Pupilfirst") ? "pf" : "school"
+      view.image_path("users/discord_account_required/#{prefix}_#{suffix}.svg")
+    end
+  end
+end

--- a/app/views/layouts/_footer_bottom.html.erb
+++ b/app/views/layouts/_footer_bottom.html.erb
@@ -9,7 +9,7 @@
             <img
                 class="w-27"
                 src="<%= presenter.logo_url %>"
-                alt="t('.logo') <%= presenter.school_name %>"
+                alt="<%= t(".logo_alt", school_name: presenter.school_name) %>"
               />
             <% else %>
               <span><%= presenter.school_name %></span>

--- a/app/views/layouts/_footer_bottom.html.erb
+++ b/app/views/layouts/_footer_bottom.html.erb
@@ -1,0 +1,32 @@
+<section class="w-full footer__bottom">
+  <div
+      class="flex flex-row w-full xl:max-w-5xl mx-auto justify-between items-start px-3"
+    >
+    <div class="w-full flex flex-row justify-between items-center">
+      <div class="w-1/4 my-4">
+        <a class="text-xs focus:outline-none" href="/">
+          <% if presenter.logo? %>
+            <img
+                class="w-27"
+                src="<%= presenter.logo_url %>"
+                alt="t('.logo') <%= presenter.school_name %>"
+              />
+            <% else %>
+              <span><%= presenter.school_name %></span>
+          <% end %>
+        </a>
+      </div>
+      <div class="w-3/4 md:w-2/5 ltr:text-right rtl:text-left text-xs">
+        <% if presenter.privacy_policy? %>
+          <%= link_to t(".privacy_policy"), agreement_path(agreement_type: 'privacy-policy'), class: "cursor-pointer me-3 hover:text-primary-500 focus:outline-none focus:text-primary-500" %>
+        <% end %>
+        <% if presenter.terms_and_conditions? %>
+          <%= link_to t(".terms_conditions"), agreement_path(agreement_type: 'terms-and-conditions'), class: "cursor-pointer md:me-3 hover:text-primary-500 focus:outline-none focus:text-primary-500" %>
+        <% end %>
+        <span class="text-gray-600 mt-1 md:mt-0 block md:inline-block">
+          &copy; <%= Time.zone.now.year %> <%= presenter.school_name %>.
+        </span>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/layouts/_student_footer.html.erb
+++ b/app/views/layouts/_student_footer.html.erb
@@ -1,5 +1,4 @@
 <% presenter = ::Layouts::FooterPresenter.new(self) %>
-
 <footer class="footer__container shrink-0 border-t">
   <section
     class="flex flex-col md:flex-row w-full lg:max-w-5xl mx-auto justify-between items-start py-8 px-3"
@@ -9,7 +8,6 @@
         <span class="uppercase font-bold text-xs py-2 tracking-wide"
           ><%= t('.sitemap') %></span
         >
-
         <div id="bottom-nav-container" class="w-full flex flex-row flex-wrap text-xs font-semibold">
           <% presenter.nav_links.each do |nav_link| %>
             <div class="w-1/3">
@@ -54,7 +52,6 @@
       <div class="text-xs">
         <% if presenter.address.present? %>
           <p class="uppercase font-bold text-xs py-2 tracking-wide"><%= t('.contact') %></p>
-
           <address class="font-semibold leading-normal not-italic">
             <%= presenter.address.html_safe %>
           </address>
@@ -72,39 +69,5 @@
       </div>
     </div>
   </section>
-
-  <section class="w-full footer__bottom">
-    <div
-      class="flex flex-row w-full xl:max-w-5xl mx-auto justify-between items-start px-3"
-    >
-      <div class="w-full flex flex-row justify-between items-center">
-        <div class="w-1/4 my-4">
-          <a class="text-xs focus:outline-none" href="/">
-            <% if presenter.logo? %>
-              <img
-                class="w-27"
-                src="<%= presenter.logo_url %>"
-                alt="t('.logo') <%= presenter.school_name %>"
-              />
-            <% else %>
-              <span><%= presenter.school_name %></span>
-            <% end %>
-          </a>
-        </div>
-
-        <div class="w-3/4 md:w-2/5 ltr:text-right rtl:text-left text-xs">
-          <% if presenter.privacy_policy? %>
-            <%= link_to t(".privacy_policy"), agreement_path(agreement_type: 'privacy-policy'), class: "cursor-pointer me-3 hover:text-primary-500 focus:outline-none focus:text-primary-500" %>
-          <% end %>
-          <% if presenter.terms_and_conditions? %>
-            <%= link_to t(".terms_conditions"), agreement_path(agreement_type: 'terms-and-conditions'), class: "cursor-pointer md:me-3 hover:text-primary-500 focus:outline-none focus:text-primary-500" %>
-          <% end %>
-
-          <span class="text-gray-600 mt-1 md:mt-0 block md:inline-block">
-            &copy; <%= Time.zone.now.year %> <%= presenter.school_name %>.
-          </span>
-        </div>
-      </div>
-    </div>
-  </section>
+  <%= render 'layouts/footer_bottom', presenter: presenter %>
 </footer>

--- a/app/views/layouts/tailwind.html.erb
+++ b/app/views/layouts/tailwind.html.erb
@@ -63,18 +63,22 @@
   </head>
 
   <body data-host="<%= current_host %>">
-        <section class="min-h-full flex flex-col items-stretch">
-          <%= yield :nav %>
-          <main class="grow bg-white">
-            <% if content_for?(:wrapper) %>
-              <%= yield :wrapper %>
-            <% else %>
-              <%= yield %>
-            <% end %>
-          </main>
-          <%= yield :tail %>
-          <%= yield :footer %>
-        </section>
+        <% if content_for?(:container) %>
+          <%= yield :container %>
+        <% else %>
+          <section class="min-h-full flex flex-col items-stretch">
+            <%= yield :nav %>
+            <main class="grow bg-white">
+              <% if content_for?(:wrapper) %>
+                <%= yield :wrapper %>
+              <% else %>
+                <%= yield %>
+              <% end %>
+            </main>
+            <%= yield :tail %>
+            <%= yield :footer %>
+          </section>
+        <% end %>
         <!-- Initialize Rollbar only at the very end. -->
         <%= vite_javascript_tag 'rollbar', nonce: true %>
         <!-- Rails specific scripts. -->

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -7,8 +7,8 @@
   <div class="flex flex-col items-stretch min-h-screen">
     <section class="flex grow bg-gray-50 items-center justify-center">
       <div class="container mx-auto p-4 max-w-4xl">
-        <div class="flex md:items-center flex-col-reverse items-start md:flex-row">
-          <div class="mt-4 md:mt-0 md:mr-6 md:w-1/2">
+        <div class="flex items-center">
+          <div class="py-4 md:py-0 md:mr-6 md:w-1/2">
             <% if current_user.discord_account_connected? %>
               <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
               <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
@@ -64,7 +64,7 @@
               <% end %>
             <% end %>
           </div>
-          <%= image_tag presenter.image_path, class: "h-48 md:h-auto md:ml-6 md:w-1/2" %>
+          <%= image_tag presenter.image_path, class: "hidden md:block md:ml-6 md:w-1/2" %>
         </div>
       </div>
     </section>

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -3,66 +3,71 @@
   <title><%= t(".page_title") %></title>
   <%= vite_javascript_tag 'tailwind', nonce: true %>
 <% end %>
-<div class="flex min-h-screen bg-gray-50 items-center justify-center">
-  <div class="container mx-auto p-4 max-w-4xl">
-    <div class="flex md:items-center flex-col-reverse items-start md:flex-row">
-      <div class="mt-4 md:mt-0 md:mr-6 md:w-1/2">
-        <% if current_user.discord_account_connected? %>
-          <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
-          <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
-          <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
-          <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
-          <% if @course_requiring_discord_account.present? %>
-            <%= link_to curriculum_course_path(@course_requiring_discord_account), class: "btn btn-primary btn-large mt-4" do %>
-              <i class="if i-book-regular if-fw text-lg" ></i>
-              <span class="ml-2">
-                <%= t(".linked.go_to_course_button") %>
-              </span>
+<% content_for(:container) do %>
+  <div class="flex flex-col items-stretch">
+    <div class="flex grow bg-gray-50 items-center justify-center">
+      <div class="container mx-auto p-4 max-w-4xl">
+        <div class="flex md:items-center flex-col-reverse items-start md:flex-row">
+          <div class="mt-4 md:mt-0 md:mr-6 md:w-1/2">
+            <% if current_user.discord_account_connected? %>
+              <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
+              <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
+              <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
+              <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
+              <% if @course_requiring_discord_account.present? %>
+                <%= link_to curriculum_course_path(@course_requiring_discord_account), class: "btn btn-primary btn-large mt-4" do %>
+                  <i class="if i-book-regular if-fw text-lg" ></i>
+                  <span class="ml-2">
+                    <%= t(".linked.go_to_course_button") %>
+                  </span>
+                <% end %>
+              <% else %>
+                <%= link_to dashboard_path, class: "btn btn-primary btn-large mt-4" do %>
+                  <i class="if i-home-regular if-fw text-lg" ></i>
+                  <span class="ml-2">
+                    <%= t(".linked.go_to_dashboard_button") %>
+                  </span>
+                <% end %>
+              <% end %>
+            <% else %>
+              <h1 class="text-3xl font-bold"><%= t(".unlinked.heading") %></h1>
+              <p class="mt-2"><%= t(".unlinked.description", school_name: current_school.name) %></p>
+              <section class="mt-4">
+                <p class="font-semibold"><%= t(".unlinked.process.prefix") %></p>
+                <div class="flex mt-4">
+                  <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                    <%= t(".unlinked.process.step_1_label") %>
+                  </span>
+                  <span class="ml-3"><%= t(".unlinked.process.step_1_description_html") %></span>
+                </div>
+                <div class="flex mt-2">
+                  <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                    <%= t(".unlinked.process.step_2_label") %>
+                  </span>
+                  <span class="ml-3">
+                    <%= t(".unlinked.process.step_2_description_html") %>
+                    <span data-re-component="HelpIcon" data-re-json='<%= {children: t(".unlinked.process.step_2_help_html"), className: 'text-xs', responsiveAlignment: 'rrc'}.to_json %>'></span>
+                  </span>
+                </div>
+                <div class="flex mt-2">
+                  <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                    <%= t(".unlinked.process.step_3_label") %>
+                  </span>
+                  <span class="ml-3"><%= t(".unlinked.process.step_3_description_html") %></span>
+                </div>
+              </section>
+              <%= link_to presenter.discord_federated_login_url, class: 'btn btn-primary btn-large mt-4' do %>
+                <i class="if i-discord if-fw text-lg"></i>
+                <span class="ml-2">
+                  <%= t(".unlinked.link_discord_button") %>
+                </span>
+              <% end %>
             <% end %>
-          <% else %>
-            <%= link_to dashboard_path, class: "btn btn-primary btn-large mt-4" do %>
-              <i class="if i-home-regular if-fw text-lg" ></i>
-              <span class="ml-2">
-                <%= t(".linked.go_to_dashboard_button") %>
-              </span>
-            <% end %>
-          <% end %>
-        <% else %>
-          <h1 class="text-3xl font-bold"><%= t(".unlinked.heading") %></h1>
-          <p class="mt-2"><%= t(".unlinked.description", school_name: current_school.name) %></p>
-          <section class="mt-4">
-            <p class="font-semibold"><%= t(".unlinked.process.prefix") %></p>
-            <div class="flex mt-4">
-              <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
-                <%= t(".unlinked.process.step_1_label") %>
-              </span>
-              <span class="ml-3"><%= t(".unlinked.process.step_1_description_html") %></span>
-            </div>
-            <div class="flex mt-2">
-              <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
-                <%= t(".unlinked.process.step_2_label") %>
-              </span>
-              <span class="ml-3">
-                <%= t(".unlinked.process.step_2_description_html") %>
-                <span data-re-component="HelpIcon" data-re-json='<%= {children: t(".unlinked.process.step_2_help_html"), className: 'text-xs', responsiveAlignment: 'rrc'}.to_json %>'></span>
-              </span>
-            </div>
-            <div class="flex mt-2">
-              <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
-                <%= t(".unlinked.process.step_3_label") %>
-              </span>
-              <span class="ml-3"><%= t(".unlinked.process.step_3_description_html") %></span>
-            </div>
-          </section>
-          <%= link_to presenter.discord_federated_login_url, class: 'btn btn-primary btn-large mt-4' do %>
-            <i class="if i-discord if-fw text-lg"></i>
-            <span class="ml-2">
-              <%= t(".unlinked.link_discord_button") %>
-            </span>
-          <% end %>
-        <% end %>
+          </div>
+          <%= image_tag presenter.image_path, class: "h-48 md:h-auto md:ml-6 md:w-1/2" %>
+        </div>
       </div>
-      <%= image_tag presenter.image_path, class: "h-48 md:h-auto md:ml-6 md:w-1/2" %>
     </div>
+    <%= render 'layouts/footer_bottom', presenter: ::Layouts::FooterPresenter.new(self) %>
   </div>
-</div>
+<% end %>

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -10,7 +10,7 @@
         <div class="flex items-center">
           <div class="py-4 md:py-0 md:mr-6 md:w-1/2">
             <% if current_user.discord_account_connected? %>
-              <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
+              <i class="text-green-600 text-7xl if i-badge-check-solid if-fw" ></i>
               <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
               <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
               <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -1,0 +1,60 @@
+<% content_for(:head) do %>
+  <title><%= t(".page_title") %></title>
+  <%= vite_javascript_tag 'tailwind', nonce: true %>
+<% end %>
+<div class="flex min-h-screen bg-gray-50 items-center justify-center">
+  <div class="py-8 w-full">
+    <div class="container mx-auto px-3 max-w-3xl">
+      <div class="flex">
+        <div class="p-2 w-1/2">
+          <% if false %>
+            <h1 class="text-2xl font-bold"><%= t(".unlinked.heading") %></h1>
+            <p class="mt-2"><%= t(".unlinked.description", school_name: current_school.name) %></p>
+            <section class="mt-4">
+              <p class="font-semibold"><%= t(".unlinked.process.prefix") %></p>
+              <div class="flex mt-4">
+                <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                  <%= t(".unlinked.process.step_1_label") %>
+                </span>
+                <span class="ml-3"><%= t(".unlinked.process.step_1_description_html") %></span>
+              </div>
+              <div class="flex mt-2">
+                <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                  <%= t(".unlinked.process.step_2_label") %>
+                </span>
+                <span class="ml-3">
+                  <%= t(".unlinked.process.step_2_description_html") %>
+                  <span data-re-component="HelpIcon" data-re-json='<%= {children: t(".unlinked.process.step_2_help_html"), className: 'text-xs'}.to_json %>'></span>
+                </span>
+              </div>
+              <div class="flex mt-2">
+                <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                  <%= t(".unlinked.process.step_3_label") %>
+                </span>
+                <span class="ml-3"><%= t(".unlinked.process.step_3_description_html") %></span>
+              </div>
+            </section>
+            <button class="btn btn-primary btn-large mt-4">
+              <i class="if i-discord if-fw"></i>
+              <span class="ml-2">
+                <%= t(".unlinked.link_discord_button") %>
+              </span>
+            </button>
+          <% else %>
+            <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
+            <h1 class="mt-3 text-2xl font-bold"><%= t(".linked.heading") %></h1>
+            <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
+            <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
+            <button class="btn btn-primary btn-large mt-4">
+              <i class="if i-book-regular if-fw" ></i>
+              <span class="ml-2">
+                <%= t(".linked.go_to_course_button") %>
+              </span>
+            </button>
+          <% end %>
+        </div>
+        <div class="p-2 w-1/2">Right side</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -4,8 +4,8 @@
   <%= vite_javascript_tag 'tailwind', nonce: true %>
 <% end %>
 <% content_for(:container) do %>
-  <div class="flex flex-col items-stretch">
-    <div class="flex grow bg-gray-50 items-center justify-center">
+  <div class="flex flex-col items-stretch min-h-screen">
+    <section class="flex grow bg-gray-50 items-center justify-center">
       <div class="container mx-auto p-4 max-w-4xl">
         <div class="flex md:items-center flex-col-reverse items-start md:flex-row">
           <div class="mt-4 md:mt-0 md:mr-6 md:w-1/2">
@@ -67,7 +67,7 @@
           <%= image_tag presenter.image_path, class: "h-48 md:h-auto md:ml-6 md:w-1/2" %>
         </div>
       </div>
-    </div>
+    </section>
     <%= render 'layouts/footer_bottom', presenter: ::Layouts::FooterPresenter.new(self) %>
   </div>
 <% end %>

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -1,70 +1,68 @@
-<% user_edit_presenter = Users::EditPresenter.new(self) %>
+<% presenter = Users::DiscordAccountRequiredPresenter.new(self) %>
 <% content_for(:head) do %>
   <title><%= t(".page_title") %></title>
   <%= vite_javascript_tag 'tailwind', nonce: true %>
 <% end %>
 <div class="flex min-h-screen bg-gray-50 items-center justify-center">
-  <div class="py-8 w-full">
-    <div class="container mx-auto px-3 max-w-4xl">
-      <div class="flex">
-        <div class="mr-6 w-1/2">
-          <% if current_user.discord_account_connected? %>
-            <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
-            <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
-            <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
-            <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
-            <% if @course_requiring_discord_account.present? %>
-              <%= link_to curriculum_course_path(@course_requiring_discord_account), class: "btn btn-primary btn-large mt-4" do %>
-                <i class="if i-book-regular if-fw text-lg" ></i>
-                <span class="ml-2">
-                  <%= t(".linked.go_to_course_button") %>
-                </span>
-              <% end %>
-            <% else %>
-              <%= link_to dashboard_path, class: "btn btn-primary btn-large mt-4" do %>
-                <i class="if i-home-regular if-fw text-lg" ></i>
-                <span class="ml-2">
-                  <%= t(".linked.go_to_dashboard_button") %>
-                </span>
-              <% end %>
+  <div class="container mx-auto p-4 max-w-4xl">
+    <div class="flex md:items-center flex-col-reverse items-start md:flex-row">
+      <div class="mt-4 md:mt-0 md:mr-6 md:w-1/2">
+        <% if current_user.discord_account_connected? %>
+          <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
+          <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
+          <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
+          <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
+          <% if @course_requiring_discord_account.present? %>
+            <%= link_to curriculum_course_path(@course_requiring_discord_account), class: "btn btn-primary btn-large mt-4" do %>
+              <i class="if i-book-regular if-fw text-lg" ></i>
+              <span class="ml-2">
+                <%= t(".linked.go_to_course_button") %>
+              </span>
             <% end %>
           <% else %>
-            <h1 class="text-3xl font-bold"><%= t(".unlinked.heading") %></h1>
-            <p class="mt-2"><%= t(".unlinked.description", school_name: current_school.name) %></p>
-            <section class="mt-4">
-              <p class="font-semibold"><%= t(".unlinked.process.prefix") %></p>
-              <div class="flex mt-4">
-                <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
-                  <%= t(".unlinked.process.step_1_label") %>
-                </span>
-                <span class="ml-3"><%= t(".unlinked.process.step_1_description_html") %></span>
-              </div>
-              <div class="flex mt-2">
-                <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
-                  <%= t(".unlinked.process.step_2_label") %>
-                </span>
-                <span class="ml-3">
-                  <%= t(".unlinked.process.step_2_description_html") %>
-                  <span data-re-component="HelpIcon" data-re-json='<%= {children: t(".unlinked.process.step_2_help_html"), className: 'text-xs'}.to_json %>'></span>
-                </span>
-              </div>
-              <div class="flex mt-2">
-                <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
-                  <%= t(".unlinked.process.step_3_label") %>
-                </span>
-                <span class="ml-3"><%= t(".unlinked.process.step_3_description_html") %></span>
-              </div>
-            </section>
-            <%= link_to user_edit_presenter.discord_federated_login_url, class: 'btn btn-primary btn-large mt-4' do %>
-              <i class="if i-discord if-fw text-lg"></i>
+            <%= link_to dashboard_path, class: "btn btn-primary btn-large mt-4" do %>
+              <i class="if i-home-regular if-fw text-lg" ></i>
               <span class="ml-2">
-                <%= t(".unlinked.link_discord_button") %>
+                <%= t(".linked.go_to_dashboard_button") %>
               </span>
             <% end %>
           <% end %>
-        </div>
-        <div class="ml-2 p-4 w-1/2 border border-gray-300">Right side: fancy-schmancy image goes here.</div>
+        <% else %>
+          <h1 class="text-3xl font-bold"><%= t(".unlinked.heading") %></h1>
+          <p class="mt-2"><%= t(".unlinked.description", school_name: current_school.name) %></p>
+          <section class="mt-4">
+            <p class="font-semibold"><%= t(".unlinked.process.prefix") %></p>
+            <div class="flex mt-4">
+              <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                <%= t(".unlinked.process.step_1_label") %>
+              </span>
+              <span class="ml-3"><%= t(".unlinked.process.step_1_description_html") %></span>
+            </div>
+            <div class="flex mt-2">
+              <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                <%= t(".unlinked.process.step_2_label") %>
+              </span>
+              <span class="ml-3">
+                <%= t(".unlinked.process.step_2_description_html") %>
+                <span data-re-component="HelpIcon" data-re-json='<%= {children: t(".unlinked.process.step_2_help_html"), className: 'text-xs', responsiveAlignment: 'rrc'}.to_json %>'></span>
+              </span>
+            </div>
+            <div class="flex mt-2">
+              <span class="shrink-0 h-8 w-8 font-semibold border rounded-full border-transparent bg-green-100 text-green-600 flex items-center justify-center">
+                <%= t(".unlinked.process.step_3_label") %>
+              </span>
+              <span class="ml-3"><%= t(".unlinked.process.step_3_description_html") %></span>
+            </div>
+          </section>
+          <%= link_to presenter.discord_federated_login_url, class: 'btn btn-primary btn-large mt-4' do %>
+            <i class="if i-discord if-fw text-lg"></i>
+            <span class="ml-2">
+              <%= t(".unlinked.link_discord_button") %>
+            </span>
+          <% end %>
+        <% end %>
       </div>
+      <%= image_tag presenter.image_path, class: "h-48 md:h-auto md:ml-6 md:w-1/2" %>
     </div>
   </div>
 </div>

--- a/app/views/users/discord_account_required.html.erb
+++ b/app/views/users/discord_account_required.html.erb
@@ -1,14 +1,35 @@
+<% user_edit_presenter = Users::EditPresenter.new(self) %>
 <% content_for(:head) do %>
   <title><%= t(".page_title") %></title>
   <%= vite_javascript_tag 'tailwind', nonce: true %>
 <% end %>
 <div class="flex min-h-screen bg-gray-50 items-center justify-center">
   <div class="py-8 w-full">
-    <div class="container mx-auto px-3 max-w-3xl">
+    <div class="container mx-auto px-3 max-w-4xl">
       <div class="flex">
-        <div class="p-2 w-1/2">
-          <% if false %>
-            <h1 class="text-2xl font-bold"><%= t(".unlinked.heading") %></h1>
+        <div class="mr-6 w-1/2">
+          <% if current_user.discord_account_connected? %>
+            <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
+            <h1 class="mt-3 text-3xl font-bold"><%= t(".linked.heading") %></h1>
+            <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
+            <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
+            <% if @course_requiring_discord_account.present? %>
+              <%= link_to curriculum_course_path(@course_requiring_discord_account), class: "btn btn-primary btn-large mt-4" do %>
+                <i class="if i-book-regular if-fw text-lg" ></i>
+                <span class="ml-2">
+                  <%= t(".linked.go_to_course_button") %>
+                </span>
+              <% end %>
+            <% else %>
+              <%= link_to dashboard_path, class: "btn btn-primary btn-large mt-4" do %>
+                <i class="if i-home-regular if-fw text-lg" ></i>
+                <span class="ml-2">
+                  <%= t(".linked.go_to_dashboard_button") %>
+                </span>
+              <% end %>
+            <% end %>
+          <% else %>
+            <h1 class="text-3xl font-bold"><%= t(".unlinked.heading") %></h1>
             <p class="mt-2"><%= t(".unlinked.description", school_name: current_school.name) %></p>
             <section class="mt-4">
               <p class="font-semibold"><%= t(".unlinked.process.prefix") %></p>
@@ -34,26 +55,15 @@
                 <span class="ml-3"><%= t(".unlinked.process.step_3_description_html") %></span>
               </div>
             </section>
-            <button class="btn btn-primary btn-large mt-4">
-              <i class="if i-discord if-fw"></i>
+            <%= link_to user_edit_presenter.discord_federated_login_url, class: 'btn btn-primary btn-large mt-4' do %>
+              <i class="if i-discord if-fw text-lg"></i>
               <span class="ml-2">
                 <%= t(".unlinked.link_discord_button") %>
               </span>
-            </button>
-          <% else %>
-            <i class="text-green-600 text-5xl if i-badge-check-solid if-fw" ></i>
-            <h1 class="mt-3 text-2xl font-bold"><%= t(".linked.heading") %></h1>
-            <p class="mt-4"><%= t(".linked.description", school_name: current_school.name) %></p>
-            <p class="mt-4"><%= t(".linked.footer_html", school_name: current_school.name) %></p>
-            <button class="btn btn-primary btn-large mt-4">
-              <i class="if i-book-regular if-fw" ></i>
-              <span class="ml-2">
-                <%= t(".linked.go_to_course_button") %>
-              </span>
-            </button>
+            <% end %>
           <% end %>
         </div>
-        <div class="p-2 w-1/2">Right side</div>
+        <div class="ml-2 p-4 w-1/2 border border-gray-300">Right side: fancy-schmancy image goes here.</div>
       </div>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,32 +8,23 @@
 </script>
 <% if Rails.application.secrets.sso[:discord][:key].present? && discord_config.configured? %>
   <div class="container mx-auto px-3 py-8 max-w-5xl">
-    <% if @course_requiring_discord_account.present? %>
-      <% if current_user.discord_account_connected? %>
-        <div class="bg-green-100 border-s-4 border-green-400 p-4">
-          <div class="flex items-center">
-            <i class="fas fa-check-circle text-green-400 text-4xl"></i>
-            <div class="ms-3">
-              <h3 class="text-lg font-semibold"><%= t('.course_discord_requirement_met.heading_html', course_path: curriculum_course_path(@course_requiring_discord_account)) %></h3>
-              <p class="text-sm text-green-900"><%= t('.course_discord_requirement_met.description_html', school_name: current_school.name, course_path: curriculum_course_path(@course_requiring_discord_account)) %></p>
-            </div>
-          </div>
-        </div>
-      <% else %>
-        <div class="bg-orange-100 border-s-4 border-orange-400 p-4">
-          <div class="flex items-center">
-            <i class="fas fa-exclamation-triangle text-orange-400 text-4xl"></i>
-            <div class="ms-3">
-              <h3 class="text-lg font-semibold"><%= t('.course_requires_discord_account.heading') %></h3>
-              <p class="text-sm text-orange-900"><%= t('.course_requires_discord_account.description_html', course_name: @course_requiring_discord_account.name) %></p>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
     <div class="bg-white shadow rounded-lg mt-4 ">
       <div class="flex flex-col md:flex-row">
-        <% if current_user.discord_user_id.blank? %>
+        <% if current_user.discord_account_connected? %>
+          <div class="flex items-center justify-center w-full md:w-1/3 bg-primary-50 rounded-t-md md:rounded-s-lg px-4 py-5 sm:p-6">
+            <%= image_tag 'users/edit/discord-logo-blue.svg', class: 'w-1/2' %>
+          </div>
+          <div class="px-4 py-5 sm:p-6 md:mt-0 w-full md:w-2/3">
+            <h4 class="font-semibold"><%= t(".discord_connected_message_title", school_name: current_school.name) %></h4>
+            <ul class="mt-1 text-sm md:text-base text-gray-700 ms-5 list-disc">
+              <%= simple_format(t(".discord_connected_message")) %>
+            </ul>
+            <div class="mt-3">
+              <a href="https://discord.com/channels/<%=discord_config.server_id%>" target="_blank" rel="noopener" class='btn btn-default w-full md:w-auto'><%= t(".discord_connected_account") %></a>
+              <%= button_to "Disconnect Discord", clear_discord_id_user_path, class: 'mt-4 md:mt-8 p-2 text-sm text-gray-500 font-semibold bg-transparent rounded-md cursor-pointer underline hover:text-red-500 hover:bg-gray-100', method: :post %>
+            </div>
+          </div>
+        <% else %>
           <div class="flex flex-col justify-between w-full md:w-1/3 bg-primary-50 px-4 py-5 sm:p-6">
             <div>
               <h3 class="text-lg font-semibold"><%= t(".discord_title") %></h3>
@@ -51,20 +42,6 @@
                 <i class="if i-discord text-lg"></i>
                 <span class="ms-2"><%= t(".discord_connect") %></span>
               <% end %>
-            </div>
-          </div>
-        <% else %>
-          <div class="flex items-center justify-center w-full md:w-1/3 bg-primary-50 rounded-t-md md:rounded-s-lg px-4 py-5 sm:p-6">
-            <%= image_tag 'users/edit/discord-logo-blue.svg', class: 'w-1/2' %>
-          </div>
-          <div class="px-4 py-5 sm:p-6 md:mt-0 w-full md:w-2/3">
-            <h4 class="font-semibold"><%= t(".discord_connected_message_title", school_name: current_school.name) %></h4>
-            <ul class="mt-1 text-sm md:text-base text-gray-700 ms-5 list-disc">
-              <%= simple_format(t(".discord_connected_message")) %>
-            </ul>
-            <div class="mt-3">
-              <a href="https://discord.com/channels/<%=discord_config.server_id%>" target="_blank" rel="noopener" class='btn btn-default w-full md:w-auto'><%= t(".discord_connected_account") %></a>
-              <%= button_to "Disconnect Discord", clear_discord_id_user_path, class: 'mt-4 md:mt-8 p-2 text-sm text-gray-500 font-semibold bg-transparent rounded-md cursor-pointer underline hover:text-red-500 hover:bg-gray-100', method: :post %>
             </div>
           </div>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2695,6 +2695,27 @@ en:
     delete_account:
       link_expired: That link has expired or is invalid. Please try again.
       title: Edit User
+    discord_account_required:
+      page_title: Discord Account Required
+      unlinked:
+        heading: Let's link your Discord account first.
+        description: The course you're trying to access requires you to connect to your Discord account to %{school_name}. Our Discord server is where you get to interact with the community!
+        link_discord_button: Link Discord
+        no_discord_account: You don't have a Discord account yet? You can sign up for one and link it in one go.
+        process:
+          prefix: "The process is simple:"
+          step_1_label: 1
+          step_1_description_html: Click on the <em>Link Discord</em> button below.
+          step_2_label: 2
+          step_2_description_html: Authorize <em>Pupilfirst LMS</em> to access your Discord account.
+          step_2_help_html: "If you don't have a Discord account, you can sign up for one and link it in one go using the button on this page.<br/><br/>We'll use the authorization to:<ul class='list-disc mt-2 ml-6'><li>Keep your nickname on the Discord server in sync with your name here.</li><li>To assign additional roles to your account on our Discord server.</li></ul>"
+          step_3_label: 3
+          step_3_description_html: You'll be redirected back to this page, and you can start taking the course.
+      linked:
+        heading: You're all set!
+        description: Your Discord account has been linked to your %{school_name} account. You can now browse the course and post messages on our Discord server. If you ever need help, don't hesitate to ask for it on the server.
+        footer_html: Happy learning! <i class="if i-heart-solid if-fw"></i>
+        go_to_course_button: Begin course
     edit:
       course_discord_requirement_met:
         description_html: Your Discord account has been linked to your %{school_name} account. You can now <a class="underline" href="%{course_path}">continue browsing the course curriculum</a>.
@@ -2707,7 +2728,7 @@ en:
       discord_connected_message: <li>Your nickname on the Discord server will be kept in sync with your name here.</li><li>You've been assigned additional roles on Discord.</li>
       discord_connected_message_title: Your %{school_name} account is now linked to your Discord account.
       discord_description: Joining our Discord server will let you get in touch with our team, coaches, and your peers instantly.
-      discord_how_it_works_html: <li> Join our Discord server (it's free!) </li><li>Link your Discord account with this school's account.</li><li>Gain access to our community on Discord!</li>
+      discord_how_it_works_html: <li>Join our Discord server (it's free!)</li><li>Link your Discord account with this school's account.</li><li>Gain access to our community on Discord!</li>
       discord_how_it_works_title: How it works
       discord_title: Join Our Discord Server
       title: Edit User

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2697,27 +2697,27 @@ en:
       link_expired: That link has expired or is invalid. Please try again.
       title: Edit User
     discord_account_required:
-      page_title: Discord Account Required
-      unlinked:
-        heading: Let's link your Discord account first.
-        description: The course you're trying to access requires you to connect your Discord account to %{school_name}. Our Discord server is where you get to interact with the community!
-        link_discord_button: Link Discord
-        no_discord_account: You don't have a Discord account yet? You can sign up for one and link it in one go.
-        process:
-          prefix: "The process is simple:"
-          step_1_label: 1
-          step_1_description_html: Click on the <em>Link Discord</em> button below.
-          step_2_label: 2
-          step_2_description_html: Authorize <em>Pupilfirst LMS</em> to access your Discord account.
-          step_2_help_html: "If you don't have a Discord account, you can sign up for one and link it in one go using the button on this page.<br/><br/>We'll use the authorization to:<ul class='list-disc mt-2 ml-6'><li>Keep your nickname on the Discord server in sync with your name here.</li><li>Assign additional roles to your account on our Discord server.</li></ul>"
-          step_3_label: 3
-          step_3_description_html: You'll be redirected back to this page, and you can start taking the course.
       linked:
-        heading: You're all set!
         description: Your Discord account has been linked to your %{school_name} account. You can now browse the course and post messages on our Discord server. If you ever need help, don't hesitate to ask for it on the server.
         footer_html: Happy learning! <i class="text-primary-500 if i-heart-solid if-fw"></i>
         go_to_course_button: Begin course
         go_to_dashboard_button: Return to dashboard
+        heading: You're all set!
+      page_title: Discord Account Required
+      unlinked:
+        description: The course you're trying to access requires you to connect your Discord account to %{school_name}. Our Discord server is where you get to interact with the community!
+        heading: Let's link your Discord account first.
+        link_discord_button: Link Discord
+        no_discord_account: You don't have a Discord account yet? You can sign up for one and link it in one go.
+        process:
+          prefix: "The process is simple:"
+          step_1_description_html: Click on the <em>Link Discord</em> button below.
+          step_1_label: 1
+          step_2_description_html: Authorize <em>Pupilfirst LMS</em> to access your Discord account.
+          step_2_help_html: If you don't have a Discord account, you can sign up for one and link it in one go using the button on this page.<br/><br/>We'll use the authorization to:<ul class='list-disc mt-2 ml-6'><li>Keep your nickname on the Discord server in sync with your name here.</li><li>Assign additional roles to your account on our Discord server.</li></ul>
+          step_2_label: 2
+          step_3_description_html: You'll be redirected back to this page, and you can start taking the course.
+          step_3_label: 3
     edit:
       discord_connect: Join Our Discord Community
       discord_connected_account: Go to Discord Community

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2699,7 +2699,7 @@ en:
       page_title: Discord Account Required
       unlinked:
         heading: Let's link your Discord account first.
-        description: The course you're trying to access requires you to connect to your Discord account to %{school_name}. Our Discord server is where you get to interact with the community!
+        description: The course you're trying to access requires you to connect your Discord account to %{school_name}. Our Discord server is where you get to interact with the community!
         link_discord_button: Link Discord
         no_discord_account: You don't have a Discord account yet? You can sign up for one and link it in one go.
         process:
@@ -2708,7 +2708,7 @@ en:
           step_1_description_html: Click on the <em>Link Discord</em> button below.
           step_2_label: 2
           step_2_description_html: Authorize <em>Pupilfirst LMS</em> to access your Discord account.
-          step_2_help_html: "If you don't have a Discord account, you can sign up for one and link it in one go using the button on this page.<br/><br/>We'll use the authorization to:<ul class='list-disc mt-2 ml-6'><li>Keep your nickname on the Discord server in sync with your name here.</li><li>To assign additional roles to your account on our Discord server.</li></ul>"
+          step_2_help_html: "If you don't have a Discord account, you can sign up for one and link it in one go using the button on this page.<br/><br/>We'll use the authorization to:<ul class='list-disc mt-2 ml-6'><li>Keep your nickname on the Discord server in sync with your name here.</li><li>Assign additional roles to your account on our Discord server.</li></ul>"
           step_3_label: 3
           step_3_description_html: You'll be redirected back to this page, and you can start taking the course.
       linked:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2716,13 +2716,8 @@ en:
         description: Your Discord account has been linked to your %{school_name} account. You can now browse the course and post messages on our Discord server. If you ever need help, don't hesitate to ask for it on the server.
         footer_html: Happy learning! <i class="text-primary-500 if i-heart-solid if-fw"></i>
         go_to_course_button: Begin course
+        go_to_dashboard_button: Return to dashboard
     edit:
-      course_discord_requirement_met:
-        description_html: Your Discord account has been linked to your %{school_name} account. You can now <a class="underline" href="%{course_path}">continue browsing the course curriculum</a>.
-        heading_html: All done! Let's <a class="underline" href="%{course_path}">take you back to the course</a>.
-      course_requires_discord_account:
-        description_html: The <em>%{course_name}</em> course you're trying to access requires that you link a Discord account to your profile. Use the button below to link your Discord account and continue with the course.
-        heading: Wait a second! You need to link your Discord account first.
       discord_connect: Join Our Discord Community
       discord_connected_account: Go to Discord Community
       discord_connected_message: <li>Your nickname on the Discord server will be kept in sync with your name here.</li><li>You've been assigned additional roles on Discord.</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2009,15 +2009,16 @@ en:
           post_created: "%{user_name} has responded to a thread you are part of in the %{community_name} community"
           topic_created: "%{user_name} has created a new topic in %{community_name} community"
   layouts:
+    footer_bottom:
+      logo_alt: Logo of %{school_name}
+      privacy_policy: Privacy Policy
+      terms_conditions: Terms & Conditions
     student_footer:
       contact: Contact
-      logo: Logo
-      privacy_policy: Privacy Policy
       reach_us: Reach us at
       sitemap: Sitemap
       social: Social
       support: Contact Support
-      terms_conditions: Terms & Conditions
   mailers:
     applicant:
       enrollment_verification:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2714,7 +2714,7 @@ en:
       linked:
         heading: You're all set!
         description: Your Discord account has been linked to your %{school_name} account. You can now browse the course and post messages on our Discord server. If you ever need help, don't hesitate to ask for it on the server.
-        footer_html: Happy learning! <i class="if i-heart-solid if-fw"></i>
+        footer_html: Happy learning! <i class="text-primary-500 if i-heart-solid if-fw"></i>
         go_to_course_button: Begin course
     edit:
       course_discord_requirement_met:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,7 @@ Rails.application.routes.draw do
   resource :user, only: %i[edit] do
     post 'upload_avatar'
     post 'clear_discord_id'
+    get 'discord_account_required'
   end
 
   resources :timeline_event_files, only: %i[create] do

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 feature "Student's view of Course Curriculum", js: true do
   include NotificationHelper
@@ -205,13 +205,13 @@ feature "Student's view of Course Curriculum", js: true do
     expect(page).to have_content("The page you were looking for doesn't exist!")
   end
 
-  context 'when the course the student belongs has ended' do
+  context "when the course the student belongs has ended" do
     let!(:cohort) { create :cohort, course: course, ends_at: 1.day.ago }
 
-    scenario 'student visits the course curriculum page' do
+    scenario "student visits the course curriculum page" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
       expect(page).to have_text(
-        'The course has ended and submissions are disabled for all targets!'
+        "The course has ended and submissions are disabled for all targets!"
       )
     end
   end
@@ -220,15 +220,15 @@ feature "Student's view of Course Curriculum", js: true do
     let!(:cohort) { create :cohort, course: course, ends_at: 1.day.ago }
     let!(:another_cohort) { create :cohort, course: course }
 
-    scenario 'student visits the course curriculum page' do
+    scenario "student visits the course curriculum page" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
       expect(page).to have_text(
-        'You have only limited access to the course now. You are allowed preview the content but cannot complete any target.'
+        "You have only limited access to the course now. You are allowed preview the content but cannot complete any target."
       )
     end
   end
 
-  scenario 'student visits the course curriculum page' do
+  scenario "student visits the course curriculum page" do
     sign_in_user student.user, referrer: curriculum_course_path(course)
 
     # Course name should be displayed.
@@ -248,31 +248,31 @@ feature "Student's view of Course Curriculum", js: true do
 
     # All targets should have the right status written next to their titles.
     within("a[data-target-id='#{completed_target_l4.id}']") do
-      expect(page).to have_content('Completed')
+      expect(page).to have_content("Completed")
     end
 
     within("a[data-target-id='#{submitted_target.id}']") do
-      expect(page).to have_content('Pending Review')
+      expect(page).to have_content("Pending Review")
     end
 
     within("a[data-target-id='#{failed_target.id}']") do
-      expect(page).to have_content('Rejected')
+      expect(page).to have_content("Rejected")
     end
 
     within("a[data-target-id='#{target_with_prerequisites.id}']") do
-      expect(page).to have_content('Locked')
+      expect(page).to have_content("Locked")
     end
 
     expect(page).to have_content(target_group_l4_1.name)
     expect(page).to have_content(target_group_l4_1.description)
 
     # There should only be two target groups...
-    expect(page).to have_selector('.curriculum__target-group', count: 2)
+    expect(page).to have_selector(".curriculum__target-group", count: 2)
 
     # ...and only one of thoese should be a milestone target group.
     expect(page).to have_selector(
-      '.curriculum__target-group',
-      text: 'MILESTONE TARGETS',
+      ".curriculum__target-group",
+      text: "MILESTONE TARGETS",
       count: 1
     )
 
@@ -292,11 +292,11 @@ feature "Student's view of Course Curriculum", js: true do
     expect(page).to have_content(completed_target_l2.title)
 
     within("a[data-target-id='#{completed_target_l2.id}']") do
-      expect(page).to have_content('Completed')
+      expect(page).to have_content("Completed")
     end
   end
 
-  scenario 'student browses a level she has not reached' do
+  scenario "student browses a level she has not reached" do
     sign_in_user student.user, referrer: curriculum_course_path(course)
 
     # Switch to Level 5.
@@ -308,7 +308,7 @@ feature "Student's view of Course Curriculum", js: true do
 
     # There should be two locked targets in L5 right now.
     expect(page).to have_selector(
-      '.curriculum__target-status--locked',
+      ".curriculum__target-status--locked",
       count: 2
     )
 
@@ -316,35 +316,35 @@ feature "Student's view of Course Curriculum", js: true do
     click_link l5_non_reviewed_target_with_prerequisite.title
 
     expect(page).to have_text(
-      'This target has prerequisites that are incomplete.'
+      "This target has prerequisites that are incomplete."
     )
     expect(page).to have_link(l5_non_reviewed_target.title)
 
-    click_button 'Close'
+    click_button "Close"
 
     # Non-reviewed targets that do not have prerequisites should be unlocked for completion.
     click_link l5_non_reviewed_target.title
-    click_button 'Mark As Complete'
+    click_button "Mark As Complete"
 
-    expect(page).to have_text('Target has been marked as complete')
+    expect(page).to have_text("Target has been marked as complete")
 
     dismiss_notification
-    click_button 'Close'
+    click_button "Close"
 
     # Completing the prerequisite should unlock the previously locked non-reviewed target.
     expect(page).to have_selector(
-      '.curriculum__target-status--locked',
+      ".curriculum__target-status--locked",
       count: 1
     )
 
     click_link l5_non_reviewed_target_with_prerequisite.title
 
     expect(page).not_to have_text(
-      'This target has prerequisites that are incomplete.'
+      "This target has prerequisites that are incomplete."
     )
-    expect(page).to have_button 'Mark As Complete'
+    expect(page).to have_button "Mark As Complete"
 
-    click_button 'Close'
+    click_button "Close"
 
     # Reviewed targets, even those without prerequisites, must be locked.
     click_link l5_reviewed_target.title
@@ -353,10 +353,10 @@ feature "Student's view of Course Curriculum", js: true do
       "You're in Level 4. Complete all milestone targets in Level 4 first."
     )
 
-    click_button 'Close'
+    click_button "Close"
   end
 
-  scenario 'student opens a locked level' do
+  scenario "student opens a locked level" do
     sign_in_user student.user, referrer: curriculum_course_path(course)
 
     # Switch to the locked Level 6.
@@ -364,34 +364,34 @@ feature "Student's view of Course Curriculum", js: true do
     click_button "L6: #{locked_level_6.name}"
 
     # Ensure level 6 is displayed as locked. - the content should not be visible.
-    expect(page).to have_text('The level is currently locked!')
-    expect(page).to have_text('You can access the content on')
+    expect(page).to have_text("The level is currently locked!")
+    expect(page).to have_text("You can access the content on")
     expect(page).not_to have_text(target_group_l6.name)
     expect(page).not_to have_text(target_group_l6.description)
     expect(page).not_to have_text(level_6_target.title)
   end
 
-  scenario 'student navigates between levels using the quick navigation links' do
+  scenario "student navigates between levels using the quick navigation links" do
     sign_in_user student.user, referrer: curriculum_course_path(course)
 
     expect(page).to have_button("L4: #{level_4.name}")
 
-    click_button 'Next Level'
+    click_button "Next Level"
 
     expect(page).to have_button("L5: #{level_5.name}")
 
-    click_button 'Next Level'
+    click_button "Next Level"
 
     expect(page).to have_button("L6: #{locked_level_6.name}")
-    expect(page).not_to have_button('Next Level')
+    expect(page).not_to have_button("Next Level")
 
-    click_button 'Previous Level'
+    click_button "Previous Level"
     click_button "L5: #{level_5.name}"
     click_button "L2: #{level_2.name}"
-    click_button 'Previous Level'
+    click_button "Previous Level"
 
     expect(page).to have_button("L1: #{level_1.name}")
-    expect(page).not_to have_button('Previous Level')
+    expect(page).not_to have_button("Previous Level")
   end
 
   context "when the students's course has a level 0 in it" do
@@ -401,7 +401,7 @@ feature "Student's view of Course Curriculum", js: true do
       create :target, target_group: target_group_l0, role: Target::ROLE_TEAM
     end
 
-    scenario 'student visits the dashboard' do
+    scenario "student visits the dashboard" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
       expect(page).to have_button(level_0.name)
@@ -425,7 +425,7 @@ feature "Student's view of Course Curriculum", js: true do
              description: Faker::Lorem.sentence
     end
 
-    scenario 'archived target groups are not displayed' do
+    scenario "archived target groups are not displayed" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
       expect(page).to have_content(target_group_l4_1.name)
@@ -434,8 +434,8 @@ feature "Student's view of Course Curriculum", js: true do
     end
   end
 
-  context 'when a user has more than one student profile' do
-    context 'when the profile is in the same school' do
+  context "when a user has more than one student profile" do
+    context "when the profile is in the same school" do
       let(:course_2) { create :course }
       let(:cohort_2) { create :cohort, course: course_2 }
       let(:c2_level_1) { create :level, :one, course: course_2 }
@@ -447,7 +447,7 @@ feature "Student's view of Course Curriculum", js: true do
         create :founder, level: c2_level_1, user: student.user, cohort: cohort_2
       end
 
-      scenario 'student switches to another course' do
+      scenario "student switches to another course" do
         # Sign into the first course.
         sign_in_user c2_student.user, referrer: curriculum_course_path(course)
 
@@ -462,7 +462,7 @@ feature "Student's view of Course Curriculum", js: true do
       end
     end
 
-    context 'when the profile is in another school' do
+    context "when the profile is in another school" do
       let(:school_2) { create :school }
       let(:course_2) { create :course, school: school_2 }
       let(:c2_level_1) { create :level, :one, course: course_2 }
@@ -470,12 +470,12 @@ feature "Student's view of Course Curriculum", js: true do
         create :founder, level: c2_level_1, user: student.user
       end
 
-      scenario 'courses in other schools are not displayed' do
+      scenario "courses in other schools are not displayed" do
         # Sign into the first course.
         sign_in_user c2_student.user, referrer: curriculum_course_path(course)
 
         # There should be no option to switch to course in second school.
-        expect(page).not_to have_selector('button.student-course__dropdown-btn')
+        expect(page).not_to have_selector("button.student-course__dropdown-btn")
 
         # Attempting to visit the course page directly should show a 404.
         visit curriculum_course_path(course_2)
@@ -486,20 +486,20 @@ feature "Student's view of Course Curriculum", js: true do
     end
   end
 
-  context 'when accessing preview mode of curriculum' do
+  context "when accessing preview mode of curriculum" do
     let(:school_admin) { create :school_admin }
 
-    scenario 'preview contents in the curriculum' do
+    scenario "preview contents in the curriculum" do
       sign_in_user school_admin.user, referrer: curriculum_course_path(course)
 
-      expect(page).to have_text('Preview Mode')
+      expect(page).to have_text("Preview Mode")
 
       # Course name should be displayed.
       expect(page).to have_content(course.name)
 
       # An admin should be shown links to edit the level and its targets.
       expect(page).to have_link(
-        'Edit Level',
+        "Edit Level",
         href: curriculum_school_course_path(id: course.id, level: 1)
       )
       expect(page).to have_selector(
@@ -517,7 +517,7 @@ feature "Student's view of Course Curriculum", js: true do
 
       # Being an admin, level 6 should be open, but there should be a notice saying when the level will open for 'regular' students.
       expect(page).to have_content(
-        "This level is still locked for students and will be unlocked on #{locked_level_6.unlock_at.strftime('%b %-d')}"
+        "This level is still locked for students and will be unlocked on #{locked_level_6.unlock_at.strftime("%b %-d")}"
       )
       expect(page).to have_content(target_group_l6.name)
       expect(page).to have_content(target_group_l6.description)
@@ -537,12 +537,12 @@ feature "Student's view of Course Curriculum", js: true do
       click_link l5_reviewed_target.title
 
       expect(page).to have_content(
-        'You are currently looking at a preview of this course.'
+        "You are currently looking at a preview of this course."
       )
     end
   end
 
-  context 'when the student is also a coach' do
+  context "when the student is also a coach" do
     let(:coach) { create :faculty, user: student.user }
 
     before do
@@ -553,7 +553,7 @@ feature "Student's view of Course Curriculum", js: true do
              founder: student
     end
 
-    scenario 'coach accesses content in locked levels' do
+    scenario "coach accesses content in locked levels" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
       click_button "L4: #{level_4.name}"
@@ -561,7 +561,7 @@ feature "Student's view of Course Curriculum", js: true do
 
       # Being a coach, level 6 should be accessible, but there should be a notice saying when the level will open for 'regular' students.
       expect(page).to have_content(
-        "This level is still locked for students and will be unlocked on #{locked_level_6.unlock_at.strftime('%b %-d')}"
+        "This level is still locked for students and will be unlocked on #{locked_level_6.unlock_at.strftime("%b %-d")}"
       )
       expect(page).to have_content(target_group_l6.name)
       expect(page).to have_content(target_group_l6.description)
@@ -572,10 +572,10 @@ feature "Student's view of Course Curriculum", js: true do
     end
   end
 
-  context 'when a level has no live targets' do
+  context "when a level has no live targets" do
     let!(:level_without_targets) { create :level, number: 7, course: course }
 
-    scenario 'level empty message is displayed' do
+    scenario "level empty message is displayed" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
       click_button "L4: #{level_4.name}"
@@ -585,29 +585,29 @@ feature "Student's view of Course Curriculum", js: true do
     end
   end
 
-  context 'when a course requires a Discord connection' do
+  context "when a course requires a Discord connection" do
     let(:course) { create :course, discord_account_required: true }
 
-    scenario 'student without a connected Discord account is redirected to the user profile edit page' do
+    scenario "student without a connected Discord account is redirected to the user profile edit page" do
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
-      expect(page).to have_content('Edit your profile')
+      expect(page).to have_content("Let's link your Discord account first")
     end
 
-    scenario 'student with a connected Discord account is shown the curriculum' do
-      student.user.update!(discord_user_id: 'DISCORD_USER_ID')
+    scenario "student with a connected Discord account is shown the curriculum" do
+      student.user.update!(discord_user_id: "DISCORD_USER_ID")
 
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
       expect(page).to have_content(course.name)
     end
 
-    scenario 'inactive student without a connection Discord account should not be redirected' do
+    scenario "inactive student without a connection Discord account should not be redirected" do
       cohort.update(ends_at: 1.day.ago)
 
       sign_in_user student.user, referrer: curriculum_course_path(course)
 
-      expect(page).to have_content('The course has ended')
+      expect(page).to have_content("The course has ended")
     end
   end
 end

--- a/spec/system/users/discord_account_requirement_spec.rb
+++ b/spec/system/users/discord_account_requirement_spec.rb
@@ -47,10 +47,13 @@ feature "Discord account requirement", js: true do
       href: curriculum_course_path(course)
     )
 
-    # Trying to visit the Discord account required page again should redirect the student
-    # to their dashboard.
+    # Trying to visit the Discord account required page again, after connecting Discord
+    # account should ask the student to return to their dashboard.
     visit(discord_account_required_user_path)
 
-    expect(page).to have_text("My Courses")
+    expect(page).to have_link(
+      "Return to dashboard",
+      href: dashboard_path
+    )
   end
 end

--- a/spec/system/users/discord_account_requirement_spec.rb
+++ b/spec/system/users/discord_account_requirement_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+feature "Discord account requirement", js: true do
+  include UserSpecHelper
+  include ConfigHelper
+
+  let(:student) { create :founder }
+  let(:user) { student.user }
+  let(:course) { student.course }
+
+  around do |example|
+    with_secret(sso: { discord: { key: "DISCORD_KEY" } }) { example.run }
+  end
+
+  before do
+    course.update!(discord_account_required: true)
+
+    course.school.update(
+      configuration: {
+        discord: {
+          server_id: "DISCORD_SERVER_ID",
+          bot_token: "DISCORD_BOT_TOKEN"
+        }
+      }
+    )
+  end
+
+  scenario "user is prompted to connect a Discord account; afterwards is shown link to course" do
+    sign_in_user(
+      user,
+      referrer:
+        discord_account_required_user_path(course_requiring_discord: course.id)
+    )
+
+    expect(page).to have_text("Let's link your Discord account first")
+
+    # Let's pretend that the user has connected their Discord account, and will now return
+    # to the school website.
+    user.update!(discord_user_id: "DISCORD_USER_ID")
+
+    # They'll end up at the edit path this time, so let's make sure that they're redirected
+    # to the discord account requirement page again.
+    visit(edit_user_path)
+
+    expect(page).to have_link(
+      "Begin course",
+      href: curriculum_course_path(course)
+    )
+
+    # Trying to visit the Discord account required page again should redirect the student
+    # to their dashboard.
+    visit(discord_account_required_user_path)
+
+    expect(page).not_to have_text("My Courses")
+  end
+end

--- a/spec/system/users/discord_account_requirement_spec.rb
+++ b/spec/system/users/discord_account_requirement_spec.rb
@@ -51,6 +51,6 @@ feature "Discord account requirement", js: true do
     # to their dashboard.
     visit(discord_account_required_user_path)
 
-    expect(page).not_to have_text("My Courses")
+    expect(page).to have_text("My Courses")
   end
 end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 feature "User Edit", js: true do
   include UserSpecHelper
   include NotificationHelper
-  include ConfigHelper
 
   let(:student) { create :founder }
   let(:user) { student.user }
@@ -171,53 +170,6 @@ feature "User Edit", js: true do
 
       expect(page).to have_text("Profile updated successfully!")
       expect(user.reload.valid_password?(new_password)).to eq(true)
-    end
-  end
-
-  context "when the user is required to connect a Discord account for a course" do
-    let(:course) { student.course }
-
-    around do |example|
-      with_secret(sso: { discord: { key: "DISCORD_KEY" } }) { example.run }
-    end
-
-    before do
-      course.update!(discord_account_required: true)
-      course.school.update(
-        configuration: {
-          discord: {
-            server_id: "DISCORD_SERVER_ID",
-            bot_token: "DISCORD_BOT_TOKEN"
-          }
-        }
-      )
-    end
-
-    scenario "user is prompted to connect a Discord account; afterwards is shown link to course" do
-      sign_in_user(
-        user,
-        referrer: edit_user_path(course_requiring_discord: course.id)
-      )
-
-      expect(page).to have_text("You need to link your Discord account first")
-
-      # Visiting the page after setting the Discord user should show a CTA to return to the course..
-      user.update!(discord_user_id: "DISCORD_USER_ID")
-
-      visit(edit_user_path)
-
-      expect(page).to have_link(
-        "take you back to the course",
-        href: curriculum_course_path(course)
-      )
-
-      # Visiting the page again should not show the prompt.
-      visit(edit_user_path)
-
-      expect(page).not_to have_link(
-        "take you back to the course",
-        href: curriculum_course_path(course)
-      )
     end
   end
 end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-  content: ["./app/**/*.html.erb", "./app/**/*.bs.js", "./app/**/*.jsx"],
+  content: ["./app/**/*.html.erb", "./app/**/*.bs.js", "./app/**/*.jsx", "config/locales/*.yml"],
   safelist: [
     {
       pattern: /bg-(red|yellow|orange|green|blue|primary|focusColor|gray)-(50|100|200|300|400|500|600|700|800|900)/,


### PR DESCRIPTION
## Proposed Changes

This adds custom views for the forced Discord account linking process, replacing the existing redirect to `User#edit` page.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
