### PR TITLE
Handle session ID being nil in auth_callback

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -145,7 +145,7 @@ module Users
         session_id = Base64.urlsafe_decode64(data[:session_id])
 
         # Abort if the session is invalid
-        if session_id.to_s != session.id.private_id.to_s
+        if session.id.nil? || session_id.to_s != session.id.private_id.to_s
           flash[:error] = t(".invalid_session")
           redirect_to new_user_session_path
           return


### PR DESCRIPTION
This is a fix for Rollbar item 368. It looks like `session.id` can be `nil` under certain (normal) circumstances, so the assumption that `session.id` always responds to `.private_id` is incorrect. This simply adds a check for `nil?` on `session.id` prior to sending `private_id`.

## Merge Checklist

- ~~Add specs that demonstrate bug / test a new feature.~~
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
- ~~If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.~~