### PR TITLE
Remove stale assignment columns from target

### DIFF
--- a/app/graphql/concerns/validate_student_submission.rb
+++ b/app/graphql/concerns/validate_student_submission.rb
@@ -68,7 +68,7 @@ module ValidateStudentSubmission
       if checklist.respond_to?(:all?) &&
            checklist.all? { |item|
              item["title"].is_a?(String) &&
-               item["kind"].in?(Target.valid_checklist_kind_types) &&
+               item["kind"].in?(Assignment.valid_checklist_kind_types) &&
                item["status"] == TimelineEvent::CHECKLIST_STATUS_NO_ANSWER &&
                item["result"].present? &&
                valid_result(item["kind"], item["result"], value[:file_ids])
@@ -81,16 +81,16 @@ module ValidateStudentSubmission
 
     def valid_result(kind, result, file_ids)
       case kind
-      when Target::CHECKLIST_KIND_FILES
+      when Assignment::CHECKLIST_KIND_FILES
         (result - file_ids).empty?
-      when Target::CHECKLIST_KIND_AUDIO
+      when Assignment::CHECKLIST_KIND_AUDIO
         (result.split - file_ids).empty?
-      when Target::CHECKLIST_KIND_LINK
+      when Assignment::CHECKLIST_KIND_LINK
         result.length >= 3 && result.length <= 2048
-      when Target::CHECKLIST_KIND_LONG_TEXT
+      when Assignment::CHECKLIST_KIND_LONG_TEXT
         result.length >= 1 && result.length <= 10_000
-      when Target::CHECKLIST_KIND_MULTI_CHOICE,
-           Target::CHECKLIST_KIND_SHORT_TEXT
+      when Assignment::CHECKLIST_KIND_MULTI_CHOICE,
+           Assignment::CHECKLIST_KIND_SHORT_TEXT
         result.length >= 1 && result.length <= 500
       else
         false

--- a/app/graphql/mutations/create_grading.rb
+++ b/app/graphql/mutations/create_grading.rb
@@ -70,7 +70,7 @@ module Mutations
         if @checklist.respond_to?(:all?) &&
              @checklist.all? { |item|
                item["title"].is_a?(String) &&
-                 item["kind"].in?(Target.valid_checklist_kind_types) &&
+                 item["kind"].in?(Assignment.valid_checklist_kind_types) &&
                  item["status"].in?(
                    [
                      TimelineEvent::CHECKLIST_STATUS_FAILED,

--- a/app/graphql/types/target_info_type.rb
+++ b/app/graphql/types/target_info_type.rb
@@ -3,5 +3,17 @@ module Types
     field :id, ID, null: false
     field :title, String, null: false
     field :milestone_number, Integer, null: true
+
+    # def milestone_number
+    #   BatchLoader::GraphQL
+    #     .for(object.id)
+    #     .batch do |target_ids, loader|
+    #       Assignment
+    #         .where(target_id: target_ids)
+    #         .each do |assignment|
+    #           loader.call(assignment.target_id, assignment.milestone_number)
+    #         end
+    #     end
+    # end
   end
 end

--- a/app/graphql/types/target_info_type.rb
+++ b/app/graphql/types/target_info_type.rb
@@ -4,16 +4,16 @@ module Types
     field :title, String, null: false
     field :milestone_number, Integer, null: true
 
-    # def milestone_number
-    #   BatchLoader::GraphQL
-    #     .for(object.id)
-    #     .batch do |target_ids, loader|
-    #       Assignment
-    #         .where(target_id: target_ids)
-    #         .each do |assignment|
-    #           loader.call(assignment.target_id, assignment.milestone_number)
-    #         end
-    #     end
-    # end
+    def milestone_number
+      BatchLoader::GraphQL
+        .for(object.id)
+        .batch do |target_ids, loader|
+          Assignment
+            .where(target_id: target_ids)
+            .each do |assignment|
+              loader.call(assignment.target_id, assignment.milestone_number)
+            end
+        end
+    end
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -47,12 +47,14 @@ class Assignment < ApplicationRecord
   validates :role, presence: true, inclusion: { in: valid_roles }
   validates_with RateLimitValidator, limit: 2, scope: :target_id
 
+  validate :milestone_should_have_a_number
+
   def milestone_should_have_a_number
     return unless milestone?
 
     return if milestone_number.present?
 
-    errors.add(:milestone_number, "must be present for milestone targets")
+    errors.add(:milestone_number, "must be present for milestone assignments")
   end
 
   def quiz?

--- a/app/models/evaluation_criterion.rb
+++ b/app/models/evaluation_criterion.rb
@@ -1,6 +1,4 @@
 class EvaluationCriterion < ApplicationRecord
-  has_many :target_evaluation_criteria, dependent: :restrict_with_error
-  has_many :targets, through: :target_evaluation_criteria
   has_many :assignments_evaluation_criteria, dependent: :restrict_with_error
   has_many :assignments, through: :assignments_evaluation_criteria
   has_many :timeline_event_grades, dependent: :restrict_with_error

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -1,5 +1,4 @@
 class Quiz < ApplicationRecord
-  belongs_to :target, optional: true
   belongs_to :assignment, optional: true
   has_many :quiz_questions, dependent: :restrict_with_error
   has_many :answer_options, through: :quiz_questions

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -22,13 +22,10 @@ class Target < ApplicationRecord
   has_many :timeline_events, dependent: :restrict_with_error
   has_many :assignments, dependent: :restrict_with_error
   has_many :page_reads, dependent: :restrict_with_error
-  has_many :target_prerequisites, dependent: :destroy
-  has_many :prerequisite_targets, through: :target_prerequisites
   belongs_to :target_group
   has_many :evaluation_criteria, through: :assignments
   has_one :level, through: :target_group
   has_one :course, through: :target_group
-  has_one :quiz, dependent: :restrict_with_error
   has_many :topics, dependent: :restrict_with_error
   has_many :resource_versions, as: :versionable, dependent: :restrict_with_error
   has_many :target_versions, dependent: :destroy

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -54,14 +54,6 @@ class Target < ApplicationRecord
           )
         end
 
-  ROLE_STUDENT = "student"
-  ROLE_TEAM = "team"
-
-  # See en.yml's target.role
-  def self.valid_roles
-    [ROLE_STUDENT, ROLE_TEAM].freeze
-  end
-
   TYPE_TODO = "Todo"
   TYPE_ATTEND = "Attend"
   TYPE_READ = "Read"
@@ -71,30 +63,12 @@ class Target < ApplicationRecord
   VISIBILITY_ARCHIVED = "archived"
   VISIBILITY_DRAFT = "draft"
 
-  CHECKLIST_KIND_SHORT_TEXT = "shortText"
-  CHECKLIST_KIND_LONG_TEXT = "longText"
-  CHECKLIST_KIND_LINK = "link"
-  CHECKLIST_KIND_FILES = "files"
-  CHECKLIST_KIND_MULTI_CHOICE = "multiChoice"
-  CHECKLIST_KIND_AUDIO = "audio"
-
   def self.valid_target_action_types
     [TYPE_TODO, TYPE_ATTEND, TYPE_READ, TYPE_LEARN].freeze
   end
 
   def self.valid_visibility_types
     [VISIBILITY_LIVE, VISIBILITY_ARCHIVED, VISIBILITY_DRAFT].freeze
-  end
-
-  def self.valid_checklist_kind_types
-    [
-      CHECKLIST_KIND_FILES,
-      CHECKLIST_KIND_LINK,
-      CHECKLIST_KIND_LONG_TEXT,
-      CHECKLIST_KIND_MULTI_CHOICE,
-      CHECKLIST_KIND_SHORT_TEXT,
-      CHECKLIST_KIND_AUDIO
-    ].freeze
   end
 
   validates :target_action_type,
@@ -156,16 +130,6 @@ class Target < ApplicationRecord
         "Target and evaluation criterion must belong to same course"
       )
     end
-  end
-
-  validate :milestone_should_have_a_number
-
-  def milestone_should_have_a_number
-    return unless milestone?
-
-    return if milestone_number.present?
-
-    errors.add(:milestone_number, "must be present for milestone targets")
   end
 
   normalize_attribute :slideshow_embed,

--- a/app/models/target_evaluation_criterion.rb
+++ b/app/models/target_evaluation_criterion.rb
@@ -1,6 +1,0 @@
-class TargetEvaluationCriterion < ApplicationRecord
-  belongs_to :target
-  belongs_to :evaluation_criterion
-
-  validates :target_id, uniqueness: { scope: :evaluation_criterion_id }
-end

--- a/app/models/target_prerequisite.rb
+++ b/app/models/target_prerequisite.rb
@@ -1,5 +1,0 @@
-class TargetPrerequisite < ApplicationRecord
-  belongs_to :target
-  belongs_to :prerequisite_target, class_name: "Target"
-  validates_with RateLimitValidator, limit: 25, scope: :target_id
-end

--- a/app/presenters/schools/courses/curriculum_presenter.rb
+++ b/app/presenters/schools/courses/curriculum_presenter.rb
@@ -51,7 +51,6 @@ module Schools
             name: target_group.name,
             description: target_group.description,
             level_id: target_group.level_id,
-            milestone: target_group.milestone,
             sort_index: target_group.sort_index,
             archived: target_group.archived
           }

--- a/app/queries/create_target_mutator.rb
+++ b/app/queries/create_target_mutator.rb
@@ -1,25 +1,31 @@
 class CreateTargetMutator < ApplicationQuery
-  property :title, validates: { presence: { message: 'TitleBlank' } }
-  property :target_group_id, validates: { presence: { message: 'TargetGroupIdBlank' } }
+  property :title, validates: { presence: { message: "TitleBlank" } }
+  property :target_group_id,
+           validates: {
+             presence: {
+               message: "TargetGroupIdBlank"
+             }
+           }
 
   def create_target
     Target.transaction do
-      target = target_group.targets.create!(
-        title: title,
-        role: Target::ROLE_STUDENT,
-        target_action_type: Target::TYPE_TODO,
-        visibility: Target::VISIBILITY_DRAFT,
-        safe_to_change_visibility: true,
-        sort_index: sort_index,
-      )
+      target =
+        target_group.targets.create!(
+          title: title,
+          target_action_type: Target::TYPE_TODO,
+          visibility: Target::VISIBILITY_DRAFT,
+          safe_to_change_visibility: true,
+          sort_index: sort_index
+        )
 
-      demo_content_block_service = ContentBlocks::DemoMarkdownBlockService.new(target)
+      demo_content_block_service =
+        ContentBlocks::DemoMarkdownBlockService.new(target)
       content_block = demo_content_block_service.execute
 
       {
         id: target.id,
         content_block_id: content_block.id,
-        sample_content: demo_content_block_service.content_block_text,
+        sample_content: demo_content_block_service.content_block_text
       }
     end
   end
@@ -29,7 +35,8 @@ class CreateTargetMutator < ApplicationQuery
   def authorized?
     return false if target_group&.course&.school != current_school
 
-    current_school_admin.present? || current_user.course_authors.exists?(course: target_group.course)
+    current_school_admin.present? ||
+      current_user.course_authors.exists?(course: target_group.course)
   end
 
   def target_group
@@ -37,7 +44,13 @@ class CreateTargetMutator < ApplicationQuery
   end
 
   def sort_index
-    max_index = TargetGroup.joins(:course).where(courses: { school_id: current_school.id }).find(target_group_id).targets.maximum(:sort_index)
+    max_index =
+      TargetGroup
+        .joins(:course)
+        .where(courses: { school_id: current_school.id })
+        .find(target_group_id)
+        .targets
+        .maximum(:sort_index)
     max_index ? max_index + 1 : 1
   end
 end

--- a/app/services/concerns/course_exportable.rb
+++ b/app/services/concerns/course_exportable.rb
@@ -119,10 +119,10 @@ module CourseExportable
 
         scope =
           case role
-          when Target::ROLE_STUDENT
-            scope.where(assignments: { role: Target::ROLE_STUDENT })
-          when Target::ROLE_TEAM
-            scope.where(assignments: { role: Target::ROLE_TEAM })
+          when Assignment::ROLE_STUDENT
+            scope.where(assignments: { role: Assignment::ROLE_STUDENT })
+          when Assignment::ROLE_TEAM
+            scope.where(assignments: { role: Assignment::ROLE_TEAM })
           else
             scope
           end

--- a/app/services/course_exports/prepare_teams_export_service.rb
+++ b/app/services/course_exports/prepare_teams_export_service.rb
@@ -94,7 +94,7 @@ module CourseExports
     end
 
     def team_targets
-      targets(role: Target::ROLE_TEAM)
+      targets(role: Assignment::ROLE_TEAM)
     end
 
     def submissions(target)

--- a/app/services/courses/demo_content_service.rb
+++ b/app/services/courses/demo_content_service.rb
@@ -46,7 +46,6 @@ module Courses
     def create_target(target_group)
       target =
         Target.create!(
-          role: Target::ROLE_STUDENT,
           title: I18n.t("services.courses.demo_content_service.target_name"),
           target_action_type: Target::TYPE_TODO,
           target_group: target_group,

--- a/app/services/courses/demo_content_service.rb
+++ b/app/services/courses/demo_content_service.rb
@@ -38,7 +38,6 @@ module Courses
             "services.courses.demo_content_service.target_group_description"
           ),
         sort_index: 1,
-        milestone: true,
         level: level
       )
     end

--- a/app/services/targets/update_visibility_service.rb
+++ b/app/services/targets/update_visibility_service.rb
@@ -1,5 +1,5 @@
 module Targets
-  # Clean-up references to the target in the TargetPrerequisite join table.
+  # Clean-up references to the target through AssignmentPrerequisite join table.
   class UpdateVisibilityService
     def initialize(target, visibility)
       @target = target

--- a/db/migrate/20240227162656_remove_assignment_columns_from_target.rb
+++ b/db/migrate/20240227162656_remove_assignment_columns_from_target.rb
@@ -1,0 +1,8 @@
+class RemoveAssignmentColumnsFromTarget < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :targets, :role, :string
+    remove_column :targets, :completion_instructions, :string
+    remove_column :targets, :milestone, :boolean
+    remove_column :targets, :milestone_number, :integer
+  end
+end

--- a/db/migrate/20240227162656_remove_assignment_columns_from_target.rb
+++ b/db/migrate/20240227162656_remove_assignment_columns_from_target.rb
@@ -2,7 +2,8 @@ class RemoveAssignmentColumnsFromTarget < ActiveRecord::Migration[7.0]
   def change
     remove_column :targets, :role, :string
     remove_column :targets, :completion_instructions, :string
-    remove_column :targets, :milestone, :boolean
+    remove_column :targets, :milestone, :boolean, default: false
     remove_column :targets, :milestone_number, :integer
+    remove_column :targets, :checklist, :jsonb, default: []
   end
 end

--- a/db/migrate/20240315101852_cleanup_assignment_related_columns.rb
+++ b/db/migrate/20240315101852_cleanup_assignment_related_columns.rb
@@ -1,6 +1,4 @@
-class CleanupAssignmentRelatedColumns < ActiveRecord::Migration[
-  7.0
-]
+class CleanupAssignmentRelatedColumns < ActiveRecord::Migration[7.0]
   def change
     remove_column :targets, :role, :string
     remove_column :targets, :completion_instructions, :string
@@ -27,8 +25,6 @@ class CleanupAssignmentRelatedColumns < ActiveRecord::Migration[
       t.references :evaluation_criterion, foreign_key: true
       t.datetime "created_at", precision: nil, null: false
       t.datetime "updated_at", precision: nil, null: false
-      t.index "evaluation_criterion_id"
-      t.index "target_id"
     end
 
     remove_column :target_groups, :milestone, :boolean

--- a/db/migrate/20240315101852_cleanup_assignment_related_columns.rb
+++ b/db/migrate/20240315101852_cleanup_assignment_related_columns.rb
@@ -1,4 +1,4 @@
-class RemoveAssignmentColumnsAndRelationsFromTarget < ActiveRecord::Migration[
+class CleanupAssignmentRelatedColumns < ActiveRecord::Migration[
   7.0
 ]
   def change

--- a/db/migrate/20240315101852_remove_assignment_columns_and_relations_from_target.rb
+++ b/db/migrate/20240315101852_remove_assignment_columns_and_relations_from_target.rb
@@ -1,9 +1,16 @@
-class RemoveAssignmentColumnsFromTarget < ActiveRecord::Migration[7.0]
+class RemoveAssignmentColumnsAndRelationsFromTarget < ActiveRecord::Migration[
+  7.0
+]
   def change
     remove_column :targets, :role, :string
     remove_column :targets, :completion_instructions, :string
     remove_column :targets, :milestone, :boolean, default: false
     remove_column :targets, :milestone_number, :integer
     remove_column :targets, :checklist, :jsonb, default: []
+
+    remove_reference :quizzes, :target, foreign_key: true
+
+    drop_table :target_prerequisites
+    drop_table :target_evaluation_criteria
   end
 end

--- a/db/migrate/20240315101852_remove_assignment_columns_and_relations_from_target.rb
+++ b/db/migrate/20240315101852_remove_assignment_columns_and_relations_from_target.rb
@@ -8,10 +8,28 @@ class RemoveAssignmentColumnsAndRelationsFromTarget < ActiveRecord::Migration[
     remove_column :targets, :milestone_number, :integer
     remove_column :targets, :checklist, :jsonb, default: []
 
-    remove_reference :quizzes, :target, foreign_key: true
+    remove_reference :quizzes,
+                     :target,
+                     foreign_key: true,
+                     index: {
+                       unique: true
+                     }
 
-    drop_table :target_prerequisites
-    drop_table :target_evaluation_criteria
+    drop_table :target_prerequisites do |t|
+      t.integer "target_id"
+      t.integer "prerequisite_target_id"
+      t.index "prerequisite_target_id"
+      t.index "target_id"
+    end
+
+    drop_table :target_evaluation_criteria do |t|
+      t.references :target, foreign_key: true
+      t.references :evaluation_criterion, foreign_key: true
+      t.datetime "created_at", precision: nil, null: false
+      t.datetime "updated_at", precision: nil, null: false
+      t.index "evaluation_criterion_id"
+      t.index "target_id"
+    end
 
     remove_column :target_groups, :milestone, :boolean
   end

--- a/db/migrate/20240315101852_remove_assignment_columns_and_relations_from_target.rb
+++ b/db/migrate/20240315101852_remove_assignment_columns_and_relations_from_target.rb
@@ -12,5 +12,7 @@ class RemoveAssignmentColumnsAndRelationsFromTarget < ActiveRecord::Migration[
 
     drop_table :target_prerequisites
     drop_table :target_evaluation_criteria
+
+    remove_column :target_groups, :milestone, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -766,7 +766,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
     t.boolean "resubmittable", default: true
     t.string "visibility"
     t.jsonb "review_checklist", default: []
-    t.jsonb "checklist", default: []
     t.text "action_config"
     t.index ["archived"], name: "index_targets_on_archived"
     t.index ["session_at"], name: "index_targets_on_session_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_15_101852) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -540,12 +540,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
 
   create_table "quizzes", force: :cascade do |t|
     t.string "title"
-    t.bigint "target_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "assignment_id"
     t.index ["assignment_id"], name: "index_quizzes_on_assignment_id"
-    t.index ["target_id"], name: "index_quizzes_on_target_id", unique: true
   end
 
   create_table "reactions", force: :cascade do |t|
@@ -707,15 +705,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "target_evaluation_criteria", force: :cascade do |t|
-    t.bigint "target_id"
-    t.bigint "evaluation_criterion_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["evaluation_criterion_id"], name: "index_target_evaluation_criteria_on_evaluation_criterion_id"
-    t.index ["target_id"], name: "index_target_evaluation_criteria_on_target_id"
-  end
-
   create_table "target_groups", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -727,13 +716,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
     t.boolean "archived", default: false
     t.index ["level_id"], name: "index_target_groups_on_level_id"
     t.index ["sort_index"], name: "index_target_groups_on_sort_index"
-  end
-
-  create_table "target_prerequisites", id: :serial, force: :cascade do |t|
-    t.integer "target_id"
-    t.integer "prerequisite_target_id"
-    t.index ["prerequisite_target_id"], name: "index_target_prerequisites_on_prerequisite_target_id"
-    t.index ["target_id"], name: "index_target_prerequisites_on_target_id"
   end
 
   create_table "target_versions", force: :cascade do |t|
@@ -1015,7 +997,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
   add_foreign_key "quiz_questions", "answer_options", column: "correct_answer_id"
   add_foreign_key "quiz_questions", "quizzes"
   add_foreign_key "quizzes", "assignments"
-  add_foreign_key "quizzes", "targets"
   add_foreign_key "reactions", "users"
   add_foreign_key "school_admins", "users"
   add_foreign_key "school_links", "schools"
@@ -1030,8 +1011,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
   add_foreign_key "submission_comments", "users"
   add_foreign_key "submission_comments", "users", column: "hidden_by_id"
   add_foreign_key "submission_reports", "timeline_events", column: "submission_id"
-  add_foreign_key "target_evaluation_criteria", "evaluation_criteria"
-  add_foreign_key "target_evaluation_criteria", "targets"
   add_foreign_key "target_groups", "levels"
   add_foreign_key "target_versions", "targets"
   add_foreign_key "teams", "cohorts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_23_120822) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_27_162656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -744,10 +744,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_23_120822) do
   end
 
   create_table "targets", id: :serial, force: :cascade do |t|
-    t.string "role"
     t.string "title"
     t.text "description"
-    t.string "completion_instructions"
     t.string "resource_url"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -770,8 +768,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_23_120822) do
     t.jsonb "review_checklist", default: []
     t.jsonb "checklist", default: []
     t.text "action_config"
-    t.boolean "milestone", default: false
-    t.integer "milestone_number"
     t.index ["archived"], name: "index_targets_on_archived"
     t.index ["session_at"], name: "index_targets_on_session_at"
     t.index ["target_group_id"], name: "index_targets_on_target_group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -711,7 +711,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_15_101852) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "sort_index"
-    t.boolean "milestone"
     t.integer "level_id"
     t.boolean "archived", default: false
     t.index ["level_id"], name: "index_target_groups_on_level_id"

--- a/db/seeds/development/targets.seeds.rb
+++ b/db/seeds/development/targets.seeds.rb
@@ -20,13 +20,13 @@ after "development:evaluation_criteria", "development:target_groups" do
         discussion: true,
         checklist: [
           {
-            kind: Target::CHECKLIST_KIND_LONG_TEXT,
+            kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
             title:
               "# This is the heading for a question\n\n_And this is its body._",
             optional: false
           },
           {
-            kind: Target::CHECKLIST_KIND_LINK,
+            kind: Assignment::CHECKLIST_KIND_LINK,
             title: "A second question, to test multiple questions",
             optional: false
           }
@@ -94,7 +94,7 @@ after "development:evaluation_criteria", "development:target_groups" do
         role: Assignment.valid_roles.sample,
         checklist: [
           {
-            kind: Target::CHECKLIST_KIND_MULTI_CHOICE,
+            kind: Assignment::CHECKLIST_KIND_MULTI_CHOICE,
             title: "Do you play any sport?",
             optional: false,
             metadata: {
@@ -103,19 +103,19 @@ after "development:evaluation_criteria", "development:target_groups" do
             }
           },
           {
-            kind: Target::CHECKLIST_KIND_LONG_TEXT,
+            kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
             title: "Describe your experience playing sports",
             optional: false
           },
           {
-            kind: Target::CHECKLIST_KIND_SHORT_TEXT,
+            kind: Assignment::CHECKLIST_KIND_SHORT_TEXT,
             title: "Are you early bird or night owl?",
             optional: false,
             metadata: {
             }
           },
           {
-            kind: Target::CHECKLIST_KIND_LINK,
+            kind: Assignment::CHECKLIST_KIND_LINK,
             title: "Please, fill your github link",
             optional: true,
             metadata: {

--- a/docs/developers/rate_limiting.md
+++ b/docs/developers/rate_limiting.md
@@ -45,7 +45,6 @@ These are the rate limits applied to the creation of all kinds of resources stor
 | SubmissionReport                  | Submission    | Each submission can receive up to 25 reports hourly.          |
 | Target                            | TargetGroup   | Each target group can have up to 100 targets.                 |
 | TargetGroup                       | Level         | Each level can contain up to 25 target groups.                |
-| TargetPrerequisite                | Target        | Each target can have up to 25 prerequisites.                  |
 | TargetVersion                     | Target        | Each target can get up to 25 versions daily.                  |
 | Team                              | Cohort        | Each cohort can form up to 2,500 teams hourly.                |
 | TimelineEventFile                 | User          | Each user can upload up to 50 files hourly.                   |

--- a/spec/factories/target.rb
+++ b/spec/factories/target.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :target do
     title { Faker::Lorem.words(number: 6).join " " }
-    role { Target.valid_roles.sample }
     target_group
     sequence(:sort_index)
     visibility { Target::VISIBILITY_LIVE }

--- a/spec/factories/target_evaluation_criterion.rb
+++ b/spec/factories/target_evaluation_criterion.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :target_evaluation_criterion do
-    target
-    evaluation_criterion
-  end
-end

--- a/spec/factories/timeline_event.rb
+++ b/spec/factories/timeline_event.rb
@@ -1,6 +1,15 @@
 FactoryBot.define do
   factory :timeline_event do
-    checklist { [{ "kind" => Target::CHECKLIST_KIND_LONG_TEXT, "title" => Faker::Lorem.sentence, "result" => Faker::Lorem.sentence, "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER }] }
+    checklist do
+      [
+        {
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
+          "title" => Faker::Lorem.sentence,
+          "result" => Faker::Lorem.sentence,
+          "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
+        }
+      ]
+    end
     target
 
     trait :passed do
@@ -20,10 +29,14 @@ FactoryBot.define do
 
       after(:create) do |submission, evaluator|
         evaluator.owners.each do |owner|
-          create(:timeline_event_owner, latest: evaluator.latest, student: owner, timeline_event: submission)
+          create(
+            :timeline_event_owner,
+            latest: evaluator.latest,
+            student: owner,
+            timeline_event: submission
+          )
         end
       end
     end
   end
 end
-

--- a/spec/services/courses/demo_content_service_spec.rb
+++ b/spec/services/courses/demo_content_service_spec.rb
@@ -20,7 +20,6 @@ describe Courses::DemoContentService do
       target_group = level.target_groups.first
       expect(target_group.name).to eq("Demo Target Group")
       expect(target_group.description).to eq("Description of demo target group")
-      expect(target_group.milestone).to eq(true)
 
       # Create a target in the target group
       expect(target_group.targets.count).to eq(1)

--- a/spec/services/courses/demo_content_service_spec.rb
+++ b/spec/services/courses/demo_content_service_spec.rb
@@ -1,12 +1,12 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Courses::DemoContentService do
   subject { described_class.new(course) }
 
   let(:course) { create :course }
 
-  describe '#execute' do
-    it 'create all basic resources for a course' do
+  describe "#execute" do
+    it "create all basic resources for a course" do
       subject.execute
 
       # Create Level 1
@@ -25,7 +25,6 @@ describe Courses::DemoContentService do
       # Create a target in the target group
       expect(target_group.targets.count).to eq(1)
       target = target_group.targets.first
-      expect(target.role).to eq(Target::ROLE_STUDENT)
       expect(target.title).to eq("Demo Target")
       expect(target.target_action_type).to eq(Target::TYPE_TODO)
       expect(target.visibility).to eq(Target::VISIBILITY_LIVE)
@@ -39,8 +38,12 @@ describe Courses::DemoContentService do
 
       # Create 2 evaluation criteria for the course.
       expect(course.evaluation_criteria.count).to eq(2)
-      expect(course.evaluation_criteria.first.name).to eq("Correctness of implementation")
-      expect(course.evaluation_criteria.last.name).to eq("Quality of submission")
+      expect(course.evaluation_criteria.first.name).to eq(
+        "Correctness of implementation"
+      )
+      expect(course.evaluation_criteria.last.name).to eq(
+        "Quality of submission"
+      )
     end
   end
 end

--- a/spec/services/levels/clone_service_spec.rb
+++ b/spec/services/levels/clone_service_spec.rb
@@ -143,8 +143,7 @@ describe Levels::CloneService do
     quiz_question_1.update!(correct_answer: q1_answer_2)
     quiz_question_2.update!(correct_answer: q2_answer_4)
 
-    # set prerequisite target
-    target_l1_2.prerequisite_targets << prerequisite_target
+    # Set evaluation criteria for assignments
     target_l1_2.assignments.first.evaluation_criteria << ec_1
 
     # attach images

--- a/spec/services/targets/status_service_spec.rb
+++ b/spec/services/targets/status_service_spec.rb
@@ -90,7 +90,7 @@ describe Targets::StatusService do
                    :draft,
                    :with_shared_assignment,
                    target_group: target_group,
-                   given_role: Target::ROLE_TEAM
+                   given_role: Assignment::ROLE_TEAM
           end
 
           before do

--- a/spec/system/coaches/bot_reviewer_repeat_rejection_alert_spec.rb
+++ b/spec/system/coaches/bot_reviewer_repeat_rejection_alert_spec.rb
@@ -117,11 +117,12 @@ feature "Alert coaches when a bot user repeatedly rejects submissions",
                    referrer: review_timeline_event_path(submission_pending)
 
       click_button "Start Review"
-
       within("div#is_acceptable") { click_button "No" }
       click_button "Reject Submission"
 
+      expect(page).to have_content("Submission Rejected")
       expect(submission_pending.reload.evaluated_at).to_not eq(nil)
+
       open_email(coach.email)
 
       expect(current_email).to be_blank

--- a/spec/system/courses/cohorts_spec.rb
+++ b/spec/system/courses/cohorts_spec.rb
@@ -22,7 +22,7 @@ feature "Cohorts", js: true do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l1,
-           given_role: Target::ROLE_STUDENT,
+           given_role: Assignment::ROLE_STUDENT,
            given_evaluation_criteria: [evaluation_criterion],
            given_milestone_number: 1
   end
@@ -30,7 +30,7 @@ feature "Cohorts", js: true do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l2,
-           given_role: Target::ROLE_STUDENT,
+           given_role: Assignment::ROLE_STUDENT,
            given_evaluation_criteria: [evaluation_criterion],
            given_milestone_number: 2
   end

--- a/spec/system/courses/curriculum_spec.rb
+++ b/spec/system/courses/curriculum_spec.rb
@@ -36,51 +36,51 @@ feature "Student's view of Course Curriculum", js: true do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l1,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:completed_target_l2) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l2,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:completed_target_l3) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l3,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:completed_target_l4) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l4_1,
-           given_role: Target::ROLE_TEAM,
+           given_role: Assignment::ROLE_TEAM,
            given_evaluation_criteria: [evaluation_criterion]
   end
   let!(:pending_target_g1) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l4_1,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:pending_target_g2) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l4_2,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:submitted_target) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l4_1,
-           given_role: Target::ROLE_TEAM,
+           given_role: Assignment::ROLE_TEAM,
            given_evaluation_criteria: [evaluation_criterion]
   end
   let!(:failed_target) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l4_1,
-           given_role: Target::ROLE_TEAM,
+           given_role: Assignment::ROLE_TEAM,
            given_evaluation_criteria: [evaluation_criterion]
   end
   let!(:target_with_prerequisites) do
@@ -91,13 +91,13 @@ feature "Student's view of Course Curriculum", js: true do
            :with_default_checklist,
            target: target_with_prerequisites,
            prerequisite_assignments: [pending_target_g1.assignments.first],
-           role: Target::ROLE_TEAM
+           role: Assignment::ROLE_TEAM
   end
   let!(:l5_reviewed_target) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l5,
-           given_role: Target::ROLE_TEAM,
+           given_role: Assignment::ROLE_TEAM,
            given_evaluation_criteria: [evaluation_criterion]
   end
   let!(:l5_non_reviewed_target) do
@@ -105,7 +105,7 @@ feature "Student's view of Course Curriculum", js: true do
            :with_shared_assignment,
            :with_markdown,
            target_group: target_group_l5,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:l5_non_reviewed_target_with_prerequisite) do
     create :target, :with_markdown, target_group: target_group_l5
@@ -114,21 +114,21 @@ feature "Student's view of Course Curriculum", js: true do
     create :assignment,
            :with_default_checklist,
            target: l5_non_reviewed_target_with_prerequisite,
-           role: Target::ROLE_TEAM,
+           role: Assignment::ROLE_TEAM,
            prerequisite_assignments: [l5_non_reviewed_target.assignments.first]
   end
   let!(:level_6_target) do
     create :target,
            :with_shared_assignment,
            target_group: target_group_l6,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
   let!(:level_6_draft_target) do
     create :target,
            :with_shared_assignment,
            :draft,
            target_group: target_group_l6,
-           given_role: Target::ROLE_TEAM
+           given_role: Assignment::ROLE_TEAM
   end
 
   # Submissions
@@ -405,7 +405,7 @@ feature "Student's view of Course Curriculum", js: true do
       create :target,
              :with_shared_assignment,
              target_group: target_group_l0,
-             given_role: Target::ROLE_TEAM
+             given_role: Assignment::ROLE_TEAM
     end
 
     scenario "student visits the dashboard" do
@@ -450,7 +450,7 @@ feature "Student's view of Course Curriculum", js: true do
         create :target,
                :with_shared_assignment,
                target_group: c2_target_group,
-               given_role: Target::ROLE_TEAM
+               given_role: Assignment::ROLE_TEAM
       end
       let!(:c2_student) do
         create :student, user: student.user, cohort: cohort_2
@@ -624,7 +624,7 @@ feature "Student's view of Course Curriculum", js: true do
              :with_shared_assignment,
              :with_shared_assignment,
              target_group: target_group_l1,
-             given_role: Target::ROLE_TEAM,
+             given_role: Assignment::ROLE_TEAM,
              given_evaluation_criteria: [evaluation_criterion],
              given_milestone_number: 1
     end
@@ -634,7 +634,7 @@ feature "Student's view of Course Curriculum", js: true do
              :with_shared_assignment,
              :with_shared_assignment,
              target_group: target_group_l2,
-             given_role: Target::ROLE_TEAM,
+             given_role: Assignment::ROLE_TEAM,
              given_evaluation_criteria: [evaluation_criterion],
              given_milestone_number: 2
     end
@@ -644,7 +644,7 @@ feature "Student's view of Course Curriculum", js: true do
              :with_shared_assignment,
              :with_shared_assignment,
              target_group: target_group_l3,
-             given_role: Target::ROLE_TEAM,
+             given_role: Assignment::ROLE_TEAM,
              given_evaluation_criteria: [evaluation_criterion],
              given_milestone_number: 3
     end
@@ -689,7 +689,7 @@ feature "Student's view of Course Curriculum", js: true do
       create :target,
              :with_shared_assignment,
              target_group: target_group_l1,
-             given_role: Target::ROLE_TEAM,
+             given_role: Assignment::ROLE_TEAM,
              given_evaluation_criteria: [evaluation_criterion]
     end
 
@@ -708,7 +708,7 @@ feature "Student's view of Course Curriculum", js: true do
       create :target,
              :with_shared_assignment,
              target_group: target_group_l1,
-             given_role: Target::ROLE_TEAM,
+             given_role: Assignment::ROLE_TEAM,
              given_evaluation_criteria: [evaluation_criterion]
     end
 

--- a/spec/system/school/courses/curriculum_editor_spec.rb
+++ b/spec/system/school/courses/curriculum_editor_spec.rb
@@ -289,8 +289,6 @@ feature "Curriculum Editor", js: true do
 
     expect(target_group_2.reload.level).to eq(level_1)
     expect(target_group_2.sort_index).to eq(2)
-    expect(target_2.reload.prerequisite_targets).to eq([])
-    expect(target_4.reload.prerequisite_targets).to eq([])
   end
 
   scenario "user who is not logged in gets redirected to sign in page" do

--- a/spec/system/school/courses/target_details_editor_spec.rb
+++ b/spec/system/school/courses/target_details_editor_spec.rb
@@ -1048,7 +1048,7 @@ feature "Target Details Editor", js: true do
       expected_checklist = []
 
       expect(assignment.checklist).to eq(expected_checklist)
-      expect(target.quiz).to eq(nil)
+      expect(assignment.quiz).to eq(nil)
       expect(assignment.evaluation_criteria.first).to eq(evaluation_criterion)
 
       # Check only the graded submissions are preserved on switching to an evaluated target

--- a/spec/system/school/courses/target_details_editor_spec.rb
+++ b/spec/system/school/courses/target_details_editor_spec.rb
@@ -1044,12 +1044,12 @@ feature "Target Details Editor", js: true do
       dismiss_notification
 
       target = quiz_target.reload
+      assignment = target.assignments.first
       expected_checklist = []
-      expect(target.checklist).to eq(expected_checklist)
+
+      expect(assignment.checklist).to eq(expected_checklist)
       expect(target.quiz).to eq(nil)
-      expect(target.assignments.first.evaluation_criteria.first).to eq(
-        evaluation_criterion
-      )
+      expect(assignment.evaluation_criteria.first).to eq(evaluation_criterion)
 
       # Check only the graded submissions are preserved on switching to an evaluated target
       expect(target.timeline_events.count).to eq(1)

--- a/spec/system/school/courses/target_details_editor_spec.rb
+++ b/spec/system/school/courses/target_details_editor_spec.rb
@@ -1179,8 +1179,6 @@ feature "Target Details Editor", js: true do
 
       expect(target_l2_2.reload.sort_index).to eq(2)
       expect(target_l2_2.target_group).to eq(target_group_l1)
-      expect(target_l2_2.prerequisite_targets).to eq([])
-      expect(target_l2_3.reload.prerequisite_targets).to eq([])
     end
 
     context "admin modifies target that currently has submissions" do

--- a/spec/system/submissions/review_spec.rb
+++ b/spec/system/submissions/review_spec.rb
@@ -760,37 +760,37 @@ feature "Submission review overlay", js: true do
       answer_5 = [submission_file_attachment.id.to_s]
       answer_6 = submission_audio_attachment.id.to_s
       submission_checklist_long_text = {
-        "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+        "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
         "title" => question_1,
         "result" => answer_1,
         "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
       }
       submission_checklist_link = {
-        "kind" => Target::CHECKLIST_KIND_LINK,
+        "kind" => Assignment::CHECKLIST_KIND_LINK,
         "title" => question_2,
         "result" => answer_2,
         "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
       }
       submission_checklist_choice = {
-        "kind" => Target::CHECKLIST_KIND_MULTI_CHOICE,
+        "kind" => Assignment::CHECKLIST_KIND_MULTI_CHOICE,
         "title" => question_3,
         "result" => [answer_3],
         "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
       }
       submission_checklist_short_text = {
-        "kind" => Target::CHECKLIST_KIND_SHORT_TEXT,
+        "kind" => Assignment::CHECKLIST_KIND_SHORT_TEXT,
         "title" => question_4,
         "result" => answer_4,
         "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
       }
       submission_checklist_files = {
-        "kind" => Target::CHECKLIST_KIND_FILES,
+        "kind" => Assignment::CHECKLIST_KIND_FILES,
         "title" => question_5,
         "result" => answer_5,
         "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
       }
       submission_checklist_audio = {
-        "kind" => Target::CHECKLIST_KIND_AUDIO,
+        "kind" => Assignment::CHECKLIST_KIND_AUDIO,
         "title" => question_6,
         "result" => answer_6,
         "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -874,13 +874,13 @@ feature "Submission review overlay", js: true do
       new_checklist = [
         submission_checklist_long_text,
         {
-          "kind" => Target::CHECKLIST_KIND_LINK,
+          "kind" => Assignment::CHECKLIST_KIND_LINK,
           "title" => question_2,
           "result" => answer_2,
           "status" => TimelineEvent::CHECKLIST_STATUS_FAILED
         },
         {
-          "kind" => Target::CHECKLIST_KIND_MULTI_CHOICE,
+          "kind" => Assignment::CHECKLIST_KIND_MULTI_CHOICE,
           "title" => question_3,
           "result" => [answer_3],
           "status" => TimelineEvent::CHECKLIST_STATUS_FAILED
@@ -888,7 +888,7 @@ feature "Submission review overlay", js: true do
         submission_checklist_short_text,
         submission_checklist_files,
         {
-          "kind" => Target::CHECKLIST_KIND_AUDIO,
+          "kind" => Assignment::CHECKLIST_KIND_AUDIO,
           "title" => question_6,
           "result" => answer_6,
           "status" => TimelineEvent::CHECKLIST_STATUS_FAILED

--- a/spec/system/submissions/show_spec.rb
+++ b/spec/system/submissions/show_spec.rb
@@ -34,30 +34,30 @@ feature "Submissions show" do
   end
 
   let(:checklist_item_long_text) do
-    checklist_item(Target::CHECKLIST_KIND_LONG_TEXT, Faker::Lorem.sentence)
+    checklist_item(Assignment::CHECKLIST_KIND_LONG_TEXT, Faker::Lorem.sentence)
   end
 
   let(:checklist_item_short_text) do
-    checklist_item(Target::CHECKLIST_KIND_SHORT_TEXT, Faker::Lorem.sentence)
+    checklist_item(Assignment::CHECKLIST_KIND_SHORT_TEXT, Faker::Lorem.sentence)
   end
 
   let(:checklist_item_link) do
-    checklist_item(Target::CHECKLIST_KIND_LINK, "https://www.example.com")
+    checklist_item(Assignment::CHECKLIST_KIND_LINK, "https://www.example.com")
   end
 
   let(:checklist_item_files) do
     checklist_item(
-      Target::CHECKLIST_KIND_FILES,
+      Assignment::CHECKLIST_KIND_FILES,
       [submission_file_1.id, submission_file_2.id]
     )
   end
 
   let(:checklist_item_audio) do
-    checklist_item(Target::CHECKLIST_KIND_AUDIO, submission_audio_file.id)
+    checklist_item(Assignment::CHECKLIST_KIND_AUDIO, submission_audio_file.id)
   end
 
   let(:checklist_item_multi_choice) do
-    checklist_item(Target::CHECKLIST_KIND_MULTI_CHOICE, ["Yes"])
+    checklist_item(Assignment::CHECKLIST_KIND_MULTI_CHOICE, ["Yes"])
   end
 
   let(:checklist) do
@@ -136,7 +136,14 @@ feature "Submissions show" do
       expect(page).to have_content(student.name)
       expect(page).to have_content(student_2.name)
       expect(page).to have_content(team.name)
-      expect(page).to have_content(submission.created_at.strftime("%b %d, %Y"))
+
+      expect(page).to have_content(
+        submission
+          .created_at
+          .in_time_zone(student.user.time_zone)
+          .strftime("%b %d, %Y")
+      )
+
       expect(page).to have_content("Rejected")
       expect(page).to have_content(checklist_item_long_text["title"])
       expect(page).to have_content(checklist_item_long_text["result"])

--- a/spec/system/targets/show_spec.rb
+++ b/spec/system/targets/show_spec.rb
@@ -98,14 +98,7 @@ feature "Target Overlay", js: true do
            :with_content,
            target_group: target_group_l2,
            given_role: Assignment::ROLE_TEAM,
-           given_evaluation_criteria: [criterion_1],
-           checklist: [
-             {
-               kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
-               title: "Write something about your target submission",
-               optional: false
-             }
-           ]
+           given_evaluation_criteria: [criterion_1]
   end
 
   let!(:quiz) { create :quiz }

--- a/spec/system/targets/show_spec.rb
+++ b/spec/system/targets/show_spec.rb
@@ -97,11 +97,11 @@ feature "Target Overlay", js: true do
            :with_shared_assignment,
            :with_content,
            target_group: target_group_l2,
-           given_role: Target::ROLE_TEAM,
+           given_role: Assignment::ROLE_TEAM,
            given_evaluation_criteria: [criterion_1],
            checklist: [
              {
-               kind: Target::CHECKLIST_KIND_LONG_TEXT,
+               kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
                title: "Write something about your target submission",
                optional: false
              }
@@ -305,7 +305,7 @@ feature "Target Overlay", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => "Write something about your submission",
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -390,7 +390,7 @@ feature "Target Overlay", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => "Write something about your submission",
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -989,17 +989,17 @@ feature "Target Overlay", js: true do
         [
           {
             title: "Describe your submission",
-            kind: Target::CHECKLIST_KIND_LONG_TEXT,
+            kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
             optional: false
           },
           {
             title: "Attach link",
-            kind: Target::CHECKLIST_KIND_LINK,
+            kind: Assignment::CHECKLIST_KIND_LINK,
             optional: true
           },
           {
             title: "Attach files",
-            kind: Target::CHECKLIST_KIND_FILES,
+            kind: Assignment::CHECKLIST_KIND_FILES,
             optional: true
           }
         ]

--- a/spec/system/targets/submission_builder_spec.rb
+++ b/spec/system/targets/submission_builder_spec.rb
@@ -52,7 +52,7 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question,
-          kind: Target::CHECKLIST_KIND_LONG_TEXT,
+          kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
           optional: false
         }
       ]
@@ -83,7 +83,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => question,
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -102,7 +102,7 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question,
-          kind: Target::CHECKLIST_KIND_SHORT_TEXT,
+          kind: Assignment::CHECKLIST_KIND_SHORT_TEXT,
           optional: false
         }
       ]
@@ -133,7 +133,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_SHORT_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_SHORT_TEXT,
           "title" => question,
           "result" => short_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -150,7 +150,11 @@ feature "Submission Builder", js: true do
     question = Faker::Lorem.sentence
     target_assignment.update!(
       checklist: [
-        { title: question, kind: Target::CHECKLIST_KIND_LINK, optional: false }
+        {
+          title: question,
+          kind: Assignment::CHECKLIST_KIND_LINK,
+          optional: false
+        }
       ]
     )
     link = "https://example.com?q=1"
@@ -182,7 +186,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LINK,
+          "kind" => Assignment::CHECKLIST_KIND_LINK,
           "title" => question,
           "result" => link,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -199,7 +203,11 @@ feature "Submission Builder", js: true do
     question = Faker::Lorem.sentence
     target_assignment.update!(
       checklist: [
-        { title: question, kind: Target::CHECKLIST_KIND_FILES, optional: false }
+        {
+          title: question,
+          kind: Assignment::CHECKLIST_KIND_FILES,
+          optional: false
+        }
       ]
     )
 
@@ -263,7 +271,7 @@ feature "Submission Builder", js: true do
     checklist_item = last_submission.checklist.first
 
     expect(last_submission.timeline_event_files.last.user).to eq(student.user)
-    expect(checklist_item["kind"]).to eq(Target::CHECKLIST_KIND_FILES)
+    expect(checklist_item["kind"]).to eq(Assignment::CHECKLIST_KIND_FILES)
     expect(checklist_item["title"]).to eq(question)
     expect(checklist_item["result"]).to match_array(last_submission_file_ids)
     expect(checklist_item["status"]).to eq(
@@ -286,7 +294,7 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question,
-          kind: Target::CHECKLIST_KIND_MULTI_CHOICE,
+          kind: Assignment::CHECKLIST_KIND_MULTI_CHOICE,
           optional: false,
           metadata: {
             allowMultiple: false,
@@ -319,7 +327,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_MULTI_CHOICE,
+          "kind" => Assignment::CHECKLIST_KIND_MULTI_CHOICE,
           "title" => question,
           "result" => [answer],
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -339,10 +347,14 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question_1,
-          kind: Target::CHECKLIST_KIND_LONG_TEXT,
+          kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
           optional: false
         },
-        { title: question_2, kind: Target::CHECKLIST_KIND_LINK, optional: true }
+        {
+          title: question_2,
+          kind: Assignment::CHECKLIST_KIND_LINK,
+          optional: true
+        }
       ]
     )
     long_answer = Faker::Lorem.sentence
@@ -391,7 +403,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => question_1,
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -412,12 +424,12 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question_1,
-          kind: Target::CHECKLIST_KIND_FILES,
+          kind: Assignment::CHECKLIST_KIND_FILES,
           optional: false
         },
         {
           title: question_2,
-          kind: Target::CHECKLIST_KIND_FILES,
+          kind: Assignment::CHECKLIST_KIND_FILES,
           optional: false
         }
       ]
@@ -481,7 +493,7 @@ feature "Submission Builder", js: true do
     checklist_item_1 = last_submission.checklist.first
     checklist_item_2 = last_submission.checklist.last
 
-    expect(checklist_item_1["kind"]).to eq(Target::CHECKLIST_KIND_FILES)
+    expect(checklist_item_1["kind"]).to eq(Assignment::CHECKLIST_KIND_FILES)
     expect(checklist_item_1["title"]).to eq(question_1)
     expect(checklist_item_1["result"]).to match_array(
       item_1_submission_file_ids
@@ -490,7 +502,7 @@ feature "Submission Builder", js: true do
       TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
     )
 
-    expect(checklist_item_2["kind"]).to eq(Target::CHECKLIST_KIND_FILES)
+    expect(checklist_item_2["kind"]).to eq(Assignment::CHECKLIST_KIND_FILES)
     expect(checklist_item_2["title"]).to eq(question_2)
     expect(checklist_item_2["result"]).to match_array(
       item_2_submission_file_ids
@@ -529,7 +541,11 @@ feature "Submission Builder", js: true do
     question = Faker::Lorem.sentence
     target_assignment.update!(
       checklist: [
-        { title: question, kind: Target::CHECKLIST_KIND_AUDIO, optional: false }
+        {
+          title: question,
+          kind: Assignment::CHECKLIST_KIND_AUDIO,
+          optional: false
+        }
       ]
     )
 
@@ -591,7 +607,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => "Write something about your submission",
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -610,7 +626,7 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question,
-          kind: Target::CHECKLIST_KIND_LONG_TEXT,
+          kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
           optional: false
         }
       ]
@@ -641,7 +657,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => question,
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -660,7 +676,7 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question,
-          kind: Target::CHECKLIST_KIND_SHORT_TEXT,
+          kind: Assignment::CHECKLIST_KIND_SHORT_TEXT,
           optional: false
         }
       ]
@@ -691,7 +707,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_SHORT_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_SHORT_TEXT,
           "title" => question,
           "result" => short_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -708,7 +724,11 @@ feature "Submission Builder", js: true do
     question = Faker::Lorem.sentence
     form_submission_target_assignment.update!(
       checklist: [
-        { title: question, kind: Target::CHECKLIST_KIND_LINK, optional: false }
+        {
+          title: question,
+          kind: Assignment::CHECKLIST_KIND_LINK,
+          optional: false
+        }
       ]
     )
     link = "https://example.com?q=1"
@@ -740,7 +760,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LINK,
+          "kind" => Assignment::CHECKLIST_KIND_LINK,
           "title" => question,
           "result" => link,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -757,7 +777,11 @@ feature "Submission Builder", js: true do
     question = Faker::Lorem.sentence
     form_submission_target_assignment.update!(
       checklist: [
-        { title: question, kind: Target::CHECKLIST_KIND_FILES, optional: false }
+        {
+          title: question,
+          kind: Assignment::CHECKLIST_KIND_FILES,
+          optional: false
+        }
       ]
     )
 
@@ -820,7 +844,7 @@ feature "Submission Builder", js: true do
       last_submission.timeline_event_files.map(&:id).map(&:to_s)
     checklist_item = last_submission.checklist.first
 
-    expect(checklist_item["kind"]).to eq(Target::CHECKLIST_KIND_FILES)
+    expect(checklist_item["kind"]).to eq(Assignment::CHECKLIST_KIND_FILES)
     expect(checklist_item["title"]).to eq(question)
     expect(checklist_item["result"]).to match_array(last_submission_file_ids)
     expect(checklist_item["status"]).to eq(
@@ -843,7 +867,7 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question,
-          kind: Target::CHECKLIST_KIND_MULTI_CHOICE,
+          kind: Assignment::CHECKLIST_KIND_MULTI_CHOICE,
           optional: false,
           metadata: {
             allowMultiple: false,
@@ -876,7 +900,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_MULTI_CHOICE,
+          "kind" => Assignment::CHECKLIST_KIND_MULTI_CHOICE,
           "title" => question,
           "result" => [answer],
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -896,10 +920,14 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question_1,
-          kind: Target::CHECKLIST_KIND_LONG_TEXT,
+          kind: Assignment::CHECKLIST_KIND_LONG_TEXT,
           optional: false
         },
-        { title: question_2, kind: Target::CHECKLIST_KIND_LINK, optional: true }
+        {
+          title: question_2,
+          kind: Assignment::CHECKLIST_KIND_LINK,
+          optional: true
+        }
       ]
     )
     long_answer = Faker::Lorem.sentence
@@ -948,7 +976,7 @@ feature "Submission Builder", js: true do
     expect(last_submission.checklist).to eq(
       [
         {
-          "kind" => Target::CHECKLIST_KIND_LONG_TEXT,
+          "kind" => Assignment::CHECKLIST_KIND_LONG_TEXT,
           "title" => question_1,
           "result" => long_answer,
           "status" => TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
@@ -969,12 +997,12 @@ feature "Submission Builder", js: true do
       checklist: [
         {
           title: question_1,
-          kind: Target::CHECKLIST_KIND_FILES,
+          kind: Assignment::CHECKLIST_KIND_FILES,
           optional: false
         },
         {
           title: question_2,
-          kind: Target::CHECKLIST_KIND_FILES,
+          kind: Assignment::CHECKLIST_KIND_FILES,
           optional: false
         }
       ]
@@ -1038,7 +1066,7 @@ feature "Submission Builder", js: true do
     checklist_item_1 = last_submission.checklist.first
     checklist_item_2 = last_submission.checklist.last
 
-    expect(checklist_item_1["kind"]).to eq(Target::CHECKLIST_KIND_FILES)
+    expect(checklist_item_1["kind"]).to eq(Assignment::CHECKLIST_KIND_FILES)
     expect(checklist_item_1["title"]).to eq(question_1)
     expect(checklist_item_1["result"]).to match_array(
       item_1_submission_file_ids
@@ -1047,7 +1075,7 @@ feature "Submission Builder", js: true do
       TimelineEvent::CHECKLIST_STATUS_NO_ANSWER
     )
 
-    expect(checklist_item_2["kind"]).to eq(Target::CHECKLIST_KIND_FILES)
+    expect(checklist_item_2["kind"]).to eq(Assignment::CHECKLIST_KIND_FILES)
     expect(checklist_item_2["title"]).to eq(question_2)
     expect(checklist_item_2["result"]).to match_array(
       item_2_submission_file_ids
@@ -1086,7 +1114,11 @@ feature "Submission Builder", js: true do
     question = Faker::Lorem.sentence
     form_submission_target_assignment.update!(
       checklist: [
-        { title: question, kind: Target::CHECKLIST_KIND_AUDIO, optional: false }
+        {
+          title: question,
+          kind: Assignment::CHECKLIST_KIND_AUDIO,
+          optional: false
+        }
       ]
     )
 
@@ -1107,6 +1139,8 @@ feature "Submission Builder", js: true do
       expect(page).to have_css("audio", count: 1)
       expect(page).to have_text("Record Again")
     end
+
+    sleep 0.5
 
     click_button "Submit"
 


### PR DESCRIPTION
## Proposed Changes

This removes columns from the `targets` table that were moved over to the new `assignments` table. Clean up of these columns revealed a large amount of code (including tests) that still used stale references.

@pupilfirst/developers

## Additional cleanup

- [x] `target_groups` table has the `milestone` column.
- [x] `Target has_one: quiz`.
- [x] `Target has_many :prerequisite_targets` and the `target_prerequisites` table.
- [x] `target_evaluation_criteria` table.

## Merge Checklist

### Inapplicable

-  Add specs that demonstrate bug / test a new feature.
- Check if route, query, or mutation authorization looks correct.
- Ensure that UI text is kept in I18n files.
- Update developer and product docs, where applicable.
- Prep screenshot or demo video for changelog entry, and attach it to issue.
- Check if new tables or columns that have been added need to be handled in the following services:
- Check if changes in _packaged_ components have been published to `npm`.
- Add development seeds for new tables.
- If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
