### PR TITLE
Fix the crash that can occur if a GitHub branch already exists

### DIFF
--- a/spec/services/github/add_submission_service_spec.rb
+++ b/spec/services/github/add_submission_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Github::AddSubmissionService, type: :service do
     {
       access_token: "access_token",
       organization_id: "organization_id",
-      default_team_id: "default_team_id",
+      default_team_id: "default_team_id"
     }
   end
 
@@ -21,7 +21,7 @@ RSpec.describe Github::AddSubmissionService, type: :service do
     create(
       :student,
       cohort: cohort,
-      github_repository: "organization_id/test_repo",
+      github_repository: "organization_id/test_repo"
     )
   end
   let!(:submission) do
@@ -53,44 +53,74 @@ RSpec.describe Github::AddSubmissionService, type: :service do
         end
       end
 
-      context "when the action config is present but student does not have a repository" do
-        let(:setup_repository_service) do
-          instance_double(Github::SetupRepositoryService, execute: nil)
-        end
-
-        before do
-          target.update!(action_config: action_config)
-          student.update!(github_repository: nil)
-          allow(Github::SetupRepositoryService).to receive(:new).and_return(
-            setup_repository_service,
-          )
-        end
-
-        it "creates a repository for the student" do
-          expect(setup_repository_service).to receive(:execute)
-          stub_request(
-            :get,
-            "https://api.github.com/repos/organization_id/student-#{student.id}",
-          ).to_return(status: 200, body: "", headers: {})
-          expect(service).to receive(:create_branch).and_return(branch_name)
-          expect(service).to receive(:ci_file_sha).and_return(sha)
-          expect(octokit_client).to receive(:update_contents)
-          expect(octokit_client).to receive(:create_contents)
-
-          expect do service.execute end.to change {
-            SubmissionReport.count
-          }.from(0).to(1)
-        end
-      end
-
       context "when the action config is present" do
         before { target.update!(action_config: action_config) }
+
+        context "when the student does not have a repository" do
+          let(:setup_repository_service) do
+            instance_double(Github::SetupRepositoryService, execute: nil)
+          end
+
+          before do
+            student.update!(github_repository: nil)
+
+            allow(Github::SetupRepositoryService).to receive(:new).and_return(
+              setup_repository_service
+            )
+          end
+
+          it "creates a repository for the student" do
+            expect(setup_repository_service).to receive(:execute)
+            stub_request(
+              :get,
+              "https://api.github.com/repos/organization_id/student-#{student.id}"
+            ).to_return(status: 200, body: "", headers: {})
+            expect(service).to receive(:create_branch).and_return(branch_name)
+            expect(service).to receive(:ci_file_sha).and_return(sha)
+            expect(octokit_client).to receive(:update_contents)
+            expect(octokit_client).to receive(:create_contents)
+
+            expect do service.execute end.to change {
+              SubmissionReport.count
+            }.from(0).to(1)
+          end
+        end
+
+        context "when the student's repository already has the branch'" do
+          it "ignores the error from Octokit and continues" do
+            allow(octokit_client).to receive(:commits).and_return(
+              [OpenStruct.new(sha: sha)]
+            )
+
+            allow(octokit_client).to receive(:contents).and_return(
+              OpenStruct.new(sha: sha)
+            )
+
+            expect(octokit_client).to receive(:update_contents)
+            expect(octokit_client).to receive(:create_contents)
+
+            allow(octokit_client).to receive(:create_ref).and_raise(
+              Octokit::UnprocessableEntity.new(
+                { status: 422, body: "Reference already exists" }
+              )
+            )
+
+            expect { service.execute }.not_to raise_error
+
+            expect(octokit_client).to have_received(:create_ref).with(
+              student.github_repository,
+              "heads/submission-#{submission.id}",
+              sha
+            )
+          end
+        end
+
         it "calls create_branch and add_submission_file methods" do
           expect(service).to receive(:ci_file_sha).and_return(sha)
           expect(service).to receive(:create_branch).and_return(branch_name)
           expect(service).to receive(:add_submission_file).with(
             branch_name,
-            student.github_repository,
+            student.github_repository
           )
           expect(octokit_client).to receive(:update_contents).with(
             student.github_repository,
@@ -98,7 +128,7 @@ RSpec.describe Github::AddSubmissionService, type: :service do
             "Update workflow [skip ci]",
             sha,
             action_config,
-            { branch: branch_name },
+            { branch: branch_name }
           )
 
           expect(octokit_client).to receive(:create_contents).with(
@@ -117,12 +147,12 @@ RSpec.describe Github::AddSubmissionService, type: :service do
                 target: {
                   id: target.id,
                   title: target.title,
-                  evaluation_criteria: target.evaluation_criteria,
+                  evaluation_criteria: target.evaluation_criteria
                 },
-                files: [],
+                files: []
               }
             ).to_json,
-            { branch: branch_name },
+            { branch: branch_name }
           )
 
           service.execute
@@ -131,7 +161,7 @@ RSpec.describe Github::AddSubmissionService, type: :service do
         it "calls create_branch with re_run" do
           expect(service).to receive(:ci_file_sha).and_return(sha)
           expect(service).to receive(:create_branch).with(true).and_return(
-            branch_name,
+            branch_name
           )
           expect(octokit_client).to receive(:update_contents)
           expect(octokit_client).to receive(:create_contents)


### PR DESCRIPTION
## Proposed Changes

This is a fix for a `422 - Reference already exists` that can occur when attempting to create a GitHub branch for a submission, when the branch already exists.

@pupilfirst/developers

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~Check if route, query, or mutation authorization looks correct.~
- ~Ensure that UI text is kept in I18n files.~
- ~Update developer and product docs, where applicable.~
- ~Prep screenshot or demo video for changelog entry, and attach it to issue.~
- ~Check if new tables or columns that have been added need to be handled in the following services:~
- ~Check if changes in _packaged_ components have been published to `npm`.~
- ~Add development seeds for new tables.~
- ~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~
- ~If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.~
