### PR TITLE
Run tests in parallel

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,2 @@
+--format progress
+--format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log

--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,8 @@ group :development, :test do
   gem "rubocop-rails", "~> 2.20", require: false # A RuboCop extension focused on enforcing Rails best practices and coding conventions.
   gem "overcommit", "~> 0.58", require: false # A fully configurable and extendable Git hook manager
   gem "fuubar", "~> 2.5" # The instafailing RSpec progress bar formatter.
-  gem "simplecov", "~> 0.21", require: false # Code coverage for Ruby. https://github.com/colszowka/simplecov
+  gem "simplecov", "~> 0.21", require: false # Code coverage for Ruby. https://github.com/simplecov-ruby/simplecov
+  gem "parallel_tests", "~> 4.4" # Increased testing Speed for RSpec. https://github.com/grosser/parallel_tests
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,6 +448,8 @@ GEM
       iniparse (~> 1.4)
       rexml (~> 3.2)
     parallel (1.23.0)
+    parallel_tests (4.4.0)
+      parallel
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -761,6 +763,7 @@ DEPENDENCIES
   omniauth-github!
   omniauth-google-oauth2 (~> 1.1)
   overcommit (~> 0.58)
+  parallel_tests (~> 4.4)
   pg (~> 1.2)
   pg_search (~> 2.3)
   postmark-rails (~> 0.22)

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,7 @@ development:
 
 test:
   <<: *common
-  database: <%= ENV['DB_NAME_TEST'] %>
+  database: <%= ENV['DB_NAME_TEST'] %><%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   <<: *common


### PR DESCRIPTION
@pupilfirst/developers This adds the parallel_tests gem to run Rspec tests in parallel with multiple databases. On my 8-core laptop, this runs with 16 processes by default and finishes all tests in approx 2:50 (`m:ss`). Manually setting the number of processes to 8 reduces memory pressure somewhat, and still finishes in 3:10. So it seems hyper-threading doesn't help too much.

To run tests in parallel on this branch, do:

```bash
# Create the parallel databases (equal to number of logical processors)
bundle exec rails parallel:create

# Load schema into all of these databases
bundle exec rails parallel:prepare

# Run the tests. I had to pass RAILS_ENV=tests to get this to work.
RAILS_ENV=test bundle exec rails parallel:spec

# Or to limit the number of processes to 8...
RAILS_ENV=test bundle exec "rails parallel:spec[8]"
```

A few specs are failing for me (2 to 3).

Running failing specs using `bundle exec rspec --only-failures` is also resulting in failures, so this needs looking into.

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [ ] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [ ] Ensure that UI text is kept in I18n files.
- [ ] Update developer and product docs, where applicable.
- [ ] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [ ] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [ ] Check if changes in _packaged_ components have been published to `npm`.
- [ ] Add development seeds for new tables.
- [ ] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [ ] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
