### PR TITLE
Fix bug in course export when students have failed grades

### DIFF
--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -82,6 +82,10 @@ class TimelineEvent < ApplicationRecord
     passed_at.present?
   end
 
+  def evaluated?
+    evaluated_at.present?
+  end
+
   def team_submission?
     target.team_target?
   end

--- a/app/services/concerns/course_exportable.rb
+++ b/app/services/concerns/course_exportable.rb
@@ -64,7 +64,7 @@ module CourseExportable
         [evaluation_grade, "passing-grade"]
       when [false, true]
         if submission.evaluated_at.present?
-          ['x', '']
+          %w[x failing-grade]
         else
           %w[RP pending-grade]
         end

--- a/app/services/concerns/course_exportable.rb
+++ b/app/services/concerns/course_exportable.rb
@@ -56,18 +56,31 @@ module CourseExportable
   def assign_styled_grade(grade_index, grading, submission)
     evaluation_grade = submission.timeline_event_grades.pluck(:grade).join(",")
 
+    # Determine the grade and style based on submission and evaluation status
     grade, style =
-      case [submission.passed_at.present?, evaluation_grade.empty?]
+      case [submission.passed?, evaluation_grade.present?]
       when [true, true]
-        [submission.quiz_score || "✓", ""]
-      when [true, false]
+        # Case when the submission has passed and there is an evaluation grade
+        # Use the evaluation grade and mark it as a passing grade
         [evaluation_grade, "passing-grade"]
-      when [false, true]
-        if submission.evaluated_at.present?
+      when [true, false]
+        # Case when the submission has passed and there is no evaluation grade
+        # Use the quiz score as the grade, or a checkmark if the score is not available
+        [submission.quiz_score || "✓", ""]
+      when [false, false]
+        if submission.evaluated?
+          # Case when the submission has not passed, but has been evaluated
+          # Mark it as failing
           %w[x failing-grade]
         else
+          # Case when the submission has not passed and has not been evaluated
+          # Mark it as pending grading
           %w[RP pending-grade]
         end
+      when [false, true]
+        # Case when the submission has not passed and there is an evaluation grade
+        # This should be impossible - submissions can be graded only after they're accepted; crash if this happens
+        raise "Submission #{submission.id} responded `false` to `#passed?` but has one or more evaluation grades"
       end
 
     append_grade(grading, grade_index, grade, style)

--- a/spec/services/course_exports/prepare_students_export_service_spec.rb
+++ b/spec/services/course_exports/prepare_students_export_service_spec.rb
@@ -109,6 +109,10 @@ describe CourseExports::PrepareStudentsExportService do
            cohorts: [cohort_live, cohort_2_live]
   end
 
+  let!(:student_1_reviewed_submission_failed) do
+    fail_target target_l1_evaluated, student_1
+  end
+
   let!(:student_1_reviewed_submission) do
     complete_target target_l1_evaluated, student_1
   end
@@ -195,20 +199,22 @@ describe CourseExports::PrepareStudentsExportService do
           ["Students with submissions", 1, 3, 3, 1],
           ["Submissions pending review", 0, 0, 0, 1],
           [
-            'Criterion A 3 - Average',
+            "Criterion A 3 - Average",
             nil,
             nil,
             (
-              evaluation_criterion_1.timeline_event_grades.pluck(:grade).sum / 1.0
+              evaluation_criterion_1.timeline_event_grades.pluck(:grade).sum /
+                1.0
             ).round(2).to_s,
             nil
           ],
           [
-            'Criterion B 3 - Average',
+            "Criterion B 3 - Average",
             nil,
             nil,
             (
-              evaluation_criterion_2.timeline_event_grades.pluck(:grade).sum  / 1.0
+              evaluation_criterion_2.timeline_event_grades.pluck(:grade).sum /
+                1.0
             ).round(2).to_s,
             nil
           ]
@@ -218,18 +224,18 @@ describe CourseExports::PrepareStudentsExportService do
         title: "Students",
         rows: [
           [
-            'User ID',
-            'Student ID',
-            'Email Address',
-            'Name',
-            'Title',
-            'Affiliation',
-            'Cohort',
-            'Tags',
-            'Last Seen At',
-            'Course Completed At',
-            'Criterion A 3 - Average',
-            'Criterion B 3 - Average'
+            "User ID",
+            "Student ID",
+            "Email Address",
+            "Name",
+            "Title",
+            "Affiliation",
+            "Cohort",
+            "Tags",
+            "Last Seen At",
+            "Course Completed At",
+            "Criterion A 3 - Average",
+            "Criterion B 3 - Average"
           ],
           [
             student_1.user_id,
@@ -265,7 +271,7 @@ describe CourseExports::PrepareStudentsExportService do
             student_1.cohort.name,
             "",
             last_seen_at(student_2),
-            student_2.completed_at&.iso8601 || '',
+            student_2.completed_at&.iso8601 || "",
             nil,
             nil
           ],
@@ -300,7 +306,8 @@ describe CourseExports::PrepareStudentsExportService do
             "✓",
             "2/2",
             {
-              "value" => submission_grading(student_1_reviewed_submission),
+              "value" =>
+                "x;#{submission_grading(student_1_reviewed_submission)}",
               "style" => "passing-grade"
             },
             { "value" => "RP", "style" => "pending-grade" }
@@ -308,14 +315,14 @@ describe CourseExports::PrepareStudentsExportService do
           [
             student_2.email,
             nil,
-            '1/2',
-            'x'
+            "1/2",
+            { "value" => "x", "style" => "failing-grade" }
           ],
           [
             student_5.email,
             nil,
             "1/2",
-            'x'
+            { "value" => "x", "style" => "failing-grade" }
           ]
         ]
       }
@@ -370,7 +377,7 @@ describe CourseExports::PrepareStudentsExportService do
               ["Students with submissions", 3, 1],
               ["Submissions pending review", 3, 1],
               [
-                'Criterion A 3 - Average',
+                "Criterion A 3 - Average",
                 student_1_reviewed_submission
                   .timeline_event_grades
                   .find_by(evaluation_criterion: evaluation_criterion_1)
@@ -380,7 +387,7 @@ describe CourseExports::PrepareStudentsExportService do
                 nil
               ],
               [
-                'Criterion B 3 - Average',
+                "Criterion B 3 - Average",
                 student_1_reviewed_submission
                   .timeline_event_grades
                   .find_by(evaluation_criterion: evaluation_criterion_2)
@@ -395,18 +402,18 @@ describe CourseExports::PrepareStudentsExportService do
             title: "Students",
             rows: [
               [
-                'User ID',
-                'Student ID',
-                'Email Address',
-                'Name',
-                'Title',
-                'Affiliation',
-                'Cohort',
-                'Tags',
-                'Last Seen At',
-                'Course Completed At',
-                'Criterion A 3 - Average',
-                'Criterion B 3 - Average'
+                "User ID",
+                "Student ID",
+                "Email Address",
+                "Name",
+                "Title",
+                "Affiliation",
+                "Cohort",
+                "Tags",
+                "Last Seen At",
+                "Course Completed At",
+                "Criterion A 3 - Average",
+                "Criterion B 3 - Average"
               ],
               [
                 student_1.user_id,
@@ -474,7 +481,7 @@ describe CourseExports::PrepareStudentsExportService do
                 student_1.email,
                 {
                   "value" =>
-                    "#{submission_grading(student_1_reviewed_submission)};RP",
+                    "x;#{submission_grading(student_1_reviewed_submission)};RP",
                   "style" => "pending-grade"
                 },
                 { "value" => "RP", "style" => "pending-grade" }

--- a/spec/services/course_exports/prepare_teams_export_service_spec.rb
+++ b/spec/services/course_exports/prepare_teams_export_service_spec.rb
@@ -109,7 +109,7 @@ describe CourseExports::PrepareTeamsExportService do
   end
 
   let!(:team_1_reviewed_submission_1) do
-    complete_target target_l1_evaluated, student_1
+    fail_target target_l1_evaluated, student_1
   end
 
   let!(:team_1_reviewed_submission_2) do
@@ -267,7 +267,7 @@ describe CourseExports::PrepareTeamsExportService do
             "2/2",
             {
               "value" =>
-                "#{submission_grading(team_1_reviewed_submission_1)};#{submission_grading(team_1_reviewed_submission_2)}",
+                "x;#{submission_grading(team_1_reviewed_submission_2)}",
               "style" => "passing-grade"
             },
             { "value" => "RP", "style" => "pending-grade" }
@@ -276,8 +276,8 @@ describe CourseExports::PrepareTeamsExportService do
             team_2.id,
             team_2.name,
             nil,
-            '1/2',
-            'x',
+            "1/2",
+            { "value" => "x", "style" => "failing-grade" },
             nil
           ],
           [team_3.id, team_3.name, "✓", nil, nil, nil],
@@ -286,7 +286,7 @@ describe CourseExports::PrepareTeamsExportService do
             team_4.name,
             nil,
             "1/2",
-            'x',
+            { "value" => "x", "style" => "failing-grade" },
             nil
           ]
         ]
@@ -366,7 +366,7 @@ describe CourseExports::PrepareTeamsExportService do
                 team_1.name,
                 {
                   "value" =>
-                    "#{submission_grading(team_1_reviewed_submission_1)};#{submission_grading(team_1_reviewed_submission_2)};RP",
+                    "x;#{submission_grading(team_1_reviewed_submission_2)};RP",
                   "style" => "pending-grade"
                 },
                 { "value" => "RP", "style" => "pending-grade" }


### PR DESCRIPTION
The course exports fail when students have failed grades for reviewed targets. This was primary because of not having the shape of data, similar to when a reviewed target submission is passed or pending review. The export was specifically crashing in cases where the first submission of a particular target was rejected.

## Proposed Changes
Have the correct shape of data while dealing with reviewed targets that are rejected. 
`{ "value" => "x", "style" => "failing-grade" }`
This is reproduced and covered using specs.

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [ ] ~Check if route, query, or mutation authorization looks correct.~
- [ ] ~Ensure that UI text is kept in I18n files.~
- [ ] ~Update developer and product docs, where applicable.~
- [ ] ~Prep screenshot or demo video for changelog entry, and attach it to issue.~
- [ ] ~Check if new tables or columns that have been added need to be handled in the following services:~
- [ ] ~Check if changes in _packaged_ components have been published to `npm`.~
- [ ] ~Add development seeds for new tables.~
- [ ] ~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~
- [ ] ~If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.~
