### PR TITLE
Add name to the subject of certificate issuance email

### DIFF
--- a/app/mailers/issued_certificate_mailer.rb
+++ b/app/mailers/issued_certificate_mailer.rb
@@ -9,7 +9,10 @@ class IssuedCertificateMailer < SchoolMailer
     @school = @issued_certificate.user.school
     simple_mail(
       @issued_certificate.user.email,
-      I18n.t('mailers.issued_certificate.issued.subject')
+      I18n.t(
+        "mailers.issued_certificate.issued.subject",
+        name: @issued_certificate.name
+      )
     )
   end
 end

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -2200,7 +2200,7 @@ ar:
           congratulations: Congratulations!
           issued_on_html: The certificate was issued on %{issued_certificate} and can be viewed or printed by %{link_to}.
           link_to: visiting the certificate's public link
-        subject: You have been awarded a certificate!
+        subject: "%{name}, you have been awarded a certificate!"
     layouts:
       mail:
         thanks: Thanks,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2135,7 +2135,7 @@ en:
           congratulations: Congratulations!
           issued_on_html: The certificate was issued on %{issued_certificate} and can be viewed or printed by %{link_to}.
           link_to: visiting the certificate's public link
-        subject: You have been awarded a certificate!
+        subject: "%{name}, you have been awarded a certificate!"
     layouts:
       mail:
         thanks: Thanks,

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2376,7 +2376,7 @@ ru:
           congratulations: Congratulations!
           issued_on_html: The certificate was issued on %{issued_certificate} and can be viewed or printed by %{link_to}.
           link_to: visiting the certificate's public link
-        subject: You have been awarded a certificate!
+        subject: "%{name}, you have been awarded a certificate!"
     school_admin:
       added: Добавлен Новый Администратор Школы
       import: Импорт студентов завершен

--- a/spec/system/certificates/auto_issue_certificates_spec.rb
+++ b/spec/system/certificates/auto_issue_certificates_spec.rb
@@ -99,11 +99,15 @@ feature "Automatic issuance of certificates", js: true do
     # Two emails should also have been sent out.
     open_email(student_1.email)
 
+    exopect(current_email.subject).to include(student_1.name)
+
     expect(sanitize_html(current_email.body)).to include(
       "http://test.host/c/#{issued_certificate.serial_number}"
     )
 
     open_email(student_2.email)
+
+    exopect(current_email.subject).to include(student_2.name)
 
     expect(sanitize_html(current_email.body)).to include(
       "http://test.host/c/#{student_2.user.issued_certificates.first.serial_number}"


### PR DESCRIPTION
@pupilfirst/developers Similar to https://github.com/pupilfirst/pupilfirst/pull/1535, this adds the name to the subject of the certificate issuance sent to students. The main advantage here is that students replying to the issuance email will do so with a custom Re: SUBJECT, forcing the emails to not get clubbed in the school's mailbox.

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- ~~Check if route, query, or mutation authorization looks correct.~~
- [x] Ensure that UI text is kept in I18n files.
- ~~Update developer and product docs, where applicable.~~
- ~~Prep screenshot or demo video for changelog entry, and attach it to issue.~~
- ~~Check if new tables or columns that have been added need to be handled in the following services:~~
- ~~Check if changes in _packaged_ components have been published to `npm`.~~
- ~~Add development seeds for new tables.~~
- ~~If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.~~
- ~~If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.~~
