### PR TITLE
Remove notification when last submission is graded

### DIFF
--- a/app/frontend/courses/review/components/CoursesReview__Editor.res
+++ b/app/frontend/courses/review/components/CoursesReview__Editor.res
@@ -195,10 +195,6 @@ let getNextSubmission = (send, courseId, filter) => {
   |> Js.Promise.then_((response: NextSubmissionQuery.t) => {
     if ArrayUtils.isEmpty(response.submissions.nodes) {
       send(SetNextSubmissionDataEmpty)
-      Notification.notice(
-        t("get_next_submission.notice.done"),
-        t("get_next_submission.notice.done_description"),
-      )
     } else {
       send(SetNextSubmissionDataLoaded(response.submissions.nodes[0].id))
     }
@@ -399,16 +395,25 @@ let closeOverlay = (state, courseId, filter) => {
 }
 
 let reviewNextButton = (nextSubmission, filter) => {
-  let className = "next-submission-button flex w-full items-center justify-center text-sm font-semibold bg-white border-t border-gray-200 px-5 py-4 hover:bg-primary-50 hover:text-primary-500 focus:ring-2 focus:ring-focusColor-500 ring-inset"
+  let buttonStyle = "next-submission-button flex w-full items-center justify-center text-sm font-semibold bg-white border-t border-gray-200 px-5 py-4 focus:ring-2 focus:ring-focusColor-500 ring-inset"
   switch nextSubmission {
   | DataLoaded(id) =>
-    <Link href={"/submissions/" ++ id ++ "/review?" ++ Filter.toQueryString(filter)} className>
+    <Link
+      href={"/submissions/" ++ id ++ "/review?" ++ Filter.toQueryString(filter)}
+      className={`${buttonStyle} hover:bg-primary-50 hover:text-primary-500`}>
       <p className="pe-2"> {str(t("review_next"))} </p>
       <Icon className="if i-arrow-right-short-light text-lg lg:text-2xl rtl:rotate-180" />
     </Link>
   | DataLoading =>
-    <button disabled={true} className> <FaIcon classes="fas fa-spinner fa-pulse me-2" /> </button>
-  | DataEmpty
+    <button disabled={true} className=buttonStyle>
+      <FaIcon classes="fas fa-spinner fa-pulse me-2" />
+    </button>
+  | DataEmpty =>
+    <div className=buttonStyle>
+      <Icon className="if i-check-circle-alt-light text-lg lg:text-2xl" />
+      <p className="ps-2 block md:hidden"> {str(t("you_are_done"))} </p>
+      <p className="ps-2 hidden md:block"> {str(t("no_more_pending_submissions"))} </p>
+    </div>
   | DataUnloaded => React.null
   }
 }

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -755,10 +755,6 @@ ar:
       feedback: Feedback
       feedback_generated_text: Feedback generated from review checklist.
       feedback_placeholder: This feedback will be emailed to students when you finish grading.
-      get_next_submission:
-        notice:
-          done: Done!
-          done_description: There are no other similar submissions.
       grade_card: Grade Card
       help_text: Notes can be used to keep track of a %{note_about}'s progress. These notes are shown only to coaches in a student's report. %{additional_help}
       hide_test_report_button: Hide Test Report

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -726,10 +726,6 @@ en:
       feedback: Feedback
       feedback_generated_text: Feedback generated from review checklist.
       feedback_placeholder: This feedback will be emailed to students when you finish grading.
-      get_next_submission:
-        notice:
-          done: Done!
-          done_description: There are no similar pending submissions.
       github_action:
         description: Do you want to re-run the Github action on this submission?
         re_run_action_button: Yes, Re-Run Github Action
@@ -737,6 +733,7 @@ en:
       grade_card: Grade Card
       help_text: Notes can be used to keep track of a %{note_about}'s progress. These notes are shown only to coaches in a student's report. %{additional_help}
       hide_test_report_button: Hide Test Report
+      no_more_pending_submissions: "This submission has been graded, and there are no more submissions awaiting review."
       note_help: Would you like to write a note about this %{noteAbout} ?
       note_placeholder: Did you notice something while reviewing this submission?
       page_title: "Submission #%{submission_number} | %{target_title} | %{name}"
@@ -766,6 +763,7 @@ en:
       team_notice: " This submission is from a team, so a note added here will be posted to the report of all students in the team."
       undo_grade_warning: Are you sure you want to remove these grades? This will return the submission to a 'Pending Review' state.
       undo_grading: Undo Grading
+      you_are_done: "You're done!"
       write_a_note: Write a Note
     CoursesReview__ReviewerManager:
       assigned_at: Assigned %{date}

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -593,10 +593,6 @@ ru:
       feedback: Отзыв
       feedback_generated_text: Отзыв, полученный из списка оценки.
       feedback_placeholder: Данный отзыв будет отправлен учащимся по электронной почте, когда вы завершите оценку.
-      get_next_submission:
-        notice:
-          done: Сделано!
-          done_description: Других подобных работ нет.
       grade_card: Оценочная Карта
       help_text: Заметки можно использовать для отслеживания прогресса %{note_about}. Эти заметки показываются только менторам в отчете студента. %{additional_help}
       hide_test_report_button: Скрыть Отчет Тестов

--- a/config/locales/zh-cn.yml
+++ b/config/locales/zh-cn.yml
@@ -757,10 +757,6 @@ zh-cn:
       feedback: 反馈
       feedback_generated_text: 来自审查清单的反馈。
       feedback_placeholder: 完成评分后，此反馈将通过电子邮件发送给学生。
-      get_next_submission:
-        notice:
-          done: 完成
-          done_description: 没有其他类似的提交。
       github_action:
         description: 你想要重新运行这个提交的 Github action 吗？
         re_run_action_button: 重新运行 Github Action

--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -1112,7 +1112,9 @@ feature "Submission review overlay", js: true do
       ) { find("button[title='Good']").click }
       click_button "Save grades"
 
-      expect(page).to have_text("There are no similar pending submissions.")
+      expect(page).to have_text(
+        "This submission has been graded, and there are no more submissions awaiting review."
+      )
     end
   end
 


### PR DESCRIPTION
## Fixes #1441 

- Remove the notification which says "_There are no similar pending submissions_"
- Instead, show the message in the place of _Next_ button.


@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [x] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [ ] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
