### PR TITLE
Fix nav overlap issue in agreements

### DIFF
--- a/app/views/home/agreement.html.erb
+++ b/app/views/home/agreement.html.erb
@@ -3,7 +3,7 @@
   <title><%= presenter.page_title %> | <%= @agreement_type %></title>
 <% end %>
 <div class="flex flex-col bg-gray-50 items-center justify-center">
-  <div class="my-6 md:my-10 px-3 max-w-3xl">
+  <div class="mb-6 mt-8 md:mb-10 md:mt-24 px-3 max-w-3xl">
     <h1 class="policy-header text-xl md:text-3xl font-bold py-1 px-2">
       <%= @agreement_type %>
     </h1>


### PR DESCRIPTION
## Proposed Changes
Fixes #1470 

**Additional context**
We made a mistake when creating other pages by adding margin-top to each page to accommodate the top navigation. Instead, we should have added margin-top to the main container in the `app/views/layouts/application.html.erb` file.


@pupilfirst/developers

