### PR TITLE
Sanitize target title for Vimeo video uploads

### DIFF
--- a/app/queries/create_vimeo_video_mutator.rb
+++ b/app/queries/create_vimeo_video_mutator.rb
@@ -8,7 +8,7 @@ class CreateVimeoVideoMutator < ApplicationQuery
 
   def create_vimeo_video
     vimeo_api = Vimeo::ApiService.new(current_school)
-    video_title = title.presence || target.title
+    video_title = sanitize_title(title.presence || target.title)
     response = vimeo_api.create_video(size, video_title, description)
 
     if response[:error].present? || response[:error_code].present?
@@ -34,6 +34,10 @@ class CreateVimeoVideoMutator < ApplicationQuery
   end
 
   private
+
+  def sanitize_title(title)
+    title.gsub(/[^0-9A-Za-z\s]/, '')
+  end
 
   def resource_school
     course.school

--- a/app/queries/create_vimeo_video_mutator.rb
+++ b/app/queries/create_vimeo_video_mutator.rb
@@ -8,7 +8,7 @@ class CreateVimeoVideoMutator < ApplicationQuery
 
   def create_vimeo_video
     vimeo_api = Vimeo::ApiService.new(current_school)
-    video_title = sanitize_title(title.presence || target.title)
+    video_title = sanitize_title(title.presence || target.title).truncate(120)
     response = vimeo_api.create_video(size, video_title, description)
 
     if response[:error].present? || response[:error_code].present?

--- a/spec/system/school/courses/target_content_editor_spec.rb
+++ b/spec/system/school/courses/target_content_editor_spec.rb
@@ -273,7 +273,7 @@ feature "Target Content Editor", js: true do
 
   context "when video upload is enabled for a school" do
     let(:vimeo_access_token) { SecureRandom.hex }
-    let(:title) { Faker::Lorem.words(number: 3).join(" ") + "" }
+    let(:title) { Faker::Lorem.words(number: 3).join(" ") }
     let(:title_with_special_chars) { title + "!@#$%^&*()" }
     let(:description) { Faker::Lorem.words(number: 10).join(" ") }
 
@@ -391,7 +391,7 @@ feature "Target Content Editor", js: true do
           headers: request_headers
         ).to_return(status: 200, body: request_body.to_json, headers: {})
         # Ensure that special characters are stripped from the title
-        target.update!(title: title + "!@#$%^&*()")
+        target.update!(title: target.title + "!@#$%^&*()")
       end
 
       scenario "course author uploads a video without a title" do

--- a/spec/system/school/courses/target_content_editor_spec.rb
+++ b/spec/system/school/courses/target_content_editor_spec.rb
@@ -273,7 +273,8 @@ feature "Target Content Editor", js: true do
 
   context "when video upload is enabled for a school" do
     let(:vimeo_access_token) { SecureRandom.hex }
-    let(:title) { Faker::Lorem.words(number: 3).join(" ") }
+    let(:title) { Faker::Lorem.words(number: 3).join(" ") + "" }
+    let(:title_with_special_chars) { title + "!@#$%^&*()" }
     let(:description) { Faker::Lorem.words(number: 10).join(" ") }
 
     let!(:request_headers) do
@@ -345,7 +346,7 @@ feature "Target Content Editor", js: true do
         )
 
         # Upload a video
-        fill_in "Title", with: title
+        fill_in "Title", with: title_with_special_chars
         fill_in "Description", with: description
 
         filename_video = "pupilfirst-logo.mp4"
@@ -389,6 +390,8 @@ feature "Target Content Editor", js: true do
             "{\"upload\":{\"approach\":\"tus\",\"size\":588563},\"privacy\":{\"embed\":\"whitelist\",\"view\":\"#{account_type == "basic" ? "anybody" : "disable"}\"},\"embed\":{\"buttons\":{\"like\":false,\"watchlater\":false,\"share\":false},\"logos\":{\"vimeo\":false},\"title\":{\"name\":\"show\",\"owner\":\"hide\",\"portrait\":\"hide\"}},\"name\":\"#{target.title}\",\"description\":\"#{description}\"}",
           headers: request_headers
         ).to_return(status: 200, body: request_body.to_json, headers: {})
+        # Ensure that special characters are stripped from the title
+        target.update!(title: title + "!@#$%^&*()")
       end
 
       scenario "course author uploads a video without a title" do


### PR DESCRIPTION
Related to #1579

Implements a method to sanitize video titles by stripping out invalid characters before uploading to Vimeo.

- **Sanitization process**: Adds a `sanitize_title` method in `CreateVimeoVideoMutator` that removes any character not a letter, digit, or whitespace from the video title. This method is then used to clean the title obtained either directly from the `title` property or from the target's title if the former is not present.
- **Error handling**: Maintains the existing error handling logic, ensuring that any errors from Vimeo or in the process are appropriately captured and reported.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pupilfirst/pupilfirst/issues/1579?shareId=fdbf0ee3-44bd-4fa6-aa7d-a0a5b9ec46ee).