### PR TITLE
Have unique role ids when using Discord API

### DIFF
--- a/app/services/discord/sync_profile_service.rb
+++ b/app/services/discord/sync_profile_service.rb
@@ -7,11 +7,10 @@ module Discord
     def execute
       return unless @user.discord_user_id.present? && configuration.configured?
 
-      role_ids =
-        [
-          @user.cohorts.pluck(:discord_role_ids),
-          configuration.default_role_ids
-        ].flatten - [nil]
+      role_ids = [
+        @user.cohorts.pluck(:discord_role_ids),
+        configuration.default_role_ids
+      ].flatten.compact.uniq
 
       return if role_ids.empty?
 
@@ -26,11 +25,9 @@ module Discord
       Rails.logger.error "Unknown member #{@user.discord_user_id}"
       @user.update!(discord_user_id: nil)
     rescue Discordrb::Errors::NoPermission
-      Rails
-        .logger.error "No permission to update member #{@user.discord_user_id}"
+      Rails.logger.error "No permission to update member #{@user.discord_user_id}"
     rescue RestClient::BadRequest => e
-      Rails
-        .logger.error "Bad request with discord_user_id: #{@user.discord_user_id}; #{e.response.body}"
+      Rails.logger.error "Bad request with discord_user_id: #{@user.discord_user_id}; #{e.response.body}"
     end
 
     def configuration
@@ -39,7 +36,7 @@ module Discord
 
     def nick_name
       return @user.name if @user.name.length <= 32
-      @user.name[0..28] + '...'
+      @user.name[0..28] + "..."
     end
   end
 end


### PR DESCRIPTION
This fixes the crash in `Discord::SyncProfileService` when a user is part of cohorts that share a common Discord role ID.
The `update_member` API method responds with `Invalid Form Body` when roles argument have duplicate role_ids.

@pupilfirst/developers