### PR TITLE
Remove coach count on coaches page

### DIFF
--- a/app/frontend/schools/coaches/components/SA_Coaches_SchoolIndex.res
+++ b/app/frontend/schools/coaches/components/SA_Coaches_SchoolIndex.res
@@ -35,11 +35,10 @@ let coachesTab = tab => {
     role="tab"
     key={label}
     href={currentPath}
-    className={`flex px-5 py-2 items-center p-2 font-medium hover:text-primary-500 ${currentTab() ==
-        tab
+    className={`px-5 py-2 p-2 font-medium hover:text-primary-500 ${currentTab() == tab
         ? "border-b-2 border-primary-500 text-primary-500"
         : ""}`}>
-    <span> {label->str} </span>
+    {label->str}
   </a>
 }
 

--- a/app/frontend/schools/coaches/components/SA_Coaches_SchoolIndex.res
+++ b/app/frontend/schools/coaches/components/SA_Coaches_SchoolIndex.res
@@ -26,7 +26,7 @@ let reducer = (state, action) =>
   | UpdateFormVisible(formVisible) => {...state, formVisible: formVisible}
   }
 
-let coachesTab = (count, tab) => {
+let coachesTab = tab => {
   let (label, currentPath) = switch tab {
   | ActiveCoaches => (tr("active_coaches"), "coaches?status=active")
   | ExitedCoaches => (tr("exited_coaches"), "coaches?status=exited")
@@ -35,17 +35,11 @@ let coachesTab = (count, tab) => {
     role="tab"
     key={label}
     href={currentPath}
-    className={`flex gap-3 px-5 py-2 items-center p-2 font-medium hover:text-primary-500 ${currentTab() ==
+    className={`flex px-5 py-2 items-center p-2 font-medium hover:text-primary-500 ${currentTab() ==
         tab
         ? "border-b-2 border-primary-500 text-primary-500"
         : ""}`}>
     <span> {label->str} </span>
-    {ReactUtils.nullUnless(
-      <span className=`bg-primary-500 text-white text-xs rounded-md px-1.5 py-1`>
-        {string_of_int(count)->str}
-      </span>,
-      currentTab() == tab,
-    )}
   </a>
 }
 
@@ -78,9 +72,7 @@ let make = (~coaches, ~authenticityToken) => {
         </div>
         <div className="max-w-3xl mx-auto">
           <div className="px-12 flex justify-start" role="tablist">
-            {[ActiveCoaches, ExitedCoaches]
-            ->Js.Array2.map(coachesTab(Js.Array2.length(coaches)))
-            ->React.array}
+            {[ActiveCoaches, ExitedCoaches]->Js.Array2.map(coachesTab)->React.array}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Fixes #1315 

- Removed coach count on each tab, in coach page.

@pupilfirst/developers

## Merge Checklist

- ~~[ ] Add specs that demonstrate bug / test a new feature.~~
-  ~~[ ] Check if route, query, or mutation authorization looks correct.~~
  -  ~~[ ] Add tests for authorization, if required .~~
-  ~~[ ] Ensure that UI text is kept in I18n files.~~ 
- ~~[ ] Update developer and product docs, where applicable.~~ 
-  ~~[ ] Prep screenshot or demo video for changelog entry, and attach it to issue.~~ 
- ~~[ ] Check if new tables or columns that have been added need to be handled in the following services:~~ 
  -  ~~`Users::DeleteAccountService`~~
  - ~~`Courses::CloneService`~~
  - ~~`Courses::DeleteService`~~
  - ~~`Courses::DemoContentService`~~
  - ~~`Levels::CloneService`~~
  - ~~`Schools::DeleteService`~~
- ~~[ ] Check if changes in _packaged_ components have been published to `npm`.~~
- ~~[ ] Add development seeds for new tables.~~
- ~~[ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
