### PR TITLE
Prioritize node install from nodesource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN bundle install -j4
 # We need NodeJS & Yarn for precompiling assets.
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo 'Package: nodejs\nPin: origin deb.nodesource.com\nPin-Priority: 1001' > /etc/apt/preferences.d/nodesource
 RUN apt-get update && apt-get install nodejs -y
 RUN corepack enable
 

--- a/Dockerfile.evaluation
+++ b/Dockerfile.evaluation
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
 # We need NodeJS & Yarn for precompiling assets.
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo 'Package: nodejs\nPin: origin deb.nodesource.com\nPin-Priority: 1001' > /etc/apt/preferences.d/nodesource
 RUN apt-get update && apt-get install nodejs -y
 RUN corepack enable
 


### PR DESCRIPTION
## Proposed Changes

Install nodejs from nodesource in Docker. The presence of other latest versions causing the nodejs to install from different sources.

In this https://github.com/pupilfirst/pupilfirst/actions/runs/7420524093/job/20197046278, merge of #1524 the image build failed as the nodejs is getting installed from [deb.debian.org/debian-security bookworm-security/main](https://github.com/pupilfirst/pupilfirst/actions/runs/7420524093/job/20197046278#step:5:1810) looks like which do not have corepack, npm, yarn bundle in installation

@pupilfirst/developers
I have a question here why we are not installing the exact node version `18.16.0` mentioned in `.tool-versions` while building the image ?


## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [ ] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
