### PR TITLE
Regenerate token only if the notify flag is set

### DIFF
--- a/app/services/cohorts/add_students_service.rb
+++ b/app/services/cohorts/add_students_service.rb
@@ -90,12 +90,12 @@ module Cohorts
       user = school.users.with_email(student.email).first
       user = school.users.create!(email: student.email) if user.blank?
 
-      user.regenerate_login_token
+      user.regenerate_login_token if @notify
 
       # If a user was already present, don't override values of name, title or affiliation.
       user.update!(
         name: user.name.presence || student.name,
-        title: user.title.presence || student.title.presence || 'Student',
+        title: user.title.presence || student.title.presence || "Student",
         affiliation: user.affiliation.presence || student.affiliation.presence
       )
 

--- a/app/services/cohorts/add_students_service.rb
+++ b/app/services/cohorts/add_students_service.rb
@@ -90,8 +90,6 @@ module Cohorts
       user = school.users.with_email(student.email).first
       user = school.users.create!(email: student.email) if user.blank?
 
-      user.regenerate_login_token if @notify
-
       # If a user was already present, don't override values of name, title or affiliation.
       user.update!(
         name: user.name.presence || student.name,

--- a/spec/services/cohorts/add_students_service_spec.rb
+++ b/spec/services/cohorts/add_students_service_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Cohorts::AddStudentsService do
   subject { described_class.new(cohort, notify: notify) }
@@ -13,30 +13,30 @@ describe Cohorts::AddStudentsService do
     OpenStruct.new(
       name: Faker::Name.name,
       email: Faker::Internet.email,
-      title: Faker::Lorem.words(number: 2).join(' '),
-      tags: ['Tag 1', 'Tag 2']
+      title: Faker::Lorem.words(number: 2).join(" "),
+      tags: ["Tag 1", "Tag 2"]
     )
   end
   let!(:student_3_data) do
     OpenStruct.new(
       name: Faker::Name.name,
       email: Faker::Internet.email,
-      team_name: 'new_team',
-      tags: ['Tag 3']
+      team_name: "new_team",
+      tags: ["Tag 3"]
     )
   end
   let!(:student_4_data) do
     OpenStruct.new(
       name: Faker::Name.name,
       email: Faker::Internet.email,
-      team_name: 'new_team',
-      tags: ['Tag 4']
+      team_name: "new_team",
+      tags: ["Tag 4"]
     )
   end
   let!(:notify) { true }
 
-  describe '#add' do
-    it 'add given list of students to the cohort' do
+  describe "#add" do
+    it "add given list of students to the cohort" do
       students_data = [
         student_1_data,
         student_2_data,
@@ -44,8 +44,9 @@ describe Cohorts::AddStudentsService do
         student_4_data
       ]
 
-      expect { subject.add(students_data) }.to change { cohort.founders.count }
-        .by(4)
+      expect { subject.add(students_data) }.to change {
+        cohort.founders.count
+      }.by(4)
       expect(cohort.teams.count).to eq(1)
 
       # Check attributes are saved correctly for students
@@ -53,10 +54,10 @@ describe Cohorts::AddStudentsService do
       expect(student_2_user.name).to eq(student_2_data.name)
       expect(student_2_user.title).to eq(student_2_data.title)
       expect(student_2_user.founders.first.tag_list).to match_array(
-        ['Tag 1', 'Tag 2']
+        ["Tag 1", "Tag 2"]
       )
       expect(cohort.school.founder_tag_list).to match_array(
-        ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4']
+        ["Tag 1", "Tag 2", "Tag 3", "Tag 4"]
       )
 
       # Email notifications
@@ -69,14 +70,14 @@ describe Cohorts::AddStudentsService do
       )
 
       # Check if students are teamed up correctly
-      new_team = Team.find_by(name: 'new_team')
+      new_team = Team.find_by(name: "new_team")
 
       expect(new_team.founders.map { |f| f.email }).to match_array(
         [student_3_data.email, student_4_data.email]
       )
     end
 
-    it 'returns the IDs of newly added students' do
+    it "returns the IDs of newly added students" do
       students_data = [
         student_1_data,
         student_2_data,
@@ -105,7 +106,7 @@ describe Cohorts::AddStudentsService do
       expect(response).to contain_exactly(*student_ids)
     end
 
-    it 'publishes student_added event for each student' do
+    it "publishes student_added event for each student" do
       students_data = [
         student_1_data,
         student_2_data,
@@ -113,7 +114,7 @@ describe Cohorts::AddStudentsService do
         student_4_data
       ]
 
-      notification_service = instance_double('Developers::NotificationService')
+      notification_service = instance_double("Developers::NotificationService")
       allow(notification_service).to receive(:execute)
       subject =
         described_class.new(
@@ -133,7 +134,7 @@ describe Cohorts::AddStudentsService do
       end
     end
 
-    context 'course already has students' do
+    context "course already has students" do
       let!(:persisted_team_1) { create :team_with_students, cohort: cohort }
       let!(:persisted_team_2) { create :team_with_students, cohort: cohort }
       let!(:student_1) { persisted_team_1.founders.first }
@@ -148,7 +149,7 @@ describe Cohorts::AddStudentsService do
         )
       end
 
-      it 'ignores persisted student emails when present in the list to add' do
+      it "ignores persisted student emails when present in the list to add" do
         students_data = [
           student_1_data,
           student_2_data,
@@ -164,21 +165,21 @@ describe Cohorts::AddStudentsService do
       end
     end
 
-    context 'when a student being added is already a registered user' do
+    context "when a student being added is already a registered user" do
       let(:name) { Faker::Name.name }
       let(:title) { Faker::Job.title }
       let(:affiliation) { Faker::Company.name }
       let!(:user) do
         create :user,
                name: name,
-               email: 'user@example.com',
+               email: "user@example.com",
                title: title,
                affiliation: affiliation
       end
 
-      it 'onboards the student without altering their name, title or affiliation' do
+      it "onboards the student without altering their name, title or affiliation" do
         students_data = [
-          OpenStruct.new(name: Faker::Name.name, email: 'User@example.com')
+          OpenStruct.new(name: Faker::Name.name, email: "User@example.com")
         ]
 
         expect { subject.add(students_data) }.to change {
@@ -190,12 +191,12 @@ describe Cohorts::AddStudentsService do
       end
     end
 
-    context 'when the data includes a student alone in a team' do
+    context "when the data includes a student alone in a team" do
       let!(:student_data) do
         OpenStruct.new(
           name: Faker::Name.name,
           email: Faker::Internet.email,
-          team_name: 'Alone in this team'
+          team_name: "Alone in this team"
         )
       end
 
@@ -204,15 +205,16 @@ describe Cohorts::AddStudentsService do
           cohort.founders.count
         }.by(1)
 
-        expect { subject.add([student_data]) }.to change { cohort.teams.count }
-          .by(0)
+        expect { subject.add([student_data]) }.to change {
+          cohort.teams.count
+        }.by(0)
       end
     end
 
-    context 'notifications is not enabled' do
+    context "notifications is not enabled" do
       let(:notify) { false }
 
-      it 'does not send notifications to the new students added' do
+      it "does not send notifications to the new students added" do
         students_data = [student_1_data, student_2_data]
 
         expect { subject.add(students_data) }.to change {
@@ -222,6 +224,40 @@ describe Cohorts::AddStudentsService do
         open_email(student_1_data.email)
 
         expect(current_email).to eq(nil)
+      end
+    end
+
+    context "when notify flag is set to false" do
+      let(:notify) { false }
+
+      it "does not regenerate login token" do
+        students_data = [student_1_data, student_2_data]
+
+        expect { subject.add(students_data) }.to change {
+          cohort.founders.count
+        }.by(2)
+
+        student_1_token_digest =
+          User.find_by(email: student_1_data.email).login_token_digest
+
+        expect(student_1_token_digest).to eq(nil)
+      end
+    end
+
+    context "when notify flag is set to true" do
+      let(:notify) { true }
+
+      it "regenerates login token" do
+        students_data = [student_1_data, student_2_data]
+
+        expect { subject.add(students_data) }.to change {
+          cohort.founders.count
+        }.by(2)
+
+        student_1_token_digest =
+          User.find_by(email: student_1_data.email).login_token_digest
+
+        expect(student_1_token_digest).not_to eq(nil)
       end
     end
   end


### PR DESCRIPTION
## Proposed Changes

Fixes #1103 

- Remove the redundant token generation in `add_student_service` as already tokens are getting generated in `student_mailer`
- Add specs

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
~~- [ ] Check if route, query, or mutation authorization looks correct.~~
 ~~- Add tests for authorization, if required.~~
~~- [ ] Ensure that UI text is kept in I18n files.~~
~~- [ ] Update developer and product docs, where applicable.~~
~~- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.~~
~~- [ ] Check if new tables or columns that have been added need to be handled in the following services:~~
 ~~ - `Users::DeleteAccountService`~~
  ~~- `Courses::CloneService`~~
  ~~- `Courses::DeleteService`~~
  ~~- `Courses::DemoContentService`~~
  ~~- `Levels::CloneService`~~
  ~~- `Schools::DeleteService`~~
~~- [ ] Check if changes in _packaged_ components have been published to `npm`.~~
~~- [ ] Add development seeds for new tables.~~
~~- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
