### PR TITLE
Apply style to export cells for all kinds of submissions

### DIFF
--- a/app/services/concerns/course_exportable.rb
+++ b/app/services/concerns/course_exportable.rb
@@ -66,7 +66,7 @@ module CourseExportable
       when [true, false]
         # Case when the submission has passed and there is no evaluation grade
         # Use the quiz score as the grade, or a checkmark if the score is not available
-        [submission.quiz_score || "✓", ""]
+        [submission.quiz_score || "✓", "default"]
       when [false, false]
         if submission.evaluated?
           # Case when the submission has not passed, but has been evaluated
@@ -102,11 +102,7 @@ module CourseExportable
         parsed_grade
       end
 
-    grading[grade_index] = if style.present?
-      { value: value, style: style }
-    else
-      value
-    end
+    grading[grade_index] = { value: value, style: style }
 
     grading
   end

--- a/spec/services/course_exports/prepare_students_export_service_spec.rb
+++ b/spec/services/course_exports/prepare_students_export_service_spec.rb
@@ -303,8 +303,8 @@ describe CourseExports::PrepareStudentsExportService do
           ],
           [
             student_1.email,
-            "✓",
-            "2/2",
+            { value: "✓", style: "default" },
+            { value: "2/2", style: "default" },
             {
               "value" =>
                 "x;#{submission_grading(student_1_reviewed_submission)}",
@@ -315,13 +315,13 @@ describe CourseExports::PrepareStudentsExportService do
           [
             student_2.email,
             nil,
-            "1/2",
+            { value: "1/2", style: "default" },
             { "value" => "x", "style" => "failing-grade" }
           ],
           [
             student_5.email,
             nil,
-            "1/2",
+            { value: "1/2", style: "default" },
             { "value" => "x", "style" => "failing-grade" }
           ]
         ]

--- a/spec/services/course_exports/prepare_teams_export_service_spec.rb
+++ b/spec/services/course_exports/prepare_teams_export_service_spec.rb
@@ -263,8 +263,8 @@ describe CourseExports::PrepareTeamsExportService do
           [
             team_1.id,
             team_1.name,
-            "✓",
-            "2/2",
+            { "value" => "✓", "style" => "default" },
+            { "value" => "2/2", "style" => "default" },
             {
               "value" =>
                 "x;#{submission_grading(team_1_reviewed_submission_2)}",
@@ -276,16 +276,23 @@ describe CourseExports::PrepareTeamsExportService do
             team_2.id,
             team_2.name,
             nil,
-            "1/2",
+            { "value" => "1/2", "style" => "default" },
             { "value" => "x", "style" => "failing-grade" },
             nil
           ],
-          [team_3.id, team_3.name, "✓", nil, nil, nil],
+          [
+            team_3.id,
+            team_3.name,
+            { "value" => "✓", "style" => "default" },
+            nil,
+            nil,
+            nil
+          ],
           [
             team_4.id,
             team_4.name,
             nil,
-            "1/2",
+            { "value" => "1/2", "style" => "default" },
             { "value" => "x", "style" => "failing-grade" },
             nil
           ]


### PR DESCRIPTION
Possibly related to #1482.

For an as-yet-undetermined reason, there are a few submissions in the DB where multiple auto-accepted submissions have been accepted from the same student. Because of this, the export code related to styling the cell in which submission grade / result is stored crashed because of a type-mismatch in the contents of the cell in graded vs non-graded submissions.

This PR is a small change that unifies the contents of the cell, preventing the crash by applying a `default` style string to the cell (without bothering to actually apply any style to this identifier). The crash is avoided by keeping the value of the cell uniform - specifying it using a _hash_ instead of a _string_, avoiding the crash caused by the assumption that two non-graded submissions cannot come for the same assignment.

## Merge Checklist

- ~Add specs that demonstrate bug / test a new feature.~
- ~Check if route, query, or mutation authorization looks correct.~
- ~Ensure that UI text is kept in I18n files.~
- ~Update developer and product docs, where applicable.~
- ~Prep screenshot or demo video for changelog entry, and attach it to issue.~
- ~Check if new tables or columns that have been added need to be handled in the following services:~
- ~Check if changes in _packaged_ components have been published to `npm`.~
- ~Add development seeds for new tables.~
- ~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~
- ~If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.~
