### PR TITLE
Fix bug in course editor 

### DIFF
--- a/app/frontend/admin/courses/CourseEditor__Root.res
+++ b/app/frontend/admin/courses/CourseEditor__Root.res
@@ -467,33 +467,25 @@ let showCourse = course => {
 
 let showCourses = (courses, state) => {
   <div className="w-full">
-    {ArrayUtils.isEmpty(courses)
-      ? <div
-          className="flex flex-col mx-auto bg-white rounded-md border p-6 justify-center items-center">
-          <FaIcon classes="fas fa-comments text-5xl text-gray-400" />
-          <h4 className="mt-3 text-base md:text-lg text-center font-semibold">
-            {t("empty_courses")->str}
-          </h4>
-        </div>
-      : <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mt-8">
-          <div
-            className="bg-gray-100 border-2 border-gray-300 border-dashed rounded-lg p-4 text-center grid place-items-center">
-            <EmptyState
-              title={t("add_new_course")}
-              description={t("create_description")}
-              primaryAction={<button
-                className="btn btn-primary btn-lg"
-                onClick={_ => {
-                  RescriptReactRouter.push("/school/courses/new")
-                }}>
-                <PfIcon className="if i-plus-circle-regular if-fw" />
-                <span className="font-semibold ms-1"> {str(t("add_new_course"))} </span>
-              </button>}
-              image={<img src={addNewCourseSVG} />}
-            />
-          </div>
-          {Js.Array.map(course => showCourse(course), courses)->React.array}
-        </div>}
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mt-8">
+      <div
+        className="bg-gray-100 border-2 border-gray-300 border-dashed rounded-lg p-4 text-center grid place-items-center">
+        <EmptyState
+          title={t("add_new_course")}
+          description={t("create_description")}
+          primaryAction={<button
+            className="btn btn-primary btn-lg"
+            onClick={_ => {
+              RescriptReactRouter.push("/school/courses/new")
+            }}>
+            <PfIcon className="if i-plus-circle-regular if-fw" />
+            <span className="font-semibold ms-1"> {str(t("add_new_course"))} </span>
+          </button>}
+          image={<img src={addNewCourseSVG} />}
+        />
+      </div>
+      {courses->Js.Array2.map(showCourse)->React.array}
+    </div>
     {entriesLoadedData(state.totalEntriesCount, Array.length(courses))}
   </div>
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -454,7 +454,6 @@ en:
       courses_partially_loaded_text: Showing %{loaded_courses_count} of %{total_courses} courses
       create_description: Let's create another course.
       edit_course_details: Edit Course Details
-      empty_courses: You don't have any courses!
       filter:
         input_hint: Or start typing to search by name...
         input_label: Search

--- a/spec/system/school/courses_index_spec.rb
+++ b/spec/system/school/courses_index_spec.rb
@@ -8,22 +8,7 @@ feature "Courses Index", js: true do
 
   # Setup a course with a single founder target, ...
   let!(:school) { create :school, :current }
-  let!(:course_1) { create :course, :with_default_cohort, school: school }
-  let!(:course_2) do
-    create :course,
-           :with_default_cohort,
-           school: school,
-           name: "Pupilfirst Demo Course"
-  end
-  let!(:course_ended) { create :course, :ended, school: school }
-  let!(:course_archived) do
-    create :course, school: school, archived_at: 1.day.ago
-  end
-
   let!(:school_admin) { create :school_admin, school: school }
-
-  let(:course_name) { Faker::Lorem.words(number: 2).join " " }
-  let(:description) { Faker::Lorem.sentences.join " " }
 
   def file_path(filename)
     File.absolute_path(
@@ -35,454 +20,468 @@ feature "Courses Index", js: true do
     Time.use_zone(school_admin.user.time_zone) { example.run }
   end
 
-  context "when school doesn't have courses on the page" do
-    before { course_archived.update!(archived_at: nil) }
-    after { course_archived.update!(archived_at: Time.now) }
-
+  context "when school has no course" do
     scenario "School admin sees create course option" do
       sign_in_user school_admin.user, referrer: school_courses_path
 
-      fill_in("Search", with: "archived")
-      click_button "Pick Status: Archived"
-
-      expect(page).not_to have_text(course_archived.name)
       expect(page).to have_text("Showing all 0 courses")
       expect(page).to have_button("Add New Course")
     end
   end
 
-  scenario "School admin creates a course" do
-    sign_in_user school_admin.user, referrer: school_courses_path
-
-    # list all courses
-    expect(page).to have_text("Add New Course")
-    expect(page).to have_text(course_1.name)
-    expect(page).to have_text(course_2.name)
-
-    # Add a new course
-    click_button "Add New Course"
-
-    fill_in "Course name", with: course_name
-    fill_in "Course description", with: description
-
-    within("div#public-signup") { click_button "No" }
-
-    click_button "Create Course"
-
-    expect(page).to have_text("Course created successfully")
-    dismiss_notification
-
-    expect(page).to have_text(course_name)
-
-    course = Course.last
-
-    expect(course.name).to eq(course_name)
-    expect(course.description).to eq(description)
-    expect(course.about).to eq(nil)
-    expect(course.enable_leaderboard).to eq(false)
-    expect(course.public_signup).to eq(false)
-    expect(course.public_preview).to eq(false)
-
-    expect(course.progression_behavior).to eq(
-      Course::PROGRESSION_BEHAVIOR_LIMITED
-    )
-
-    expect(course.progression_limit).to eq(1)
-    expect(course.highlights).to eq([])
-    expect(course.processing_url).to eq(nil)
-  end
-
-  context "when a course exists" do
-    let(:new_course_name) { Faker::Lorem.words(number: 2).join " " }
-    let!(:new_cohort) { create :cohort, course: course_1 }
-    let(:new_about) { Faker::Lorem.paragraph }
-    let(:new_description) { Faker::Lorem.sentences.join " " }
-    let(:course_end_date) { Time.zone.today }
-    let(:processing_url) { Faker::Internet.url }
-    let(:highlights) do
-      [
-        {
-          icon: Types::CourseHighlightInputType.allowed_icons.sample,
-          title: Faker::Lorem.words(number: 2).join(" ").titleize,
-          description: Faker::Lorem.paragraph
-        },
-        {
-          icon: Types::CourseHighlightInputType.allowed_icons.sample,
-          title: Faker::Lorem.words(number: 2).join(" ").titleize,
-          description: Faker::Lorem.paragraph
-        }
-      ]
+  context "when school has courses" do
+    let!(:course_1) { create :course, :with_default_cohort, school: school }
+    let!(:course_2) do
+      create :course,
+             :with_default_cohort,
+             school: school,
+             name: "Pupilfirst Demo Course"
+    end
+    let!(:course_ended) { create :course, :ended, school: school }
+    let!(:course_archived) do
+      create :course, school: school, archived_at: 1.day.ago
     end
 
-    scenario "School admin edits an existing course" do
-      sign_in_user school_admin.user,
-                   referrer: "/school/courses/#{course_1.id}/details"
+    let(:course_name) { Faker::Lorem.words(number: 2).join " " }
+    let(:description) { Faker::Lorem.sentences.join " " }
 
-      fill_in "Course name",
-              with: new_course_name,
-              fill_options: {
-                clear: :backspace
-              }
-      fill_in "Course description",
-              with: new_description,
-              fill_options: {
-                clear: :backspace
-              }
-      replace_markdown new_about
-      select "thrice", from: "progression-limit"
+    scenario "School admin creates a course" do
+      sign_in_user school_admin.user, referrer: school_courses_path
 
-      within("div#public-signup") { click_button "Yes" }
-      within("div#processing-url") { click_button "Yes" }
-      fill_in "processing_url", with: processing_url
+      # list all courses
+      expect(page).to have_text("Add New Course")
+      expect(page).to have_text(course_1.name)
+      expect(page).to have_text(course_2.name)
 
-      click_button "Add Course Highlight"
-      click_button "Add Course Highlight"
+      # Add a new course
+      click_button "Add New Course"
 
-      within('div[data-highlight-index="2"]') do
-        click_button "Select Icon"
-        click_button "Select #{highlights.last[:icon]}"
+      fill_in "Course name", with: course_name
+      fill_in "Course description", with: description
 
-        fill_in "highlight-2-title",
-                with: highlights.last[:title],
-                fill_options: {
-                  clear: :backspace
-                }
-        fill_in "highlight-2-description",
-                with: highlights.last[:description],
-                fill_options: {
-                  clear: :backspace
-                }
-        click_button "Move Down"
-      end
+      within("div#public-signup") { click_button "No" }
 
-      within('div[data-highlight-index="2"]') do
-        click_button "Select Icon"
+      click_button "Create Course"
 
-        click_button "Select #{highlights.first[:icon]}"
+      expect(page).to have_text("Course created successfully")
+      dismiss_notification
 
-        fill_in "highlight-2-title",
-                with: highlights.first[:title],
-                fill_options: {
-                  clear: :backspace
-                }
-        fill_in "highlight-2-description",
-                with: highlights.first[:description],
-                fill_options: {
-                  clear: :backspace
-                }
-      end
+      expect(page).to have_text(course_name)
 
-      within('div[data-highlight-index="0"]') do
-        click_button "Delete highlight"
-        click_button "Delete highlight"
-      end
-      within("div#public-preview") { click_button "Yes" }
+      course = Course.last
 
-      click_button course_1.default_cohort.name
-      click_button new_cohort.name
+      expect(course.name).to eq(course_name)
+      expect(course.description).to eq(description)
+      expect(course.about).to eq(nil)
+      expect(course.enable_leaderboard).to eq(false)
+      expect(course.public_signup).to eq(false)
+      expect(course.public_preview).to eq(false)
 
-      click_button "Update Course"
-
-      expect(page).to have_text("Course updated successfully")
-
-      expect(course_1.reload.name).to eq(new_course_name)
-      expect(course_1.description).to eq(new_description)
-      expect(course_1.about).to eq(new_about)
-      expect(course_1.public_signup).to eq(true)
-      expect(course_1.public_preview).to eq(true)
-
-      expect(course_1.progression_behavior).to eq(
+      expect(course.progression_behavior).to eq(
         Course::PROGRESSION_BEHAVIOR_LIMITED
       )
 
-      expect(course_1.progression_limit).to eq(3)
-      expect(course_1.highlights).to eq(highlights.map(&:stringify_keys))
-      expect(course_1.processing_url).to eq(processing_url)
-      expect(course_1.default_cohort).to eq(new_cohort)
+      expect(course.progression_limit).to eq(1)
+      expect(course.highlights).to eq([])
+      expect(course.processing_url).to eq(nil)
     end
 
-    scenario "School admin sets other progression behaviors on existing course" do
+    context "when a course exists" do
+      let(:new_course_name) { Faker::Lorem.words(number: 2).join " " }
+      let!(:new_cohort) { create :cohort, course: course_1 }
+      let(:new_about) { Faker::Lorem.paragraph }
+      let(:new_description) { Faker::Lorem.sentences.join " " }
+      let(:course_end_date) { Time.zone.today }
+      let(:processing_url) { Faker::Internet.url }
+      let(:highlights) do
+        [
+          {
+            icon: Types::CourseHighlightInputType.allowed_icons.sample,
+            title: Faker::Lorem.words(number: 2).join(" ").titleize,
+            description: Faker::Lorem.paragraph
+          },
+          {
+            icon: Types::CourseHighlightInputType.allowed_icons.sample,
+            title: Faker::Lorem.words(number: 2).join(" ").titleize,
+            description: Faker::Lorem.paragraph
+          }
+        ]
+      end
+
+      scenario "School admin edits an existing course" do
+        sign_in_user school_admin.user,
+                     referrer: "/school/courses/#{course_1.id}/details"
+
+        fill_in "Course name",
+                with: new_course_name,
+                fill_options: {
+                  clear: :backspace
+                }
+        fill_in "Course description",
+                with: new_description,
+                fill_options: {
+                  clear: :backspace
+                }
+        replace_markdown new_about
+        select "thrice", from: "progression-limit"
+
+        within("div#public-signup") { click_button "Yes" }
+        within("div#processing-url") { click_button "Yes" }
+        fill_in "processing_url", with: processing_url
+
+        click_button "Add Course Highlight"
+        click_button "Add Course Highlight"
+
+        within('div[data-highlight-index="2"]') do
+          click_button "Select Icon"
+          click_button "Select #{highlights.last[:icon]}"
+
+          fill_in "highlight-2-title",
+                  with: highlights.last[:title],
+                  fill_options: {
+                    clear: :backspace
+                  }
+          fill_in "highlight-2-description",
+                  with: highlights.last[:description],
+                  fill_options: {
+                    clear: :backspace
+                  }
+          click_button "Move Down"
+        end
+
+        within('div[data-highlight-index="2"]') do
+          click_button "Select Icon"
+
+          click_button "Select #{highlights.first[:icon]}"
+
+          fill_in "highlight-2-title",
+                  with: highlights.first[:title],
+                  fill_options: {
+                    clear: :backspace
+                  }
+          fill_in "highlight-2-description",
+                  with: highlights.first[:description],
+                  fill_options: {
+                    clear: :backspace
+                  }
+        end
+
+        within('div[data-highlight-index="0"]') do
+          click_button "Delete highlight"
+          click_button "Delete highlight"
+        end
+        within("div#public-preview") { click_button "Yes" }
+
+        click_button course_1.default_cohort.name
+        click_button new_cohort.name
+
+        click_button "Update Course"
+
+        expect(page).to have_text("Course updated successfully")
+
+        expect(course_1.reload.name).to eq(new_course_name)
+        expect(course_1.description).to eq(new_description)
+        expect(course_1.about).to eq(new_about)
+        expect(course_1.public_signup).to eq(true)
+        expect(course_1.public_preview).to eq(true)
+
+        expect(course_1.progression_behavior).to eq(
+          Course::PROGRESSION_BEHAVIOR_LIMITED
+        )
+
+        expect(course_1.progression_limit).to eq(3)
+        expect(course_1.highlights).to eq(highlights.map(&:stringify_keys))
+        expect(course_1.processing_url).to eq(processing_url)
+        expect(course_1.default_cohort).to eq(new_cohort)
+      end
+
+      scenario "School admin sets other progression behaviors on existing course" do
+        sign_in_user school_admin.user, referrer: school_courses_path
+
+        find("button[title='Edit #{course_1.name}']").click
+
+        click_button "Unlimited"
+        click_button "Update Course"
+
+        expect(page).to have_text("Course updated successfully")
+        expect(course_1.reload.progression_behavior).to eq(
+          Course::PROGRESSION_BEHAVIOR_UNLIMITED
+        )
+        expect(course_1.progression_limit).to eq(nil)
+
+        find("button[title='Edit #{course_1.name}']").click
+
+        click_button "Strict"
+        click_button "Update Course"
+
+        expect(page).to have_text("Course updated successfully")
+
+        expect(course_1.reload.progression_behavior).to eq(
+          Course::PROGRESSION_BEHAVIOR_STRICT
+        )
+        expect(course_1.progression_limit).to eq(nil)
+      end
+
+      scenario "School admin edits images associated with the course" do
+        sign_in_user school_admin.user,
+                     referrer: "/school/courses/#{course_1.id}/images"
+
+        expect(page).to have_text("Please choose an image file.", count: 2)
+
+        attach_file "course_thumbnail",
+                    file_path("logo_lipsum_on_light_bg.png"),
+                    visible: false
+        attach_file "course_cover",
+                    file_path("logo_lipsum_on_dark_bg.png"),
+                    visible: false
+
+        click_button "Update Images"
+
+        expect(page).to have_text("Images have been updated successfully")
+
+        find("button[title='Edit #{course_1.name}']").click
+        click_button "Images"
+
+        expect(page).to have_text(
+          "Please pick a file to replace logo_lipsum_on_light_bg.png"
+        )
+        expect(page).to have_text(
+          "Please pick a file to replace logo_lipsum_on_dark_bg.png"
+        )
+
+        expect(course_1.cover).to be_attached
+        expect(course_1.thumbnail).to be_attached
+      end
+
+      scenario "School admin edits images associated with the archived course" do
+        sign_in_user school_admin.user,
+                     referrer: "/school/courses/#{course_archived.id}/images"
+
+        expect(page).to have_text("Please choose an image file.", count: 2)
+
+        attach_file "course_thumbnail",
+                    file_path("logo_lipsum_on_light_bg.png"),
+                    visible: false
+        attach_file "course_cover",
+                    file_path("logo_lipsum_on_dark_bg.png"),
+                    visible: false
+
+        click_button "Update Images"
+
+        expect(page).to have_text("Images have been updated successfully")
+
+        fill_in("Search", with: "archived")
+        click_button "Pick Status: Archived"
+
+        find("button[title='Edit #{course_archived.name}']").click
+        click_button "Images"
+
+        expect(page).to have_text(
+          "Please pick a file to replace logo_lipsum_on_light_bg.png"
+        )
+        expect(page).to have_text(
+          "Please pick a file to replace logo_lipsum_on_dark_bg.png"
+        )
+
+        expect(course_archived.cover).to be_attached
+        expect(course_archived.thumbnail).to be_attached
+      end
+    end
+
+    context "with many courses" do
+      before { 23.times { create :course, :with_cohort, school: school } }
+
+      scenario "school admin loads all courses" do
+        sign_in_user school_admin.user, referrer: school_courses_path
+
+        expect(page).to have_text("Showing 10 of 25 courses")
+        click_button "Load More Courses..."
+
+        expect(page).to have_text("Showing 20 of 25 courses")
+        click_button "Load More Courses..."
+
+        expect(page).to have_text("Showing all 25 courses")
+        expect(page).not_to have_text("Load More Courses...")
+      end
+
+      scenario "school admin loads details route for last course" do
+        sign_in_user school_admin.user,
+                     referrer:
+                       "/school/courses/#{school.courses.last.id}/details"
+
+        expect(page).to have_text("EDIT COURSE DETAILS")
+      end
+    end
+
+    scenario "user who is not logged in gets redirected to sign in page" do
+      visit school_courses_path
+      expect(page).to have_text("Please sign in to continue.")
+    end
+
+    scenario "school admin searches and filters courses" do
       sign_in_user school_admin.user, referrer: school_courses_path
 
-      find("button[title='Edit #{course_1.name}']").click
+      expect(page).to have_text("Status: Active")
 
-      click_button "Unlimited"
-      click_button "Update Course"
+      within("div[id='courses']") do
+        expect(page).to have_text(course_1.name)
 
-      expect(page).to have_text("Course updated successfully")
-      expect(course_1.reload.progression_behavior).to eq(
-        Course::PROGRESSION_BEHAVIOR_UNLIMITED
-      )
-      expect(course_1.progression_limit).to eq(nil)
+        expect(page).not_to have_text(course_ended.name)
+        expect(page).not_to have_text(course_archived.name)
+      end
 
-      find("button[title='Edit #{course_1.name}']").click
+      fill_in("Search", with: "ended")
+      click_button "Pick Status: Ended"
 
-      click_button "Strict"
-      click_button "Update Course"
-
-      expect(page).to have_text("Course updated successfully")
-
-      expect(course_1.reload.progression_behavior).to eq(
-        Course::PROGRESSION_BEHAVIOR_STRICT
-      )
-      expect(course_1.progression_limit).to eq(nil)
-    end
-
-    scenario "School admin edits images associated with the course" do
-      sign_in_user school_admin.user,
-                   referrer: "/school/courses/#{course_1.id}/images"
-
-      expect(page).to have_text("Please choose an image file.", count: 2)
-
-      attach_file "course_thumbnail",
-                  file_path("logo_lipsum_on_light_bg.png"),
-                  visible: false
-      attach_file "course_cover",
-                  file_path("logo_lipsum_on_dark_bg.png"),
-                  visible: false
-
-      click_button "Update Images"
-
-      expect(page).to have_text("Images have been updated successfully")
-
-      find("button[title='Edit #{course_1.name}']").click
-      click_button "Images"
-
-      expect(page).to have_text(
-        "Please pick a file to replace logo_lipsum_on_light_bg.png"
-      )
-      expect(page).to have_text(
-        "Please pick a file to replace logo_lipsum_on_dark_bg.png"
-      )
-
-      expect(course_1.cover).to be_attached
-      expect(course_1.thumbnail).to be_attached
-    end
-
-    scenario "School admin edits images associated with the archived course" do
-      sign_in_user school_admin.user,
-                   referrer: "/school/courses/#{course_archived.id}/images"
-
-      expect(page).to have_text("Please choose an image file.", count: 2)
-
-      attach_file "course_thumbnail",
-                  file_path("logo_lipsum_on_light_bg.png"),
-                  visible: false
-      attach_file "course_cover",
-                  file_path("logo_lipsum_on_dark_bg.png"),
-                  visible: false
-
-      click_button "Update Images"
-
-      expect(page).to have_text("Images have been updated successfully")
+      within("div[id='courses']") do
+        expect(page).not_to have_text(course_1.name)
+        expect(page).to have_text(course_ended.name)
+        expect(page).not_to have_text(course_archived.name)
+      end
 
       fill_in("Search", with: "archived")
       click_button "Pick Status: Archived"
 
-      find("button[title='Edit #{course_archived.name}']").click
-      click_button "Images"
-
-      expect(page).to have_text(
-        "Please pick a file to replace logo_lipsum_on_light_bg.png"
-      )
-      expect(page).to have_text(
-        "Please pick a file to replace logo_lipsum_on_dark_bg.png"
-      )
-
-      expect(course_archived.cover).to be_attached
-      expect(course_archived.thumbnail).to be_attached
-    end
-  end
-
-  context "with many courses" do
-    before { 23.times { create :course, :with_cohort, school: school } }
-
-    scenario "school admin loads all courses" do
-      sign_in_user school_admin.user, referrer: school_courses_path
-
-      expect(page).to have_text("Showing 10 of 25 courses")
-      click_button "Load More Courses..."
-
-      expect(page).to have_text("Showing 20 of 25 courses")
-      click_button "Load More Courses..."
-
-      expect(page).to have_text("Showing all 25 courses")
-      expect(page).not_to have_text("Load More Courses...")
-    end
-
-    scenario "school admin loads details route for last course" do
-      sign_in_user school_admin.user,
-                   referrer: "/school/courses/#{school.courses.last.id}/details"
-
-      expect(page).to have_text("EDIT COURSE DETAILS")
-    end
-  end
-
-  scenario "user who is not logged in gets redirected to sign in page" do
-    visit school_courses_path
-    expect(page).to have_text("Please sign in to continue.")
-  end
-
-  scenario "school admin searches and filters courses" do
-    sign_in_user school_admin.user, referrer: school_courses_path
-
-    expect(page).to have_text("Status: Active")
-
-    within("div[id='courses']") do
-      expect(page).to have_text(course_1.name)
-
-      expect(page).not_to have_text(course_ended.name)
-      expect(page).not_to have_text(course_archived.name)
-    end
-
-    fill_in("Search", with: "ended")
-    click_button "Pick Status: Ended"
-
-    within("div[id='courses']") do
-      expect(page).not_to have_text(course_1.name)
-      expect(page).to have_text(course_ended.name)
-      expect(page).not_to have_text(course_archived.name)
-    end
-
-    fill_in("Search", with: "archived")
-    click_button "Pick Status: Archived"
-
-    within("div[id='courses']") do
-      expect(page).not_to have_text(course_1.name)
-      expect(page).not_to have_text(course_ended.name)
-      expect(page).to have_text(course_archived.name)
-    end
-
-    click_button "Remove selection: Archived"
-    fill_in("Search", with: "pupilfirst demo course")
-    click_button "Pick Search by name: pupilfirst demo course"
-
-    within("div[id='courses']") { expect(page).to have_text(course_2.name) }
-  end
-
-  scenario "school admin filters archived courses" do
-    sign_in_user school_admin.user, referrer: school_courses_path
-
-    fill_in("Search", with: "archived")
-    click_button "Pick Status: Archived"
-
-    within("div[id='courses']") do
-      expect(page).to have_text(course_archived.name)
-      expect(page).not_to have_text("View public page")
-      expect(page).not_to have_text("Quick Links")
-    end
-  end
-
-  scenario "school admin clicks on quick links" do
-    sign_in_user school_admin.user, referrer: school_courses_path
-
-    within("div[data-t='#{course_1.name}']") do
-      expect(page).to have_link("View public page", href: course_path(course_1))
-
-      click_button "Quick Links"
-      expect(page).to have_link(
-        "View as Student",
-        href: curriculum_course_path(course_1)
-      )
-      expect(page).to have_link(
-        "Edit Curriculum",
-        href: curriculum_school_course_path(course_1)
-      )
-      expect(page).to have_link(
-        "Manage Students",
-        href: school_course_students_path(course_1)
-      )
-      expect(page).to have_link(
-        "Manage Coaches",
-        href: school_course_coaches_path(course_1)
-      )
-      expect(page).to have_link(
-        "Download Reports",
-        href: exports_school_course_path(course_1)
-      )
-    end
-  end
-
-  scenario "school admin visits details route for archived course" do
-    sign_in_user school_admin.user,
-                 referrer: "/school/courses/#{course_archived.id}/details"
-    expect(page).to have_text("EDIT COURSE DETAILS")
-  end
-
-  context "when students exist in a course" do
-    let!(:level) { create :level, course: course_1 }
-    let!(:student) { create :student, level: level }
-
-    scenario "school admin archives a course" do
-      notification_service = prepare_developers_notification
-      sign_in_user school_admin.user,
-                   referrer: "/school/courses/#{course_1.id}/actions"
-
-      expect(page).to have_text("Do you want to archive the course?")
-
-      accept_confirm { click_button("Archive Course") }
-
-      expect(page).to have_text("Course archived successfully")
-      expect(course_1.reload.archived_at).not_to eq(nil)
-      expect(course_1.cohorts.first.ends_at).not_to eq(nil)
       within("div[id='courses']") do
         expect(page).not_to have_text(course_1.name)
+        expect(page).not_to have_text(course_ended.name)
+        expect(page).to have_text(course_archived.name)
+      end
+
+      click_button "Remove selection: Archived"
+      fill_in("Search", with: "pupilfirst demo course")
+      click_button "Pick Search by name: pupilfirst demo course"
+
+      within("div[id='courses']") { expect(page).to have_text(course_2.name) }
+    end
+
+    scenario "school admin filters archived courses" do
+      sign_in_user school_admin.user, referrer: school_courses_path
+
+      fill_in("Search", with: "archived")
+      click_button "Pick Status: Archived"
+
+      within("div[id='courses']") do
+        expect(page).to have_text(course_archived.name)
+        expect(page).not_to have_text("View public page")
+        expect(page).not_to have_text("Quick Links")
+      end
+    end
+
+    scenario "school admin clicks on quick links" do
+      sign_in_user school_admin.user, referrer: school_courses_path
+
+      within("div[data-t='#{course_1.name}']") do
+        expect(page).to have_link(
+          "View public page",
+          href: course_path(course_1)
+        )
+
+        click_button "Quick Links"
+        expect(page).to have_link(
+          "View as Student",
+          href: curriculum_course_path(course_1)
+        )
+        expect(page).to have_link(
+          "Edit Curriculum",
+          href: curriculum_school_course_path(course_1)
+        )
+        expect(page).to have_link(
+          "Manage Students",
+          href: school_course_students_path(course_1)
+        )
+        expect(page).to have_link(
+          "Manage Coaches",
+          href: school_course_coaches_path(course_1)
+        )
+        expect(page).to have_link(
+          "Download Reports",
+          href: exports_school_course_path(course_1)
+        )
+      end
+    end
+
+    scenario "school admin visits details route for archived course" do
+      sign_in_user school_admin.user,
+                   referrer: "/school/courses/#{course_archived.id}/details"
+      expect(page).to have_text("EDIT COURSE DETAILS")
+    end
+
+    context "when students exist in a course" do
+      let!(:level) { create :level, course: course_1 }
+      let!(:student) { create :student, level: level }
+
+      scenario "school admin archives a course" do
+        notification_service = prepare_developers_notification
+        sign_in_user school_admin.user,
+                     referrer: "/school/courses/#{course_1.id}/actions"
+
+        expect(page).to have_text("Do you want to archive the course?")
+
+        accept_confirm { click_button("Archive Course") }
+
+        expect(page).to have_text("Course archived successfully")
+        expect(course_1.reload.archived_at).not_to eq(nil)
+        expect(course_1.cohorts.first.ends_at).not_to eq(nil)
+        within("div[id='courses']") do
+          expect(page).not_to have_text(course_1.name)
+        end
+        expect_published(
+          notification_service,
+          course_1,
+          :course_archived,
+          school_admin.user,
+          course_1
+        )
+      end
+    end
+
+    scenario "school admin un-archives a course" do
+      notification_service = prepare_developers_notification
+      sign_in_user school_admin.user, referrer: school_courses_path
+
+      fill_in("Search", with: "archived")
+      click_button "Pick Status: Archived"
+      find("button[title='Edit #{course_archived.name}']").click
+      click_button "Actions"
+
+      expect(page).to have_text("Do you want to unarchive the course?")
+
+      accept_confirm { click_button("Unarchive Course") }
+
+      expect(page).to have_text("Course unarchived successfully")
+      expect(course_archived.reload.archived_at).to eq(nil)
+      within("div[id='courses']") do
+        expect(page).not_to have_text(course_archived.name)
       end
       expect_published(
         notification_service,
-        course_1,
-        :course_archived,
+        course_archived,
+        :course_unarchived,
         school_admin.user,
-        course_1
+        course_archived
       )
     end
-  end
 
-  scenario "school admin un-archives a course" do
-    notification_service = prepare_developers_notification
-    sign_in_user school_admin.user, referrer: school_courses_path
+    scenario "school admin makes a copy of a course" do
+      sign_in_user school_admin.user, referrer: school_courses_path
+      find("button[title='Edit #{course_1.name}']").click
+      click_button "Actions"
 
-    fill_in("Search", with: "archived")
-    click_button "Pick Status: Archived"
-    find("button[title='Edit #{course_archived.name}']").click
-    click_button "Actions"
+      expect(page).to have_text("Do you want to create a copy of the course?")
 
-    expect(page).to have_text("Do you want to unarchive the course?")
+      accept_confirm { click_button("Clone Course") }
 
-    accept_confirm { click_button("Unarchive Course") }
+      expect(page).to have_text(
+        "Course copy requested. It will appear here soon!"
+      )
 
-    expect(page).to have_text("Course unarchived successfully")
-    expect(course_archived.reload.archived_at).to eq(nil)
-    within("div[id='courses']") do
-      expect(page).not_to have_text(course_archived.name)
-    end
-    expect_published(
-      notification_service,
-      course_archived,
-      :course_unarchived,
-      school_admin.user,
-      course_archived
-    )
-  end
-
-  scenario "school admin makes a copy of a course" do
-    sign_in_user school_admin.user, referrer: school_courses_path
-    find("button[title='Edit #{course_1.name}']").click
-    click_button "Actions"
-
-    expect(page).to have_text("Do you want to create a copy of the course?")
-
-    accept_confirm { click_button("Clone Course") }
-
-    expect(page).to have_text(
-      "Course copy requested. It will appear here soon!"
-    )
-
-    visit school_courses_path
-    fill_in("Search", with: "ended")
-    click_button "Pick Status: Ended"
-    within("div[id='courses']") do
-      expect(page).to have_text(course_1.name + " - copy")
+      visit school_courses_path
+      fill_in("Search", with: "ended")
+      click_button "Pick Status: Ended"
+      within("div[id='courses']") do
+        expect(page).to have_text(course_1.name + " - copy")
+      end
     end
   end
 end

--- a/spec/system/school/courses_index_spec.rb
+++ b/spec/system/school/courses_index_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Courses Index', js: true do
+feature "Courses Index", js: true do
   include UserSpecHelper
   include NotificationHelper
   include MarkdownEditorHelper
@@ -13,7 +13,7 @@ feature 'Courses Index', js: true do
     create :course,
            :with_default_cohort,
            school: school,
-           name: 'Pupilfirst Demo Course'
+           name: "Pupilfirst Demo Course"
   end
   let!(:course_ended) { create :course, :ended, school: school }
   let!(:course_archived) do
@@ -22,12 +22,12 @@ feature 'Courses Index', js: true do
 
   let!(:school_admin) { create :school_admin, school: school }
 
-  let(:course_name) { Faker::Lorem.words(number: 2).join ' ' }
-  let(:description) { Faker::Lorem.sentences.join ' ' }
+  let(:course_name) { Faker::Lorem.words(number: 2).join " " }
+  let(:description) { Faker::Lorem.sentences.join " " }
 
   def file_path(filename)
     File.absolute_path(
-      Rails.root.join('spec', 'support', 'uploads', 'files', filename)
+      Rails.root.join("spec", "support", "uploads", "files", filename)
     )
   end
 
@@ -35,25 +35,41 @@ feature 'Courses Index', js: true do
     Time.use_zone(school_admin.user.time_zone) { example.run }
   end
 
-  scenario 'School admin creates a course' do
+  context "when school doesn't have courses on the page" do
+    before { course_archived.update!(archived_at: nil) }
+    after { course_archived.update!(archived_at: Time.now) }
+
+    scenario "School admin sees create course option" do
+      sign_in_user school_admin.user, referrer: school_courses_path
+
+      fill_in("Search", with: "archived")
+      click_button "Pick Status: Archived"
+
+      expect(page).not_to have_text(course_archived.name)
+      expect(page).to have_text("Showing all 0 courses")
+      expect(page).to have_button("Add New Course")
+    end
+  end
+
+  scenario "School admin creates a course" do
     sign_in_user school_admin.user, referrer: school_courses_path
 
     # list all courses
-    expect(page).to have_text('Add New Course')
+    expect(page).to have_text("Add New Course")
     expect(page).to have_text(course_1.name)
     expect(page).to have_text(course_2.name)
 
     # Add a new course
-    click_button 'Add New Course'
+    click_button "Add New Course"
 
-    fill_in 'Course name', with: course_name
-    fill_in 'Course description', with: description
+    fill_in "Course name", with: course_name
+    fill_in "Course description", with: description
 
-    within('div#public-signup') { click_button 'No' }
+    within("div#public-signup") { click_button "No" }
 
-    click_button 'Create Course'
+    click_button "Create Course"
 
-    expect(page).to have_text('Course created successfully')
+    expect(page).to have_text("Course created successfully")
     dismiss_notification
 
     expect(page).to have_text(course_name)
@@ -76,80 +92,80 @@ feature 'Courses Index', js: true do
     expect(course.processing_url).to eq(nil)
   end
 
-  context 'when a course exists' do
-    let(:new_course_name) { Faker::Lorem.words(number: 2).join ' ' }
+  context "when a course exists" do
+    let(:new_course_name) { Faker::Lorem.words(number: 2).join " " }
     let!(:new_cohort) { create :cohort, course: course_1 }
     let(:new_about) { Faker::Lorem.paragraph }
-    let(:new_description) { Faker::Lorem.sentences.join ' ' }
+    let(:new_description) { Faker::Lorem.sentences.join " " }
     let(:course_end_date) { Time.zone.today }
     let(:processing_url) { Faker::Internet.url }
     let(:highlights) do
       [
         {
           icon: Types::CourseHighlightInputType.allowed_icons.sample,
-          title: Faker::Lorem.words(number: 2).join(' ').titleize,
+          title: Faker::Lorem.words(number: 2).join(" ").titleize,
           description: Faker::Lorem.paragraph
         },
         {
           icon: Types::CourseHighlightInputType.allowed_icons.sample,
-          title: Faker::Lorem.words(number: 2).join(' ').titleize,
+          title: Faker::Lorem.words(number: 2).join(" ").titleize,
           description: Faker::Lorem.paragraph
         }
       ]
     end
 
-    scenario 'School admin edits an existing course' do
+    scenario "School admin edits an existing course" do
       sign_in_user school_admin.user,
                    referrer: "/school/courses/#{course_1.id}/details"
 
-      fill_in 'Course name',
+      fill_in "Course name",
               with: new_course_name,
               fill_options: {
                 clear: :backspace
               }
-      fill_in 'Course description',
+      fill_in "Course description",
               with: new_description,
               fill_options: {
                 clear: :backspace
               }
       replace_markdown new_about
-      select 'thrice', from: 'progression-limit'
+      select "thrice", from: "progression-limit"
 
-      within('div#public-signup') { click_button 'Yes' }
-      within('div#processing-url') { click_button 'Yes' }
-      fill_in 'processing_url', with: processing_url
+      within("div#public-signup") { click_button "Yes" }
+      within("div#processing-url") { click_button "Yes" }
+      fill_in "processing_url", with: processing_url
 
-      click_button 'Add Course Highlight'
-      click_button 'Add Course Highlight'
+      click_button "Add Course Highlight"
+      click_button "Add Course Highlight"
 
       within('div[data-highlight-index="2"]') do
-        click_button 'Select Icon'
+        click_button "Select Icon"
         click_button "Select #{highlights.last[:icon]}"
 
-        fill_in 'highlight-2-title',
+        fill_in "highlight-2-title",
                 with: highlights.last[:title],
                 fill_options: {
                   clear: :backspace
                 }
-        fill_in 'highlight-2-description',
+        fill_in "highlight-2-description",
                 with: highlights.last[:description],
                 fill_options: {
                   clear: :backspace
                 }
-        click_button 'Move Down'
+        click_button "Move Down"
       end
 
       within('div[data-highlight-index="2"]') do
-        click_button 'Select Icon'
+        click_button "Select Icon"
 
         click_button "Select #{highlights.first[:icon]}"
 
-        fill_in 'highlight-2-title',
+        fill_in "highlight-2-title",
                 with: highlights.first[:title],
                 fill_options: {
                   clear: :backspace
                 }
-        fill_in 'highlight-2-description',
+        fill_in "highlight-2-description",
                 with: highlights.first[:description],
                 fill_options: {
                   clear: :backspace
@@ -157,17 +173,17 @@ feature 'Courses Index', js: true do
       end
 
       within('div[data-highlight-index="0"]') do
-        click_button 'Delete highlight'
-        click_button 'Delete highlight'
+        click_button "Delete highlight"
+        click_button "Delete highlight"
       end
-      within('div#public-preview') { click_button 'Yes' }
+      within("div#public-preview") { click_button "Yes" }
 
       click_button course_1.default_cohort.name
       click_button new_cohort.name
 
-      click_button 'Update Course'
+      click_button "Update Course"
 
-      expect(page).to have_text('Course updated successfully')
+      expect(page).to have_text("Course updated successfully")
 
       expect(course_1.reload.name).to eq(new_course_name)
       expect(course_1.description).to eq(new_description)
@@ -185,15 +201,15 @@ feature 'Courses Index', js: true do
       expect(course_1.default_cohort).to eq(new_cohort)
     end
 
-    scenario 'School admin sets other progression behaviors on existing course' do
+    scenario "School admin sets other progression behaviors on existing course" do
       sign_in_user school_admin.user, referrer: school_courses_path
 
       find("button[title='Edit #{course_1.name}']").click
 
-      click_button 'Unlimited'
-      click_button 'Update Course'
+      click_button "Unlimited"
+      click_button "Update Course"
 
-      expect(page).to have_text('Course updated successfully')
+      expect(page).to have_text("Course updated successfully")
       expect(course_1.reload.progression_behavior).to eq(
         Course::PROGRESSION_BEHAVIOR_UNLIMITED
       )
@@ -201,10 +217,10 @@ feature 'Courses Index', js: true do
 
       find("button[title='Edit #{course_1.name}']").click
 
-      click_button 'Strict'
-      click_button 'Update Course'
+      click_button "Strict"
+      click_button "Update Course"
 
-      expect(page).to have_text('Course updated successfully')
+      expect(page).to have_text("Course updated successfully")
 
       expect(course_1.reload.progression_behavior).to eq(
         Course::PROGRESSION_BEHAVIOR_STRICT
@@ -212,65 +228,65 @@ feature 'Courses Index', js: true do
       expect(course_1.progression_limit).to eq(nil)
     end
 
-    scenario 'School admin edits images associated with the course' do
+    scenario "School admin edits images associated with the course" do
       sign_in_user school_admin.user,
                    referrer: "/school/courses/#{course_1.id}/images"
 
-      expect(page).to have_text('Please choose an image file.', count: 2)
+      expect(page).to have_text("Please choose an image file.", count: 2)
 
-      attach_file 'course_thumbnail',
-                  file_path('logo_lipsum_on_light_bg.png'),
+      attach_file "course_thumbnail",
+                  file_path("logo_lipsum_on_light_bg.png"),
                   visible: false
-      attach_file 'course_cover',
-                  file_path('logo_lipsum_on_dark_bg.png'),
+      attach_file "course_cover",
+                  file_path("logo_lipsum_on_dark_bg.png"),
                   visible: false
 
-      click_button 'Update Images'
+      click_button "Update Images"
 
-      expect(page).to have_text('Images have been updated successfully')
+      expect(page).to have_text("Images have been updated successfully")
 
       find("button[title='Edit #{course_1.name}']").click
-      click_button 'Images'
+      click_button "Images"
 
       expect(page).to have_text(
-        'Please pick a file to replace logo_lipsum_on_light_bg.png'
+        "Please pick a file to replace logo_lipsum_on_light_bg.png"
       )
       expect(page).to have_text(
-        'Please pick a file to replace logo_lipsum_on_dark_bg.png'
+        "Please pick a file to replace logo_lipsum_on_dark_bg.png"
       )
 
       expect(course_1.cover).to be_attached
       expect(course_1.thumbnail).to be_attached
     end
 
-    scenario 'School admin edits images associated with the archived course' do
+    scenario "School admin edits images associated with the archived course" do
       sign_in_user school_admin.user,
                    referrer: "/school/courses/#{course_archived.id}/images"
 
-      expect(page).to have_text('Please choose an image file.', count: 2)
+      expect(page).to have_text("Please choose an image file.", count: 2)
 
-      attach_file 'course_thumbnail',
-                  file_path('logo_lipsum_on_light_bg.png'),
+      attach_file "course_thumbnail",
+                  file_path("logo_lipsum_on_light_bg.png"),
                   visible: false
-      attach_file 'course_cover',
-                  file_path('logo_lipsum_on_dark_bg.png'),
+      attach_file "course_cover",
+                  file_path("logo_lipsum_on_dark_bg.png"),
                   visible: false
 
-      click_button 'Update Images'
+      click_button "Update Images"
 
-      expect(page).to have_text('Images have been updated successfully')
+      expect(page).to have_text("Images have been updated successfully")
 
-      fill_in('Search', with: 'archived')
-      click_button 'Pick Status: Archived'
+      fill_in("Search", with: "archived")
+      click_button "Pick Status: Archived"
 
       find("button[title='Edit #{course_archived.name}']").click
-      click_button 'Images'
+      click_button "Images"
 
       expect(page).to have_text(
-        'Please pick a file to replace logo_lipsum_on_light_bg.png'
+        "Please pick a file to replace logo_lipsum_on_light_bg.png"
       )
       expect(page).to have_text(
-        'Please pick a file to replace logo_lipsum_on_dark_bg.png'
+        "Please pick a file to replace logo_lipsum_on_dark_bg.png"
       )
 
       expect(course_archived.cover).to be_attached
@@ -278,39 +294,39 @@ feature 'Courses Index', js: true do
     end
   end
 
-  context 'with many courses' do
+  context "with many courses" do
     before { 23.times { create :course, :with_cohort, school: school } }
 
-    scenario 'school admin loads all courses' do
+    scenario "school admin loads all courses" do
       sign_in_user school_admin.user, referrer: school_courses_path
 
-      expect(page).to have_text('Showing 10 of 25 courses')
-      click_button 'Load More Courses...'
+      expect(page).to have_text("Showing 10 of 25 courses")
+      click_button "Load More Courses..."
 
-      expect(page).to have_text('Showing 20 of 25 courses')
-      click_button 'Load More Courses...'
+      expect(page).to have_text("Showing 20 of 25 courses")
+      click_button "Load More Courses..."
 
-      expect(page).to have_text('Showing all 25 courses')
-      expect(page).not_to have_text('Load More Courses...')
+      expect(page).to have_text("Showing all 25 courses")
+      expect(page).not_to have_text("Load More Courses...")
     end
 
-    scenario 'school admin loads details route for last course' do
+    scenario "school admin loads details route for last course" do
       sign_in_user school_admin.user,
                    referrer: "/school/courses/#{school.courses.last.id}/details"
 
-      expect(page).to have_text('EDIT COURSE DETAILS')
+      expect(page).to have_text("EDIT COURSE DETAILS")
     end
   end
 
-  scenario 'user who is not logged in gets redirected to sign in page' do
+  scenario "user who is not logged in gets redirected to sign in page" do
     visit school_courses_path
-    expect(page).to have_text('Please sign in to continue.')
+    expect(page).to have_text("Please sign in to continue.")
   end
 
-  scenario 'school admin searches and filters courses' do
+  scenario "school admin searches and filters courses" do
     sign_in_user school_admin.user, referrer: school_courses_path
 
-    expect(page).to have_text('Status: Active')
+    expect(page).to have_text("Status: Active")
 
     within("div[id='courses']") do
       expect(page).to have_text(course_1.name)
@@ -319,8 +335,8 @@ feature 'Courses Index', js: true do
       expect(page).not_to have_text(course_archived.name)
     end
 
-    fill_in('Search', with: 'ended')
-    click_button 'Pick Status: Ended'
+    fill_in("Search", with: "ended")
+    click_button "Pick Status: Ended"
 
     within("div[id='courses']") do
       expect(page).not_to have_text(course_1.name)
@@ -328,8 +344,8 @@ feature 'Courses Index', js: true do
       expect(page).not_to have_text(course_archived.name)
     end
 
-    fill_in('Search', with: 'archived')
-    click_button 'Pick Status: Archived'
+    fill_in("Search", with: "archived")
+    click_button "Pick Status: Archived"
 
     within("div[id='courses']") do
       expect(page).not_to have_text(course_1.name)
@@ -337,76 +353,76 @@ feature 'Courses Index', js: true do
       expect(page).to have_text(course_archived.name)
     end
 
-    click_button 'Remove selection: Archived'
-    fill_in('Search', with: 'pupilfirst demo course')
-    click_button 'Pick Search by name: pupilfirst demo course'
+    click_button "Remove selection: Archived"
+    fill_in("Search", with: "pupilfirst demo course")
+    click_button "Pick Search by name: pupilfirst demo course"
 
     within("div[id='courses']") { expect(page).to have_text(course_2.name) }
   end
 
-  scenario 'school admin filters archived courses' do
+  scenario "school admin filters archived courses" do
     sign_in_user school_admin.user, referrer: school_courses_path
 
-    fill_in('Search', with: 'archived')
-    click_button 'Pick Status: Archived'
+    fill_in("Search", with: "archived")
+    click_button "Pick Status: Archived"
 
     within("div[id='courses']") do
       expect(page).to have_text(course_archived.name)
-      expect(page).not_to have_text('View public page')
-      expect(page).not_to have_text('Quick Links')
+      expect(page).not_to have_text("View public page")
+      expect(page).not_to have_text("Quick Links")
     end
   end
 
-  scenario 'school admin clicks on quick links' do
+  scenario "school admin clicks on quick links" do
     sign_in_user school_admin.user, referrer: school_courses_path
 
     within("div[data-t='#{course_1.name}']") do
-      expect(page).to have_link('View public page', href: course_path(course_1))
+      expect(page).to have_link("View public page", href: course_path(course_1))
 
-      click_button 'Quick Links'
+      click_button "Quick Links"
       expect(page).to have_link(
-        'View as Student',
+        "View as Student",
         href: curriculum_course_path(course_1)
       )
       expect(page).to have_link(
-        'Edit Curriculum',
+        "Edit Curriculum",
         href: curriculum_school_course_path(course_1)
       )
       expect(page).to have_link(
-        'Manage Students',
+        "Manage Students",
         href: school_course_students_path(course_1)
       )
       expect(page).to have_link(
-        'Manage Coaches',
+        "Manage Coaches",
         href: school_course_coaches_path(course_1)
       )
       expect(page).to have_link(
-        'Download Reports',
+        "Download Reports",
         href: exports_school_course_path(course_1)
       )
     end
   end
 
-  scenario 'school admin visits details route for archived course' do
+  scenario "school admin visits details route for archived course" do
     sign_in_user school_admin.user,
                  referrer: "/school/courses/#{course_archived.id}/details"
-    expect(page).to have_text('EDIT COURSE DETAILS')
+    expect(page).to have_text("EDIT COURSE DETAILS")
   end
 
-  context 'when students exist in a course' do
+  context "when students exist in a course" do
     let!(:level) { create :level, course: course_1 }
     let!(:student) { create :student, level: level }
 
-    scenario 'school admin archives a course' do
+    scenario "school admin archives a course" do
       notification_service = prepare_developers_notification
       sign_in_user school_admin.user,
                    referrer: "/school/courses/#{course_1.id}/actions"
 
-      expect(page).to have_text('Do you want to archive the course?')
+      expect(page).to have_text("Do you want to archive the course?")
 
-      accept_confirm { click_button('Archive Course') }
+      accept_confirm { click_button("Archive Course") }
 
-      expect(page).to have_text('Course archived successfully')
+      expect(page).to have_text("Course archived successfully")
       expect(course_1.reload.archived_at).not_to eq(nil)
       expect(course_1.cohorts.first.ends_at).not_to eq(nil)
       within("div[id='courses']") do
@@ -422,20 +438,20 @@ feature 'Courses Index', js: true do
     end
   end
 
-  scenario 'school admin un-archives a course' do
+  scenario "school admin un-archives a course" do
     notification_service = prepare_developers_notification
     sign_in_user school_admin.user, referrer: school_courses_path
 
-    fill_in('Search', with: 'archived')
-    click_button 'Pick Status: Archived'
+    fill_in("Search", with: "archived")
+    click_button "Pick Status: Archived"
     find("button[title='Edit #{course_archived.name}']").click
-    click_button 'Actions'
+    click_button "Actions"
 
-    expect(page).to have_text('Do you want to unarchive the course?')
+    expect(page).to have_text("Do you want to unarchive the course?")
 
-    accept_confirm { click_button('Unarchive Course') }
+    accept_confirm { click_button("Unarchive Course") }
 
-    expect(page).to have_text('Course unarchived successfully')
+    expect(page).to have_text("Course unarchived successfully")
     expect(course_archived.reload.archived_at).to eq(nil)
     within("div[id='courses']") do
       expect(page).not_to have_text(course_archived.name)
@@ -449,24 +465,24 @@ feature 'Courses Index', js: true do
     )
   end
 
-  scenario 'school admin makes a copy of a course' do
+  scenario "school admin makes a copy of a course" do
     sign_in_user school_admin.user, referrer: school_courses_path
     find("button[title='Edit #{course_1.name}']").click
-    click_button 'Actions'
+    click_button "Actions"
 
-    expect(page).to have_text('Do you want to create a copy of the course?')
+    expect(page).to have_text("Do you want to create a copy of the course?")
 
-    accept_confirm { click_button('Clone Course') }
+    accept_confirm { click_button("Clone Course") }
 
     expect(page).to have_text(
-      'Course copy requested. It will appear here soon!'
+      "Course copy requested. It will appear here soon!"
     )
 
     visit school_courses_path
-    fill_in('Search', with: 'ended')
-    click_button 'Pick Status: Ended'
+    fill_in("Search", with: "ended")
+    click_button "Pick Status: Ended"
     within("div[id='courses']") do
-      expect(page).to have_text(course_1.name + ' - copy')
+      expect(page).to have_text(course_1.name + " - copy")
     end
   end
 end


### PR DESCRIPTION
## Proposed Changes
### Fixes #1332 

- Allow course creation option to be visible all the time 
- I also removed the message which was shown when there weren't any courses.

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~[ ] Check if route, query, or mutation authorization looks correct.~~
  - ~~Add tests for authorization, if required.~~
- [x] Ensure that UI text is kept in I18n files.
- ~~[ ] Update developer and product docs, where applicable.~~
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- ~~[ ] Check if new tables or columns that have been added need to be handled in the following services:~~
  - ~~`Users::DeleteAccountService`~~
  - ~~`Courses::CloneService`~~
  - ~~`Courses::DeleteService`~~
  - ~~`Courses::DemoContentService`~~
  - ~~`Levels::CloneService`~~
  - ~~`Schools::DeleteService`~~
- ~~[ ] Check if changes in _packaged_ components have been published to `npm`.~~
- ~~[ ] Add development seeds for new tables.~~
- ~~[ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~

### Before the fix 
![image](https://github.com/pupilfirst/pupilfirst/assets/31089012/ba2aa5cf-dfd8-46ee-b63f-6fde3bb1d090)

### After the fix 
![image](https://github.com/pupilfirst/pupilfirst/assets/31089012/49dc1078-778e-421d-bec5-3084de5b6249)
