### PR TITLE
feat: add seo_slug to courses for public-facing urls

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -100,7 +100,7 @@ class CoursesController < ApplicationController
   private
 
   def course
-    @course ||= Course.find(params[:id])
+    @course ||= find_course
   end
 
   def preview_or_authenticate
@@ -117,7 +117,11 @@ class CoursesController < ApplicationController
   end
 
   def find_course
-    policy_scope(Course).find(params[:id])
+    if params[:seo_slug]&.to_i&.to_s == params[:seo_slug]
+      policy_scope(Course).find(params[:seo_slug])
+    else
+      policy_scope(Course).find_by!(seo_slug: params[:seo_slug])
+    end
   end
 
   def save_tag

--- a/app/frontend/users/home/components/UsersDashboard__Root.res
+++ b/app/frontend/users/home/components/UsersDashboard__Root.res
@@ -104,7 +104,7 @@ let ctaText = (message, icon) =>
     <span> <i className=icon /> <span className="ms-2"> {message->str} </span> </span>
   </div>
 
-let studentLink = (courseId, suffix) => "/courses/" ++ (courseId ++ ("/" ++ suffix))
+let studentLink = (courseSeoSlug, suffix) => "/courses/" ++ (courseSeoSlug ++ ("/" ++ suffix))
 
 let callToAction = (course, currentSchoolAdmin) =>
   if currentSchoolAdmin {
@@ -125,12 +125,13 @@ let callToAction = (course, currentSchoolAdmin) =>
 
 let ctaFooter = (course, currentSchoolAdmin) => {
   let courseId = Course.id(course)
+  let courseSeoSlug = Course.seoSlug(course)
 
   switch callToAction(course, currentSchoolAdmin) {
-  | #ViewCourse => ctaButton(t("cta.view_course"), studentLink(courseId, "curriculum"))
+  | #ViewCourse => ctaButton(t("cta.view_course"), studentLink(courseSeoSlug, "curriculum"))
   | #EditCourse =>
     ctaButton(t("cta.edit_curriculum"), "/school/courses/" ++ (courseId ++ "/curriculum"))
-  | #ReviewSubmissions => ctaButton(t("cta.review_submissions"), studentLink(courseId, "review"))
+  | #ReviewSubmissions => ctaButton(t("cta.review_submissions"), studentLink(courseSeoSlug, "review"))
   | #DroppedOut => ctaText(t("cta.dropped_out"), "fas fa-user-slash")
   | #AccessEnded => ctaText(t("cta.access_ended"), "fas fa-history")
   | #CourseEnded => ctaText(t("cta.course_ended"), "fas fa-history")
@@ -154,6 +155,7 @@ let communityLinks = (communityIds, communities) => Js.Array.map(id => {
 
 let courseLinks = (course, currentSchoolAdmin, communities) => {
   let courseId = Course.id(course)
+  let courseSeoSlug = Course.seoSlug(course)
   let cta = callToAction(course, currentSchoolAdmin)
 
   <div className="flex flex-wrap px-4 mt-2">
@@ -166,23 +168,23 @@ let courseLinks = (course, currentSchoolAdmin, communities) => {
       Course.author(course) && cta != #EditCourse,
     )}
     {ReactUtils.nullUnless(
-      courseLink(studentLink(courseId, "curriculum"), t("cta.view_curriculum"), "fas fa-book"),
+      courseLink(studentLink(courseSeoSlug, "curriculum"), t("cta.view_curriculum"), "fas fa-book"),
       cta != #ViewCourse,
     )}
     {ReactUtils.nullUnless(
-      courseLink(studentLink(courseId, "leaderboard"), t("cta.leaderboard"), "fas fa-calendar-alt"),
+      courseLink(studentLink(courseSeoSlug, "leaderboard"), t("cta.leaderboard"), "fas fa-calendar-alt"),
       Course.enableLeaderboard(course),
     )}
     {ReactUtils.nullUnless(
       courseLink(
-        studentLink(courseId, "review"),
+        studentLink(courseSeoSlug, "review"),
         t("cta.review_submissions"),
         "fas fa-check-square",
       ),
       Course.review(course) && cta != #ReviewSubmissions,
     )}
     {ReactUtils.nullUnless(
-      courseLink(studentLink(courseId, "cohorts"), t("cta.my_cohorts"), "fas fa-user-friends"),
+      courseLink(studentLink(courseSeoSlug, "cohorts"), t("cta.my_cohorts"), "fas fa-user-friends"),
       Course.review(course),
     )}
     {communityLinks(Course.linkedCommunities(course), communities)}

--- a/app/frontend/users/home/types/UsersDashboard__Course.res
+++ b/app/frontend/users/home/types/UsersDashboard__Course.res
@@ -1,5 +1,6 @@
 type t = {
   id: string,
+  seoSlug: string,
   name: string,
   review: bool,
   author: bool,
@@ -14,6 +15,7 @@ type t = {
 
 let name = t => t.name
 let id = t => t.id
+let seoSlug = t => t.seoSlug
 let review = t => t.review
 let author = t => t.author
 let description = t => t.description
@@ -28,6 +30,7 @@ let decode = json => {
   open Json.Decode
   {
     id: json |> field("id", string),
+    seoSlug: json |> field("seoSlug", string),
     name: json |> field("name", string),
     description: json |> field("description", string),
     exited: json |> field("exited", bool),

--- a/app/graphql/types/course_type.rb
+++ b/app/graphql/types/course_type.rb
@@ -8,6 +8,7 @@ module Types
       end
     connection_type_class Types::PupilfirstConnection
     field :id, ID, null: false
+    field :seo_slug, String, null: true
     field :name, String, null: false
     field :description, String, null: false
     field :enable_leaderboard, Boolean, null: false

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -61,6 +61,8 @@ class Course < ApplicationRecord
                  scope: :school_id,
                  time_frame: 1.year
 
+  before_save :set_seo_slug
+
   def short_name
     name[0..2].upcase.strip
   end
@@ -104,5 +106,29 @@ class Course < ApplicationRecord
 
   def live?
     archived_at.blank?
+  end
+
+  def to_param
+    seo_slug || id
+  end
+
+private
+
+  def set_seo_slug
+    return if seo_slug.present?
+
+    self.seo_slug = generate_seo_slug(name)
+  end
+
+  def generate_seo_slug(value, count = 0)
+    value = value.gsub(/[^a-zA-Z0-9]/, '-').titleize.parameterize
+
+    if Course.where(seo_slug: value).exists?
+      value = value.rpartition('-').first if count > 0
+      return generate_seo_slug(
+        "#{value}-#{count + 1}", count + 1
+      )
+    end
+    value
   end
 end

--- a/app/presenters/layouts/course_nav_presenter.rb
+++ b/app/presenters/layouts/course_nav_presenter.rb
@@ -112,7 +112,7 @@ module Layouts
         case view.request.path.split("/")[3]
         when "review"
           if courses_as_coach.include?(course)
-            view.review_course_path(course)
+            view.review_course_path(course.id)
           else
             default_path
           end

--- a/app/presenters/users/dashboard_presenter.rb
+++ b/app/presenters/users/dashboard_presenter.rb
@@ -141,6 +141,7 @@ module Users
         .map do |course|
           {
             id: course.id,
+            seo_slug: course.seo_slug,
             name: course.name,
             review: course.id.in?(courses_with_review_access),
             author: course.id.in?(courses_with_author_access),

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -92,7 +92,7 @@
                       <% when nil %>
                       <a
                           class="w-full btn <%= course.public_signup? ? 'btn-primary' : 'btn-default' %>"
-                          href="/courses/<%= course.id %>"
+                          href="/courses/<%= course.to_param %>"
                         >
                         <% if course.public_signup? %>
                           <i class="fas fa-feather-alt me-2"></i>
@@ -112,7 +112,7 @@
                       <% when :access_ended %>
                       <a
                           class="w-full btn btn-secondary"
-                          href="/courses/<%= course.id %>/curriculum"
+                          href="/courses/<%= course.to_param %>/curriculum"
                         >
                         <i class="fas fa-eye me-2"></i>
                         <%= t('.access_ended') %>
@@ -120,7 +120,7 @@
                       <% when :active %>
                       <a
                           class="w-full btn btn-secondary"
-                          href="/courses/<%= course.id %>/curriculum"
+                          href="/courses/<%= course.to_param %>/curriculum"
                         >
                         <i class="fas fa-book me-2"></i>
                         <%= t('.active') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -263,6 +263,11 @@ Rails.application.routes.draw do
   resources :courses, only: %i[show] do
     member do
       get 'review', action: 'review'
+    end
+  end
+
+  resources :courses, only: %i[show], param: :seo_slug do
+    member do
       get 'cohorts', action: 'cohorts'
       get 'calendar', action: 'calendar'
       get 'calendar_month_data', action: 'calendar_month_data'

--- a/db/migrate/20231124100701_add_seo_slug_to_courses.rb
+++ b/db/migrate/20231124100701_add_seo_slug_to_courses.rb
@@ -1,0 +1,7 @@
+class AddSeoSlugToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :seo_slug, :string
+
+    Course.all.each{ |course| course.save! }
+  end
+end


### PR DESCRIPTION
Is there an existing, preferred way to do this that I missed? `:id`-based urls are fine on the admin side, but it would be nice to have cleaner urls for seo and to obfuscate the number of courses on the system. I'm happy to go through the checklist if this is a welcome change.

## Proposed Changes

- Adds `:seo_slug` attribute to `Course` model
- Uses `to_param` to use the seo_slug value if set or falls back to the id
- Handles edge-case for review page


@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [ ] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
