### PR TITLE
Display new email in progress alongside current email

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1837,6 +1837,7 @@ en:
       already_iniated_deletion_warning: You have already initiated account deletion. Please check your inbox for further steps to delete your account.
       avatar_uploaded_notification: Avatar uploaded successfully.
       cancel: Cancel
+      cancel_new_email: Cancel
       change_password: Change your current password
       change_photo: Change photo
       community_digest: Community Digest
@@ -1854,6 +1855,7 @@ en:
       displayed_publicly: This information will be displayed publicly so be careful what you share.
       edit_profile: Edit your profile
       email_label: Email
+      new_email_label: New Email
       email_placeholder: Type your email
       email_sent_notification: Please check your new email. We've sent instructions to update your email address.
       initiate_deletion: Initiate Deletion


### PR DESCRIPTION
## Fixes [#1177](https://github.com/pupilfirst/pupilfirst/issues/1177)

-  Added a `new input` field field for the new email in the HTML template
- Added label and button text in `en.yml` file
-  `Updated` the existing `reducer` function to handle the new email and update the state accordingly
-  `Stored` the `new email` in the `localStorage` when it is updated
- Implemented logic to `display new email` alongside the current email, indicating a pending email change request.
- Added `cancel` functionality to `remove` the new email from the `state` and `localStorage`.

@pupilfirst/developers

## Merge Checklist

~~- [ ] Add specs that demonstrate bug / test a new feature.~~
~~- [ ] Check if route, query, or mutation authorization looks correct.~~
~~  - Add tests for authorization, if required.~~
~~- [ ] Ensure that UI text is kept in I18n files.~~
~~- [ ] Update developer and product docs, where applicable.~~
~~- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.~~
~~- [ ] Check if new tables or columns that have been added need to be handled in the following services:~~
~~- `Users::DeleteAccountService`~~
~~- `Courses::CloneService`~~
~~- `Courses::DeleteService`~~
~~- `Courses::DemoContentService`~~
~~- `Levels::CloneService`~~
~~- `Schools::DeleteService`~~
~~- [ ] Check if changes in _packaged_ components have been published to `npm`.~~
~~- [ ] Add development seeds for new tables.~~
~~- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
