### PR TITLE
Fix the Help Text issue on Calender Event

### DIFF
--- a/app/views/schools/calendar_events/_form.html.erb
+++ b/app/views/schools/calendar_events/_form.html.erb
@@ -27,7 +27,12 @@
         </div>
         <div class="col-span-2">
           <label>
-            <span class="text-sm font-medium space-x-1"><span><%= t(".color_label") %></span><i class="if i-question-circle-regular" aria-hidden="true" title="Colors help you to differntiate different types of events at glance"></i></span>
+            <span class="text-sm font-medium space-x-1">
+              <span><%= t(".color_label") %></span>
+              <span title="Colors help you to differntiate different types of events at glance">
+                <i class="if i-question-circle-regular" aria-hidden="true"></i>
+              </span>
+            </span>
             <%= f.select :color, CalendarEvent.colors , { include_blank: false }, { class: "select mt-1 items-center bg-white border border-gray-300 text-sm w-full outline-none py-3 px-4 pe-10 rounded-md focus:outline-none focus:ring-1 focus:ring-focusColor-500" } %>
           </label>
         </div>

--- a/app/views/schools/calendar_events/_form.html.erb
+++ b/app/views/schools/calendar_events/_form.html.erb
@@ -29,7 +29,7 @@
           <label>
             <span class="text-sm font-medium space-x-1">
               <span><%= t(".color_label") %></span>
-              <span title="Colors help you to differntiate different types of events at glance">
+              <span title="<%= t(".color_label_hint") %>">
                 <i class="if i-question-circle-regular" aria-hidden="true"></i>
               </span>
             </span>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -2494,6 +2494,7 @@ ar:
         add_link_section_title: إضافة رابط للفعالية (إختياري)
         calendar_label: إضافة الفعالية الى
         color_label: اللون
+        color_label_hint: تساعدك الألوان على التمييز بين أنواع الأحداث المختلفة في لمحة
         description_label: الوصف
         edit_event_heading: تعديل الفعالية
         link_title_label: عنوان الرابط

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2558,6 +2558,7 @@ en:
         add_link_section_title: Add an event link (optional)
         calendar_label: Add event to
         color_label: Color
+        color_label_hint: Colors help you to differentiate different types of events at glance
         description_label: Event description
         edit_event_heading: Edit %{event_title}
         link_title_label: Event link title

--- a/config/locales/zh-cn.yml
+++ b/config/locales/zh-cn.yml
@@ -2542,6 +2542,7 @@ zh-cn:
         add_link_section_title: 添加一个活动链接（可选）
         calendar_label: 添加事件到
         color_label: 颜色
+        color_label_hint: 颜色可帮助您一目了然地区分不同类型的事件
         description_label: 活动描述
         edit_event_heading: 编辑 %{event_title}
         link_title_label: 活动链接标题


### PR DESCRIPTION
## Proposed Changes
Resolves #1372
**Issue**
 - We are using `<i>` to show the help text, whose purpose here to render the `?` icon

**The Fix**

 - This PR adds the following:
   - A span to render the help text
   - Translations for the help text in `en`, `ar` and `zh-cn` locales as only these languages were already having the color label locales 

**Screen Recording:**
[Screencast from 10-28-2023 11:06:09 PM.webm](https://github.com/pupilfirst/pupilfirst/assets/59338032/e6029305-705f-4440-9496-e17f038cb6e9)

@pupilfirst/developers
