### PR TITLE
Fix some intermittent spec failures

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2345,7 +2345,7 @@ en:
     create_user_standing:
       standing_archived_error: Selected standing is no longer active. Please refresh the page and try again.
       standing_not_found_error: Selected standing doesn't exist. Please refresh the page and try again.
-      success_notification: Standing log created successfully!.
+      success_notification: Standing log created successfully!
     delete_certificate:
       success_notification: Certificate has been deleted.
     delete_course_author:

--- a/spec/system/school/courses/students_index_spec.rb
+++ b/spec/system/school/courses/students_index_spec.rb
@@ -830,7 +830,7 @@ feature "School students index", js: true do
 
       click_button "Add Entry"
 
-      expect(page).to have_text("Standing log created successfully!.")
+      expect(page).to have_text("Standing log created successfully!")
 
       dismiss_notification
 
@@ -893,7 +893,7 @@ feature "School students index", js: true do
 
       click_button "Add Entry"
 
-      expect(page).to have_text("Standing log created successfully!.")
+      expect(page).to have_text("Standing log created successfully!")
 
       dismiss_notification
 

--- a/spec/system/school/courses/students_index_spec.rb
+++ b/spec/system/school/courses/students_index_spec.rb
@@ -4,6 +4,7 @@ feature "School students index", js: true do
   include UserSpecHelper
   include NotificationHelper
   include HtmlSanitizerSpecHelper
+  include MarkdownEditorHelper
 
   let(:tag_1) { "Single Student" }
   let(:tag_2) { "Another Tag" }
@@ -826,8 +827,7 @@ feature "School students index", js: true do
 
       reason = Faker::Lorem.sentence
 
-      fill_in "reason-for-altering-standing", with: reason
-
+      add_markdown reason
       click_button "Add Entry"
 
       expect(page).to have_text("Standing log created successfully!")
@@ -835,9 +835,7 @@ feature "School students index", js: true do
       dismiss_notification
 
       expect(page).to have_text(standing_2.name)
-
       expect(page).to have_text(school_admin.user.name)
-
       expect(page).to have_text(reason)
 
       expect(page).to have_select(
@@ -889,7 +887,7 @@ feature "School students index", js: true do
 
       reason = Faker::Lorem.sentence
 
-      fill_in "reason-for-altering-standing", with: reason
+      add_markdown reason
 
       click_button "Add Entry"
 
@@ -898,7 +896,6 @@ feature "School students index", js: true do
       dismiss_notification
 
       expect(page).to have_text(standing_2.name)
-
       expect(page).to have_text(reason)
 
       expect(page).to have_select(

--- a/spec/system/school/courses/students_index_spec.rb
+++ b/spec/system/school/courses/students_index_spec.rb
@@ -804,7 +804,7 @@ feature "School students index", js: true do
       expect(page).to have_text(standing_1.name)
     end
 
-    scenario "school admin changes the student standing" do
+    scenario "school admin adds an entry to the student standing log" do
       sign_in_user school_admin.user,
                    referrer: "/school/students/#{student.id}/standing"
 
@@ -864,73 +864,52 @@ feature "School students index", js: true do
       expect(body).to have_text(reason)
     end
 
-    scenario "school admin deletes a user standing log" do
-      sign_in_user school_admin.user,
-                   referrer: "/school/students/#{student.id}/standing"
-
-      expect(page).to have_text("There are no entries in the log")
-
-      expect(page).to have_select(
-        "current-standing",
-        selected: standing_1.name,
-        disabled: true
-      )
-
-      expect(page).to have_select(
-        "change-standing",
-        selected: "Select Standing"
-      )
-
-      select standing_2.name, from: "change-standing"
-
-      expect(page).to have_text(standing_2.description)
-
-      reason = Faker::Lorem.sentence
-
-      add_markdown reason
-
-      click_button "Add Entry"
-
-      expect(page).to have_text("Standing log created successfully!")
-
-      dismiss_notification
-
-      expect(page).to have_text(standing_2.name)
-      expect(page).to have_text(reason)
-
-      expect(page).to have_select(
-        "current-standing",
-        selected: standing_2.name,
-        disabled: true
-      )
-
-      expect(page).to have_select(
-        "change-standing",
-        selected: "Select Standing"
-      )
-
-      accept_confirm do
-        find(
-          "button[title='Delete Standing Log#{student.user.user_standings.last.id}']"
-        ).click
+    context "when there are entries in the standing log" do
+      let!(:user_standing) do
+        create :user_standing, user: student.user, standing: standing_2
       end
 
-      expect(page).to have_text("Standing log deleted successfully")
+      scenario "school admin deletes an entry in the log" do
+        sign_in_user school_admin.user,
+                     referrer: "/school/students/#{student.id}/standing"
 
-      dismiss_notification
+        expect(page).to have_text(standing_2.name)
+        expect(page).to have_text(user_standing.reason)
 
-      expect(page).to have_text("There are no entries in the log")
+        expect(page).to have_select(
+          "current-standing",
+          selected: standing_2.name,
+          disabled: true
+        )
 
-      expect(page).to have_select(
-        "current-standing",
-        selected: standing_1.name,
-        disabled: true
-      )
+        expect(page).to have_select(
+          "change-standing",
+          selected: "Select Standing"
+        )
 
-      expect(page).to have_select(
-        "change-standing",
-        selected: "Select Standing"
-      )
+        accept_confirm do
+          find(
+            "button[title='Delete Standing Log#{student.user.user_standings.last.id}']"
+          ).click
+        end
+
+        expect(page).to have_text("Standing log deleted successfully")
+
+        dismiss_notification
+
+        expect(page).to have_text("There are no entries in the log")
+
+        expect(page).to have_select(
+          "current-standing",
+          selected: standing_1.name,
+          disabled: true
+        )
+
+        expect(page).to have_select(
+          "change-standing",
+          selected: "Select Standing"
+        )
+      end
     end
   end
 end

--- a/spec/system/school/standing_spec.rb
+++ b/spec/system/school/standing_spec.rb
@@ -148,20 +148,16 @@ feature "School Standing", js: true do
 
       expect(page).to have_text("Enabled")
 
-      expect(page).to have_link("Add CoC")
-
       click_link "Add CoC"
 
       expect(page).to have_text("Code of Conduct")
 
-      code_of_conduct = Faker::Markdown.sandwich(sentences: 6)
+      code_of_conduct = Faker::Lorem.sentence
       add_markdown(code_of_conduct)
 
       click_button "Save Code of Conduct"
 
       expect(page).to have_text("Code of Conduct saved successfully")
-
-      expect(page).to have_link("Edit CoC")
 
       click_link "Edit CoC"
 
@@ -171,8 +167,7 @@ feature "School Standing", js: true do
         expect(page).to have_text(code_of_conduct)
       end
 
-      code_of_conduct = Faker::Markdown.sandwich(sentences: 6)
-
+      code_of_conduct = Faker::Lorem.sentence
       replace_markdown(code_of_conduct)
 
       click_button "Save Code of Conduct"


### PR DESCRIPTION
@yash-learner This makes a few fixes to recently failing specs:

- It avoids using Faker's MD sandwich for checking save & retrieve, since it isn't strictly necessary. Generated MD can contain extra spaces that the saving process throws away. We don't care about details like that.
- Always use the `MarkdownEditorHelper` module method to interact with the Markdown editor in specs. We can't use `fill_in` to interact with the editor because of incompatibility with React's state management.
- I've removed repetition of _standing addition_ actions in a spec meant to check deletion of existing entries. Instead of manually adding the standing, I simply created a `user_standing` using context.