### PR TITLE
Fix duplicate names in multiselect review interface

### DIFF
--- a/app/queries/reviewed_targets_info_resolver.rb
+++ b/app/queries/reviewed_targets_info_resolver.rb
@@ -4,7 +4,7 @@ class ReviewedTargetsInfoResolver < ApplicationQuery
   property :course_id
 
   def reviewed_targets_info
-    course.targets.live.joins(:evaluation_criteria)
+    course.targets.live.joins(:evaluation_criteria).distinct
   end
 
   private

--- a/spec/system/courses/review_spec.rb
+++ b/spec/system/courses/review_spec.rb
@@ -26,6 +26,7 @@ feature "Coach's review interface" do
     create :target, :for_students, target_group: target_group_l1
   end
   let(:evaluation_criterion) { create :evaluation_criterion, course: course }
+  let(:evaluation_criterion_2) { create :evaluation_criterion, course: course }
   let(:student_l1) { create :student, cohort: cohort }
   let(:student_l2) { create :student, cohort: cohort }
   let(:team_l3) { create :team, cohort: cohort }
@@ -49,6 +50,7 @@ feature "Coach's review interface" do
     target_l1.evaluation_criteria << evaluation_criterion
     target_l2.evaluation_criteria << evaluation_criterion
     target_l3.evaluation_criteria << evaluation_criterion
+    target_l3.evaluation_criteria << evaluation_criterion_2
     team_target.evaluation_criteria << evaluation_criterion
     student_l3.user.update!(email: "pupilfirst@example.com")
     student_l2.user.update!(name: "Pupilfirst Test User")
@@ -247,7 +249,10 @@ feature "Coach's review interface" do
 
       # filter pending submissions
       fill_in "filter", with: "target:"
-
+      # Check if there are not duplicate target names.
+      within(".multiselect-dropdown__search-dropdown") do
+        expect(page).to have_text(target_l3.title, count: 1)
+      end
       # choose level 1 from the dropdown
       click_button team_target.title
 


### PR DESCRIPTION
## Fixes #1417 

- Selects distinct targets when joins is performed with `evaluation_criteria`

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [ ] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
