### PR TITLE
Consider only latest submissions on level progress bar

### DIFF
--- a/app/queries/student_details_resolver.rb
+++ b/app/queries/student_details_resolver.rb
@@ -24,7 +24,7 @@ class StudentDetailsResolver < ApplicationQuery
         .joins(:target_group)
         .where(target_groups: { milestone: true, level_id: levels.select(:id) })
         .distinct(:id)
-        .pluck(:id, 'target_groups.level_id')
+        .pluck(:id, "target_groups.level_id")
         .each_with_object(
           {}
         ) do |(target_id, level_id), required_targets_by_level|
@@ -33,12 +33,7 @@ class StudentDetailsResolver < ApplicationQuery
         end
 
     passed_target_ids =
-      TimelineEvent
-        .joins(:founders)
-        .where(founders: { id: student.id })
-        .where.not(passed_at: nil)
-        .distinct(:target_id)
-        .pluck(:target_id)
+      student.latest_submissions.passed.distinct(:target_id).pluck(:target_id)
 
     levels
       .pluck(:id)
@@ -93,7 +88,7 @@ class StudentDetailsResolver < ApplicationQuery
   end
 
   def levels
-    @levels ||= course.levels.unlocked.where('number <= ?', level.number)
+    @levels ||= course.levels.unlocked.where("number <= ?", level.number)
   end
 
   def level

--- a/spec/system/students/report_spec.rb
+++ b/spec/system/students/report_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Course students report', js: true do
+feature "Course students report", js: true do
   include UserSpecHelper
   include MarkdownEditorHelper
   include NotificationHelper
@@ -20,6 +20,7 @@ feature 'Course students report', js: true do
   let!(:team) { create :team, cohort: cohort }
 
   let!(:student) { create :student, level: level_3, cohort: cohort, team: team }
+
   let!(:another_student) do
     create :student, level: level_3, cohort: cohort, team: team
   end
@@ -28,9 +29,11 @@ feature 'Course students report', js: true do
   let(:target_group_l1) do
     create :target_group, level: level_1, milestone: true
   end
+
   let(:target_group_l2) do
     create :target_group, level: level_2, milestone: true
   end
+
   let(:target_group_l3) do
     create :target_group, level: level_3, milestone: true
   end
@@ -38,18 +41,23 @@ feature 'Course students report', js: true do
   let(:target_l1) do
     create :target, :for_founders, target_group: target_group_l1
   end
+
   let(:target_l2) do
     create :target, :for_founders, target_group: target_group_l2
   end
-  let(:target_l3) do
+
+  let(:target_l3_1) do
     create :target, :for_founders, target_group: target_group_l3
   end
-  let!(:target_4) do
+
+  let!(:target_l3_2) do
     create :target, :for_founders, target_group: target_group_l3
   end
+
   let(:quiz_target_1) do
     create :target, :for_founders, target_group: target_group_l1
   end
+
   let(:quiz_target_2) do
     create :target, :for_founders, target_group: target_group_l3
   end
@@ -68,19 +76,21 @@ feature 'Course students report', js: true do
       target: target_l1,
       evaluator_id: course_coach.id,
       evaluated_at: 2.days.ago,
-      passed_at: 3.days.ago
+      passed_at: nil
     )
   end
+
   let!(:submission_target_l1_2) do
     create(
       :timeline_event,
       founders: [student],
-      target: target_l2,
+      target: target_l1,
       evaluator_id: course_coach.id,
       evaluated_at: 3.days.ago,
-      passed_at: nil
+      passed_at: 3.days.ago
     )
   end
+
   let!(:submission_target_l2) do
     create(
       :timeline_event,
@@ -93,18 +103,20 @@ feature 'Course students report', js: true do
       passed_at: 1.day.ago
     )
   end
-  let!(:submission_target_l3) do
+
+  let!(:submission_target_l3_1) do
     create(
       :timeline_event,
       :with_owners,
       latest: true,
       owners: [student],
-      target: target_l3,
+      target: target_l3_1,
       evaluator_id: course_coach.id,
       evaluated_at: 1.day.ago,
       passed_at: 1.day.ago
     )
   end
+
   let!(:submission_quiz_target_1) do
     create(
       :timeline_event,
@@ -113,9 +125,10 @@ feature 'Course students report', js: true do
       owners: [student],
       target: quiz_target_1,
       passed_at: 1.day.ago,
-      quiz_score: '1/3'
+      quiz_score: "1/3"
     )
   end
+
   let!(:submission_quiz_target_2) do
     create(
       :timeline_event,
@@ -124,35 +137,41 @@ feature 'Course students report', js: true do
       owners: [student],
       target: quiz_target_2,
       passed_at: 1.day.ago,
-      quiz_score: '3/5'
+      quiz_score: "3/5"
     )
   end
+
   let!(:coach_note_1) do
     create :coach_note, author: course_coach.user, student: student
   end
+
   let!(:coach_note_2) do
     create :coach_note, author: team_coach.user, student: student
   end
 
   before do
     create :faculty_cohort_enrollment, faculty: course_coach, cohort: cohort
+
     create :faculty_founder_enrollment,
            :with_cohort_enrollment,
            faculty: team_coach,
            founder: student
 
     target_l1.evaluation_criteria << evaluation_criterion_1
+
     target_l2.evaluation_criteria << [
       evaluation_criterion_1,
       evaluation_criterion_2
     ]
-    target_l3.evaluation_criteria << evaluation_criterion_2
-    target_4.evaluation_criteria << evaluation_criterion_2
+
+    target_l3_1.evaluation_criteria << evaluation_criterion_2
+    target_l3_2.evaluation_criteria << evaluation_criterion_2
 
     submission_target_l1_2.timeline_event_grades.create!(
       evaluation_criterion: evaluation_criterion_1,
       grade: 1
     )
+
     submission_target_l1_1.timeline_event_grades.create!(
       evaluation_criterion: evaluation_criterion_1,
       grade: 3
@@ -162,11 +181,13 @@ feature 'Course students report', js: true do
       evaluation_criterion: evaluation_criterion_1,
       grade: 2
     )
+
     submission_target_l2.timeline_event_grades.create!(
       evaluation_criterion: evaluation_criterion_2,
       grade: 2
     )
-    submission_target_l3.timeline_event_grades.create!(
+
+    submission_target_l3_1.timeline_event_grades.create!(
       evaluation_criterion: evaluation_criterion_2,
       grade: 2
     )
@@ -176,71 +197,83 @@ feature 'Course students report', js: true do
     Time.use_zone(course_coach.user.time_zone) { example.run }
   end
 
-  scenario 'coach opens the student report and checks performance' do
+  scenario "coach opens the student report and checks performance" do
     sign_in_user course_coach.user, referrer: students_course_path(course)
 
     click_link student.name
 
     expect(page).to have_text(student.name)
-    expect(page).to have_text('Level Progress')
+    expect(page).to have_text("Level Progress")
+
+    expect(page).to have_selector(".student-overlay__student-level", count: 3)
+
     expect(page).to have_selector(
-      '.student-overlay__student-level',
-      count: course.levels.where.not(number: 0).count
+      ".student-overlay__student-level--reached",
+      count: 3
+    )
+
+    expect(page).to have_selector(
+      ".student-overlay__student-level--completed",
+      count: 1
     )
 
     # Targets Overview
-    expect(page).to have_text('Targets Overview')
+    expect(page).to have_text("Targets Overview")
 
     within("div[aria-label='target-completion-status']") do
-      expect(page).to have_content('Total Targets Completed')
-      expect(page).to have_content('83%')
-      expect(page).to have_content('5/6 Targets')
+      expect(page).to have_content("Total Targets Completed")
+      expect(page).to have_content("66%")
+      expect(page).to have_content("4/6 Targets")
     end
 
     within("div[aria-label='quiz-performance-chart']") do
-      expect(page).to have_content('Average Quiz Score')
-      expect(page).to have_content('46%')
-      expect(page).to have_content('2 Quizzes Attempted')
+      expect(page).to have_content("Average Quiz Score")
+      expect(page).to have_content("46%")
+      expect(page).to have_content("2 Quizzes Attempted")
     end
 
     # Average Grades
-    expect(page).to have_text('Average Grades')
+    expect(page).to have_text("Average Grades")
 
     within(
       "div[aria-label='average-grade-for-criterion-#{evaluation_criterion_1.id}']"
     ) do
       expect(page).to have_content(evaluation_criterion_1.name)
-      expect(page).to have_content('2.5/3')
+      expect(page).to have_content("2.5/3")
     end
 
     within(
       "div[aria-label='average-grade-for-criterion-#{evaluation_criterion_2.id}']"
     ) do
       expect(page).to have_content(evaluation_criterion_2.name)
-      expect(page).to have_content('2/3')
+      expect(page).to have_content("2/3")
     end
 
     # Check submissions of student
-    find('li', text: 'Submissions').click
+    find("li", text: "Submissions").click
 
     expect(page).to have_content(target_l1.title)
-    expect(page).to_not have_content(target_4.title)
+    expect(page).to_not have_content(target_l3_2.title)
+
+    within(
+      "div[aria-label='student-submission-card-#{submission_target_l1_1.id}']"
+    ) { expect(page).to have_content("Rejected") }
 
     within(
       "div[aria-label='student-submission-card-#{submission_target_l1_2.id}']"
-    ) { expect(page).to have_content('Rejected') }
+    ) { expect(page).to have_content("Completed") }
 
     within("div[aria-label='student-submissions']") do
       expect(page).to have_link(
         href: "/submissions/#{submission_target_l1_1.id}/review"
       )
       expect(page).to have_link(
-        href: "/submissions/#{submission_target_l3.id}/review"
+        href: "/submissions/#{submission_target_l3_1.id}/review"
       )
     end
   end
 
-  scenario 'coach loads more submissions' do
+  scenario "coach loads more submissions" do
     # Create over 20 reviewed submissions
     20.times do
       submission =
@@ -249,7 +282,7 @@ feature 'Course students report', js: true do
           :with_owners,
           latest: true,
           owners: [student],
-          target: target_4,
+          target: target_l3_2,
           evaluator_id: course_coach.id,
           evaluated_at: 2.days.ago,
           passed_at: 3.days.ago
@@ -262,49 +295,54 @@ feature 'Course students report', js: true do
 
     sign_in_user course_coach.user, referrer: student_report_path(student)
     expect(page).to have_text(student.name)
-    find('li', text: 'Submissions').click
-    expect(page).to have_button('Load More...')
-    click_button('Load More...')
+    find("li", text: "Submissions").click
+    expect(page).to have_button("Load More...")
+    click_button("Load More...")
 
     within("div[aria-label='student-submissions']") do
       expect(page).to have_selector(
-        'a',
+        "a",
         count: student.timeline_events.evaluated_by_faculty.count
       )
     end
 
     # Switching tabs should preserve already loaded submissions
-    find('li', text: 'Notes').click
-    find('li', text: 'Submissions').click
+    find("li", text: "Notes").click
+    find("li", text: "Submissions").click
 
     within("div[aria-label='student-submissions']") do
       expect(page).to have_selector(
-        'a',
+        "a",
         count: student.timeline_events.evaluated_by_faculty.count
       )
     end
   end
 
-  scenario 'team coach accesses student report' do
+  scenario "team coach accesses student report" do
     sign_in_user team_coach.user, referrer: student_report_path(student)
 
     # Check a student parameter
     within("div[aria-label='target-completion-status']") do
-      expect(page).to have_content('Total Targets Completed')
-      expect(page).to have_content('83%')
-      expect(page).to have_content('5/6 Targets')
+      expect(page).to have_content("Total Targets Completed")
+      expect(page).to have_content("66%")
+      expect(page).to have_content("4/6 Targets")
     end
 
     # Check submissions
-    find('li', text: 'Submissions').click
+    find("li", text: "Submissions").click
     expect(page).to have_content(target_l1.title)
-    expect(page).to_not have_content(target_4.title)
+    expect(page).to_not have_content(target_l3_2.title)
+
+    within(
+      "div[aria-label='student-submission-card-#{submission_target_l1_1.id}']"
+    ) { expect(page).to have_content("Rejected") }
+
     within(
       "div[aria-label='student-submission-card-#{submission_target_l1_2.id}']"
-    ) { expect(page).to have_content('Rejected') }
+    ) { expect(page).to have_content("Completed") }
 
     # Check notes
-    find('li', text: 'Notes').click
+    find("li", text: "Notes").click
     expect(page).to have_text(coach_note_1.note)
     expect(page).to have_text(coach_note_2.note)
 
@@ -318,34 +356,34 @@ feature 'Course students report', js: true do
     expect(coach_note_2.reload.archived_at).to_not eq(nil)
 
     within("div[aria-label='Note #{coach_note_1.id}']") do
-      expect(page).not_to have_selector('.fa-trash-alt')
+      expect(page).not_to have_selector(".fa-trash-alt")
     end
   end
 
-  scenario 'coach adds few notes for a student' do
+  scenario "coach adds few notes for a student" do
     sign_in_user course_coach.user, referrer: student_report_path(student)
 
-    find('li', text: 'Notes').click
+    find("li", text: "Notes").click
     note_1 = Faker::Markdown.sandwich(sentences: 2)
     note_2 = Faker::Markdown.sandwich(sentences: 2)
     add_markdown(note_1)
-    click_button('Save Note')
+    click_button("Save Note")
     dismiss_notification
     expect(page).to have_text(course_coach.name)
     expect(page).to have_text(course_coach.title)
     expect(CoachNote.where(student: student).last.note).to eq(note_1)
 
     add_markdown(note_2)
-    click_button('Save Note')
+    click_button("Save Note")
     dismiss_notification
     expect(page).to have_text(course_coach.name, count: 3)
     expect(page).to have_text(course_coach.title, count: 3)
-    expect(page).to have_text(Time.zone.today.strftime('%B %-d'), count: 4)
+    expect(page).to have_text(Time.zone.today.strftime("%B %-d"), count: 4)
     expect(CoachNote.where(student: student).last.note).to eq(note_2)
   end
 
-  context 'when a coach sees existing notes on the report page' do
-    scenario 'coach can archive her own notes' do
+  context "when a coach sees existing notes on the report page" do
+    scenario "coach can archive her own notes" do
       sign_in_user team_coach.user, referrer: student_report_path(student)
 
       expect(page).to have_text(coach_note_1.note)
@@ -366,25 +404,25 @@ feature 'Course students report', js: true do
       sign_in_user team_coach.user, referrer: student_report_path(student)
 
       within("div[aria-label='Note #{coach_note_1.id}']") do
-        expect(page).not_to have_selector('.fa-trash-alt')
+        expect(page).not_to have_selector(".fa-trash-alt")
       end
     end
 
-    scenario 'coach is indicated if there are no notes' do
+    scenario "coach is indicated if there are no notes" do
       another_student = team.founders.last
       sign_in_user team_coach.user,
                    referrer: student_report_path(another_student)
-      expect(page).to have_text('No notes here!')
+      expect(page).to have_text("No notes here!")
     end
   end
 
-  scenario 'unauthorized coach attempts to access student report' do
+  scenario "unauthorized coach attempts to access student report" do
     sign_in_user coach_without_access.user,
                  referrer: student_report_path(student)
     expect(page).to have_content("The page you were looking for doesn't exist")
   end
 
-  context 'when there are more than one team coaches' do
+  context "when there are more than one team coaches" do
     let(:team_coach_2) { create :faculty, school: school }
 
     before do
@@ -394,7 +432,7 @@ feature 'Course students report', js: true do
              founder: student
     end
 
-    scenario 'coach checks list of directly assigned team coaches' do
+    scenario "coach checks list of directly assigned team coaches" do
       sign_in_user course_coach.user, referrer: student_report_path(student)
 
       expect(page).to have_text(team_coach.name)
@@ -402,7 +440,7 @@ feature 'Course students report', js: true do
     end
   end
 
-  scenario 'coach can navigate to other team members in the team' do
+  scenario "coach can navigate to other team members in the team" do
     sign_in_user course_coach.user, referrer: student_report_path(student)
 
     team
@@ -416,14 +454,14 @@ feature 'Course students report', js: true do
       end
   end
 
-  scenario 'coach is shown a warning about a student being dropped out' do
+  scenario "coach is shown a warning about a student being dropped out" do
     time = 1.day.ago
     student.update!(dropped_out_at: time)
 
     sign_in_user course_coach.user, referrer: student_report_path(student)
 
     expect(page).to have_text(
-      "This student dropped out of the course on #{time.strftime('%b %-d, %Y')}."
+      "This student dropped out of the course on #{time.strftime("%b %-d, %Y")}."
     )
   end
 
@@ -433,7 +471,7 @@ feature 'Course students report', js: true do
     sign_in_user course_coach.user, referrer: student_report_path(student)
 
     expect(page).to have_text(
-      "This student's access to the course ended on #{time.strftime('%b %-d, %Y')}."
+      "This student's access to the course ended on #{time.strftime("%b %-d, %Y")}."
     )
   end
 end


### PR DESCRIPTION
This fixes a bug on the level progress bar shown as a part of a student's report, where it would show a level as completed even if there is a `latest: true` submission that is failed.

The main fix is in `StudentDetailsResolver`...

```diff
     passed_target_ids =
-      TimelineEvent
-        .joins(:founders)
-        .where(founders: { id: student.id })
-        .where.not(passed_at: nil)
-        .distinct(:target_id)
-        .pluck(:target_id)
+      student.latest_submissions.passed.distinct(:target_id).pluck(:target_id)
```

...and is tested in `spec/system/students/report_spec.rb` by setting `submission_target_l1_1` as the latest _failed_ submission, and `submission_target_l1_2` as an earlier _passed_ submission.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~