### PR TITLE
Reset course completion flag when a milestone submission is ungraded

### DIFF
--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -1955,7 +1955,7 @@ feature "Submission review overlay", js: true do
     end
   end
 
-  context "When a milestone submission is ungraded after certificate is issued" do
+  context "When a milestone submission is ungraded after the course is marked complete for a student" do
     let(:target_3) do
       create :target,
              :for_students,

--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -1954,4 +1954,55 @@ feature "Submission review overlay", js: true do
       expect(page).to have_text("A new report description")
     end
   end
+
+  context "When a milestone submission is ungraded after certificate is issued" do
+    let(:target_3) do
+      create :target,
+             :for_students,
+             target_group: target_group,
+             milestone_number: 1,
+             milestone: true
+    end
+
+    let!(:submission_3) do
+      create(
+        :timeline_event,
+        :with_owners,
+        latest: true,
+        owners: team.students,
+        target: target_3,
+        evaluator_id: team_coach.id,
+        evaluated_at: nil,
+        passed_at: nil
+      )
+    end
+
+    before { target_3.evaluation_criteria << [evaluation_criterion_1] }
+
+    scenario "coach grades and than ungrades milestone submission" do
+      sign_in_user team_coach.user,
+                   referrer: review_timeline_event_path(submission_3)
+
+      click_button "Start Review"
+      within(
+        "div[aria-label='evaluation-criterion-#{evaluation_criterion_1.id}']"
+      ) do
+        expect(page).to have_selector(
+          ".course-review-editor__grade-pill",
+          count: 4
+        )
+        find("button[title='Great']").click
+      end
+
+      click_button "Save grades"
+
+      expect(page).to have_button("Undo Grading")
+      expect(team.students.reload.pluck(:completed_at)).not_to eq([nil, nil])
+
+      accept_confirm { click_button("Undo Grading") }
+
+      expect(page).to have_button("Start Review")
+      expect(team.students.reload.pluck(:completed_at)).to eq([nil, nil])
+    end
+  end
 end


### PR DESCRIPTION
## Fixes #1445 
## Proposed Changes

- Removes `completed_at` flag on submission student when submission is ungraded, given the submission has milestone target.


@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [ ] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
