### PR TITLE
Assignment table's archived and milestone columns should default to false and be non-nil

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -16,6 +16,8 @@ class Assignment < ApplicationRecord
   scope :not_archived, -> { where.not(archived: true) }
   scope :milestone, -> { not_archived.where(milestone: true) }
 
+  normalize_attribute :completion_instructions
+
   ROLE_STUDENT = "student"
   ROLE_TEAM = "team"
 

--- a/db/migrate/20231218123723_non_nil_booleans_in_assignments.rb
+++ b/db/migrate/20231218123723_non_nil_booleans_in_assignments.rb
@@ -1,0 +1,20 @@
+class NonNilBooleansInAssignments < ActiveRecord::Migration[7.0]
+  class Assignment < ApplicationRecord
+  end
+
+  def up
+    Assignment.where(archived: nil).update_all(archived: false)
+
+    change_column_default :assignments, :archived, from: nil, to: false
+    change_column_null :assignments, :archived, false
+
+    Assignment.where(milestone: nil).update_all(milestone: false)
+
+    change_column_default :assignments, :milestone, from: nil, to: false
+    change_column_null :assignments, :milestone, false
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_28_121837) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_18_123723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -85,11 +85,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_28_121837) do
     t.string "role"
     t.jsonb "checklist"
     t.string "completion_instructions"
-    t.boolean "milestone"
+    t.boolean "milestone", default: false, null: false
     t.integer "milestone_number"
-    t.boolean "archived"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.boolean "archived", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["target_id"], name: "index_assignments_on_target_id"
   end
 

--- a/db/seeds/development/targets.seeds.rb
+++ b/db/seeds/development/targets.seeds.rb
@@ -72,7 +72,7 @@ after "development:evaluation_criteria", "development:target_groups" do
 
     form_submission =
       target_group.targets.create!(
-        title: Faker::Lorem.sentence,
+        title: "Form: #{Faker::Lorem.sentence}",
         resubmittable: true,
         visibility: "live",
         sort_index: 5
@@ -83,7 +83,7 @@ after "development:evaluation_criteria", "development:target_groups" do
         checklist: [
           {
             kind: Target::CHECKLIST_KIND_MULTI_CHOICE,
-            title: "Do you play cricket?",
+            title: "Do you play any sport?",
             optional: false,
             metadata: {
               choices: %w[Yes No],
@@ -92,19 +92,19 @@ after "development:evaluation_criteria", "development:target_groups" do
           },
           {
             kind: Target::CHECKLIST_KIND_LONG_TEXT,
-            title: "Describe your cricketing experience",
+            title: "Describe your experience playing sports",
             optional: false
           },
           {
             kind: Target::CHECKLIST_KIND_SHORT_TEXT,
-            title: "Are you morning person or night owl?",
+            title: "Are you early bird or night owl?",
             optional: false,
             metadata: {
             }
           },
           {
             kind: Target::CHECKLIST_KIND_LINK,
-            title: "Please, fill your portifolio link",
+            title: "Please, fill your github link",
             optional: true,
             metadata: {
             }

--- a/db/seeds/development/timeline_events.seeds.rb
+++ b/db/seeds/development/timeline_events.seeds.rb
@@ -105,24 +105,21 @@ after "development:students", "development:targets", "development:faculty" do
 
   form_submission_checklist = [
     {
-      title:
-        "Have you participated (asked or answered questions) in Pupilfirst School Discord server during WD 101 duration?",
+      title: "Do you play any sport?",
       kind: "multiChoice",
       result: ["Yes"],
       status: "noAnswer"
     },
     {
-      title:
-        "If you have chosen Yes for the previous question on participation in the Discord server, type \"None\" and proceed to the next question.\n\nElse, if you have chosen No, please let us know why?",
+      title: "Describe your experience playing sports",
       kind: "longText",
-      result: "None",
+      result: "It keeps me fit",
       status: "noAnswer"
     },
     {
-      title:
-        "Approximately how much time did it take you to complete the WD101 course?",
+      title: "Are you early bird or night owl?",
       kind: "shortText",
-      result: "15",
+      result: "Night owl",
       status: "noAnswer"
     },
     {
@@ -138,7 +135,7 @@ after "development:students", "development:targets", "development:faculty" do
     TimelineEvent.create!(
       checklist: form_submission_checklist,
       created_at: 2.hours.ago,
-      target_id: 6
+      target_id: Target.find_by("title LIKE ?", "Form: %").id
     )
 
   form_submission.timeline_event_owners.create!(latest: true, student: student)

--- a/db/seeds/development/timeline_events.seeds.rb
+++ b/db/seeds/development/timeline_events.seeds.rb
@@ -30,7 +30,8 @@ after "development:students", "development:targets", "development:faculty" do
   # Add lots of reviewed submissions.
   course
     .targets
-    .includes(:level, :evaluation_criteria)
+    .joins(:evaluation_criteria)
+    .includes(:level)
     .each do |target|
       # Create two such submissions per target.
       (1..2).each do |submission_number|
@@ -77,7 +78,8 @@ after "development:students", "development:targets", "development:faculty" do
   # Add a few pending review submissions and archived ones.
   course
     .targets
-    .joins(:level)
+    .joins(:evaluation_criteria)
+    .includes(:level)
     .where(levels: { id: final_level.id })
     .each do |target|
       pending_review =
@@ -136,7 +138,7 @@ after "development:students", "development:targets", "development:faculty" do
     TimelineEvent.create!(
       checklist: form_submission_checklist,
       created_at: 2.hours.ago,
-      target_id: 7
+      target_id: 6
     )
 
   form_submission.timeline_event_owners.create!(latest: true, student: student)

--- a/spec/system/school/courses/target_details_editor_spec.rb
+++ b/spec/system/school/courses/target_details_editor_spec.rb
@@ -149,9 +149,9 @@ feature "Target Details Editor", js: true do
     click_button "Update Target"
     dismiss_notification
 
-    expect(target_1_l2.reload.assignments.first.completion_instructions).to eq(
-      ""
-    )
+    expect(
+      target_1_l2.reload.assignments.first.completion_instructions
+    ).to be_nil
   end
 
   scenario "school admin updates a target as reviewed by faculty" do


### PR DESCRIPTION
This fixes the seeding issue in development that was preventing assignments from showing up correctly in the UI.

This also updates the DB structure to make the two booleans in the `assignments` table `null: false`.

This fixes the issue with seeds, create submissions for only targets that have evaluation criteria attached.

This fixes the issue with form submission target id.

## Unrelated changes

- Added normalization for `Assignment.completion_instructions`.

## Merge Checklist

- ~~Add specs that demonstrate bug / test a new feature.~~
- ~~Check if route, query, or mutation authorization looks correct.~~
- ~~Ensure that UI text is kept in I18n files.~~
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
- ~~If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.~~
