### PR TITLE
Fix bug in Level Selector in Curriculum Editor

### DIFF
--- a/app/frontend/schools/courses/components/CurriculumEditor.res
+++ b/app/frontend/schools/courses/components/CurriculumEditor.res
@@ -32,7 +32,7 @@ let reducer = (state, action) =>
   | SelectLevel(selectedLevel) => {...state, selectedLevel: selectedLevel}
   | UpdateEditorAction(editorAction) => {...state, editorAction: editorAction}
   | UpdateLevels(level) =>
-    let newLevels = level |> Level.updateArray(state.levels)
+    let newLevels = level->Level.updateArray(state.levels)
     {...state, levels: newLevels, editorAction: Hidden, selectedLevel: level}
   | UpdateTargetGroup(targetGroup) =>
     let newtargetGroups = targetGroup |> TargetGroup.updateArray(state.targetGroups)
@@ -46,33 +46,33 @@ let reducer = (state, action) =>
   }
 
 let showArchivedButton = (targetGroupsInLevel, targets) => {
-  let tgIds = targetGroupsInLevel |> Js.Array.map(TargetGroup.id)
+  let tgIds = targetGroupsInLevel->Js.Array2.map(TargetGroup.id)
 
   let numberOfArchivedTargetGroupsInLevel =
-    targetGroupsInLevel |> Js.Array.filter(TargetGroup.archived) |> Js.Array.length
+    targetGroupsInLevel->Js.Array2.filter(TargetGroup.archived)->Js.Array2.length
 
   let numberOfArchivedTargetsInLevel =
     targets
-    |> Js.Array.filter(target => tgIds |> Js.Array.includes(Target.targetGroupId(target)))
-    |> Js.Array.filter(target => Target.visibility(target) == Archived)
-    |> Js.Array.length
+    ->Js.Array2.filter(target => tgIds->Js.Array2.includes(Target.targetGroupId(target)))
+    ->Js.Array2.filter(target => Target.visibility(target) == Archived)
+    ->Js.Array2.length
 
   numberOfArchivedTargetGroupsInLevel > 0 || numberOfArchivedTargetsInLevel > 0
 }
 
 let updateTargetSortIndex = (state, send, sortedTargets) => {
-  let oldTargets = state.targets |> Js.Array.filter(t => !Js.Array.includes(t, sortedTargets))
+  let oldTargets = state.targets->Js.Array2.filter(t => !Js.Array2.includes(sortedTargets, t))
 
-  send(UpdateTargets(Js.Array.concat(oldTargets, Target.updateSortIndex(sortedTargets))))
+  send(UpdateTargets(Js.Array2.concat(oldTargets, Target.updateSortIndex(sortedTargets))))
 }
 
 let updateTargetGroupSortIndex = (state, send, sortedTargetGroups) => {
   let oldTargetGroups =
-    state.targetGroups |> Js.Array.filter(t => !Js.Array.includes(t, sortedTargetGroups))
+    state.targetGroups->Js.Array2.filter(t => !Js.Array2.includes(sortedTargetGroups, t))
 
   send(
     UpdateTargetGroups(
-      Js.Array.concat(TargetGroup.updateSortIndex(sortedTargetGroups), oldTargetGroups),
+      Js.Array2.concat(TargetGroup.updateSortIndex(sortedTargetGroups), oldTargetGroups),
     ),
   )
 }
@@ -99,7 +99,7 @@ let computeIntialState = ((levels, targetGroups, targets, path)) => {
     DomUtils.getUrlParam(~key="level")
     ->Belt.Option.flatMap(Belt.Int.fromString)
     ->Belt.Option.flatMap(levelNumber => {
-      Js.Array.find(level => Level.number(level) == levelNumber, levels)
+      Js.Array2.find(levels, level => Level.number(level) == levelNumber)
     })
     ->Belt.Option.getWithDefault(
       Js.Array2.reduce(
@@ -151,12 +151,12 @@ let make = (
 
   let targetGroupsInLevel =
     state.targetGroups
-    |> Js.Array.filter(targetGroup => TargetGroup.levelId(targetGroup) == currentLevelId)
-    |> TargetGroup.sort
+    ->Js.Array2.filter(targetGroup => TargetGroup.levelId(targetGroup) == currentLevelId)
+    ->TargetGroup.sort
 
   let targetGroupsToDisplay = state.showArchived
     ? targetGroupsInLevel
-    : targetGroupsInLevel |> Js.Array.filter(tg => !TargetGroup.archived(tg))
+    : targetGroupsInLevel->Js.Array2.filter(tg => !TargetGroup.archived(tg))
 
   let showTargetGroupEditorCB = targetGroup =>
     send(UpdateEditorAction(ShowTargetGroupEditor(targetGroup)))
@@ -168,11 +168,11 @@ let make = (
         "Unable to find target group with ID:" ++ Target.targetGroupId(target),
       )
 
-    let updatedTargetGroup = switch target |> Target.visibility {
+    let updatedTargetGroup = switch Target.visibility(target) {
     | Archived => targetGroup
     | Draft
     | Live =>
-      targetGroup |> TargetGroup.unarchive
+      TargetGroup.unarchive(targetGroup)
     }
 
     send(UpdateTarget(target))
@@ -180,13 +180,13 @@ let make = (
   }
 
   let updateTargetGroupsCB = targetGroup => {
-    targetGroup |> TargetGroup.archived
+    TargetGroup.archived(targetGroup)
       ? {
           let targetIdsInTargerGroup =
-            state.targets |> Target.targetIdsInTargetGroup(targetGroup |> TargetGroup.id)
+            state.targets |> Target.targetIdsInTargetGroup(TargetGroup.id(targetGroup))
           let newTargets =
-            state.targets |> Js.Array.map(target =>
-              targetIdsInTargerGroup |> Js.Array.includes(Target.id(target))
+            state.targets->Js.Array2.map(target =>
+              targetIdsInTargerGroup->Js.Array2.includes(Target.id(target))
                 ? Target.archive(target)
                 : target
             )
@@ -238,7 +238,7 @@ let make = (
                   let level_id = ReactEvent.Form.target(event)["value"]
                   send(SelectLevel(Level.selectLevel(state.levels, level_id)))
                 }}
-                value={currentLevel->Level.id}
+                value={Level.id(currentLevel)}
                 ariaLabel="Select level"
                 className="block appearance-none w-full bg-white border text-sm border-gray-300 rounded-s hover:border-gray-500 px-4 py-3 pe-8 rounded-e-none leading-tight focus:outline-none focus:ring-2 focus:ring-inset focus:ring-focusColor-500">
                 {state.levels

--- a/app/frontend/schools/courses/components/CurriculumEditor.res
+++ b/app/frontend/schools/courses/components/CurriculumEditor.res
@@ -235,23 +235,23 @@ let make = (
             <div className="inline-block relative w-auto md:w-64">
               <select
                 onChange={event => {
-                  let level_name = ReactEvent.Form.target(event)["value"]
-                  send(SelectLevel(Level.selectLevel(state.levels, level_name)))
+                  let level_id = ReactEvent.Form.target(event)["value"]
+                  send(SelectLevel(Level.selectLevel(state.levels, level_id)))
                 }}
-                value={currentLevel |> Level.name}
+                value={currentLevel->Level.id}
                 ariaLabel="Select level"
                 className="block appearance-none w-full bg-white border text-sm border-gray-300 rounded-s hover:border-gray-500 px-4 py-3 pe-8 rounded-e-none leading-tight focus:outline-none focus:ring-2 focus:ring-inset focus:ring-focusColor-500">
                 {state.levels
-                |> Level.sort
-                |> Array.map(level =>
-                  <option key={Level.id(level)} value={level |> Level.name}>
+                ->Level.sort
+                ->Js.Array2.map(level =>
+                  <option key={level->Level.id} value={level->Level.id}>
                     {LevelLabel.format(
-                      ~name=level |> Level.name,
-                      level |> Level.number |> string_of_int,
-                    ) |> str}
+                      ~name=level->Level.name,
+                      level->Level.number->string_of_int,
+                    )->str}
                   </option>
                 )
-                |> React.array}
+                ->React.array}
               </select>
               <div
                 className="pointer-events-none absolute inset-y-0 end-0 flex items-center px-3 text-gray-800">

--- a/app/frontend/schools/courses/components/CurriculumEditor.res
+++ b/app/frontend/schools/courses/components/CurriculumEditor.res
@@ -244,10 +244,10 @@ let make = (
                 {state.levels
                 ->Level.sort
                 ->Js.Array2.map(level =>
-                  <option key={level->Level.id} value={level->Level.id}>
+                  <option key={Level.id(level)} value={Level.id(level)}>
                     {LevelLabel.format(
-                      ~name=level->Level.name,
-                      level->Level.number->string_of_int,
+                      ~name=Level.name(level),
+                      Level.number(level)->string_of_int,
                     )->str}
                   </option>
                 )

--- a/app/frontend/schools/courses/types/curriculum_editor/CurriculumEditor__Level.res
+++ b/app/frontend/schools/courses/types/curriculum_editor/CurriculumEditor__Level.res
@@ -23,10 +23,10 @@ let decode = json => {
   }
 }
 
-let selectLevel = (levels, level_name) =>
+let selectLevel = (levels, level_id) =>
   levels |> ArrayUtils.unsafeFind(
-    q => q.name == level_name,
-    "Unable to find level with name: " ++ (level_name ++ "in CurriculumEditor"),
+    q => q.id == level_id,
+    `Unable to find level with specified level id, ID=${level_id}, in CurriculumEditor`,
   )
 
 let create = (id, name, number, unlockAt) => {
@@ -49,4 +49,4 @@ let unsafeFind = (levels, componentName, levelId) =>
     "Unable to find level with id: " ++ (levelId ++ (" in CurriculumEditor__" ++ componentName)),
   )
 
-let levelNumberWithName = t => LevelLabel.format(~name=t.name, (t.number |> string_of_int))
+let levelNumberWithName = t => LevelLabel.format(~name=t.name, t.number->string_of_int)

--- a/app/frontend/schools/courses/types/curriculum_editor/CurriculumEditor__Level.res
+++ b/app/frontend/schools/courses/types/curriculum_editor/CurriculumEditor__Level.res
@@ -16,10 +16,10 @@ let unlockAt = t => t.unlockAt
 let decode = json => {
   open Json.Decode
   {
-    id: json |> field("id", string),
-    name: json |> field("name", string),
-    number: json |> field("number", int),
-    unlockAt: json |> optional(field("unlockAt", DateFns.decodeISO)),
+    id: field("id", string, json),
+    name: field("name", string, json),
+    number: field("number", int, json),
+    unlockAt: optional(field("unlockAt", DateFns.decodeISO), json),
   }
 }
 
@@ -36,9 +36,9 @@ let create = (id, name, number, unlockAt) => {
   unlockAt: unlockAt,
 }
 
-let updateArray = (levels, level) => {
-  let oldLevels = levels |> Js.Array.filter(l => l.id !== level.id)
-  oldLevels |> Array.append([level])
+let updateArray = (level, levels) => {
+  let oldLevels = levels->Js.Array2.filter(l => l.id !== level.id)
+  oldLevels->Js.Array2.concat([level])
 }
 
 let sort = levels => levels |> ArrayUtils.copyAndSort((x, y) => x.number - y.number)
@@ -49,4 +49,4 @@ let unsafeFind = (levels, componentName, levelId) =>
     "Unable to find level with id: " ++ (levelId ++ (" in CurriculumEditor__" ++ componentName)),
   )
 
-let levelNumberWithName = t => LevelLabel.format(~name=t.name, t.number->string_of_int)
+let levelNumberWithName = t => LevelLabel.format(~name=t.name, string_of_int(t.number))

--- a/app/frontend/schools/courses/types/curriculum_editor/CurriculumEditor__Level.res
+++ b/app/frontend/schools/courses/types/curriculum_editor/CurriculumEditor__Level.res
@@ -26,7 +26,7 @@ let decode = json => {
 let selectLevel = (levels, level_id) =>
   levels |> ArrayUtils.unsafeFind(
     q => q.id == level_id,
-    `Unable to find level with specified level id, ID=${level_id}, in CurriculumEditor`,
+    `Unable to find level with ID: ${level_id}, in CurriculumEditor`,
   )
 
 let create = (id, name, number, unlockAt) => {

--- a/spec/system/school/courses/curriculum_editor_spec.rb
+++ b/spec/system/school/courses/curriculum_editor_spec.rb
@@ -377,10 +377,9 @@ feature "Curriculum Editor", js: true do
 
   context "when multiple levels have same name" do
     before do
-      level_1.update!(name: "How to become a test engineer")
-      level_2.update!(name: "How to become a test engineer")
-      # To be sure that target groups doesn't have same name
-      target_group_1.update!(name: "consectetur adipiscing elit 22890")
+      level_name = Faker::Lorem.words(number: 6).join(" ")
+      level_1.update!(name: level_name)
+      level_2.update!(name: level_name)
     end
 
     scenario "author goes through levels" do

--- a/spec/system/school/courses/curriculum_editor_spec.rb
+++ b/spec/system/school/courses/curriculum_editor_spec.rb
@@ -374,4 +374,25 @@ feature "Curriculum Editor", js: true do
       end
     end
   end
+
+  context "when multiple levels have same name" do
+    before do
+      level_1.update!(name: "How to become a test engineer")
+      level_2.update!(name: "How to become a test engineer")
+      # To be sure that target groups doesn't have same name
+      target_group_1.update!(name: "consectetur adipiscing elit 22890")
+    end
+
+    scenario "author goes through levels" do
+      sign_in_user course_author.user,
+                   referrer: curriculum_school_course_path(course)
+
+      expect(page).to have_text(target_group_2.name)
+
+      find("option[value=\"#{level_2.id}\"]").click
+      find("option[value=\"#{level_1.id}\"]").click
+
+      expect(page).to have_text(target_group_1.name)
+    end
+  end
 end


### PR DESCRIPTION
## Fixes #1249 

- Use item id instead of item name as value in level selector.

@pupilfirst/developers

## Merge Checklist

- ~~[ ] Add specs that demonstrate bug / test a new feature.~~
- ~~[ ] Check if route, query, or mutation authorization looks correct.~~
  - ~~Add tests for authorization, if required.~~
- ~~[ ] Ensure that UI text is kept in I18n files.~~
- ~~[ ] Update developer and product docs, where applicable.~~
- ~~[ ] Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~[ ] Check if new tables or columns that have been added need to be handled in the following services:~~
  - ~~`Users::DeleteAccountService`~~
  - ~~`Courses::CloneService`~~
  - ~~`Courses::DeleteService`~~
  - ~~`Courses::DemoContentService`~~
  - ~~`Levels::CloneService`~~
  - ~~`Schools::DeleteService`~~
- ~~[ ] Check if changes in _packaged_ components have been published to `npm`.~~
- ~~[ ] Add development seeds for new tables.~~
- ~~[ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
