### PR TITLE
fix update_certificate_mutator to update active status correctly

### DIFF
--- a/app/queries/update_certificate_mutator.rb
+++ b/app/queries/update_certificate_mutator.rb
@@ -2,11 +2,35 @@ class UpdateCertificateMutator < ApplicationQuery
   include AuthorizeSchoolAdmin
 
   property :id
-  property :margin, validates: { numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 20 } }
-  property :name_offset_top, validates: { numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 95 } }
-  property :font_size, validates: { numericality: { greater_than_or_equal_to: 75, less_than_or_equal_to: 150 } }
+  property :margin,
+           validates: {
+             numericality: {
+               greater_than_or_equal_to: 0,
+               less_than_or_equal_to: 20
+             }
+           }
+  property :name_offset_top,
+           validates: {
+             numericality: {
+               greater_than_or_equal_to: 0,
+               less_than_or_equal_to: 95
+             }
+           }
+  property :font_size,
+           validates: {
+             numericality: {
+               greater_than_or_equal_to: 75,
+               less_than_or_equal_to: 150
+             }
+           }
   property :qr_corner, validates: { presence: true }
-  property :qr_scale, validates: { numericality: { greater_than_or_equal_to: 50, less_than_or_equal_to: 150 } }
+  property :qr_scale,
+           validates: {
+             numericality: {
+               greater_than_or_equal_to: 50,
+               less_than_or_equal_to: 150
+             }
+           }
   property :active
   property :name, validates: { length: { minimum: 1, maximum: 30 } }
 

--- a/app/queries/update_certificate_mutator.rb
+++ b/app/queries/update_certificate_mutator.rb
@@ -13,7 +13,7 @@ class UpdateCertificateMutator < ApplicationQuery
   def update_certificate
     Certificate.transaction do
       if active && !certificate.active
-        certificate.course.certificates.active.update(active: false)
+        course.certificates.active.update(active: false)
       end
 
       certificate.update!(
@@ -31,7 +31,11 @@ class UpdateCertificateMutator < ApplicationQuery
   private
 
   def resource_school
-    certificate&.course&.school
+    course&.school
+  end
+
+  def course
+    certificate&.course
   end
 
   def certificate

--- a/app/queries/update_certificate_mutator.rb
+++ b/app/queries/update_certificate_mutator.rb
@@ -13,7 +13,7 @@ class UpdateCertificateMutator < ApplicationQuery
   def update_certificate
     Certificate.transaction do
       if active && !certificate.active
-        Certificate.active.update(active: false)
+        certificate.course.certificates.active.update(active: false)
       end
 
       certificate.update!(


### PR DESCRIPTION
Currently, there is no way to set an auto-issue certificate on two courses at the same time.
This also affects multi-tenant mode. Setting a certificate to be active will set all active certificates to `false` globally.

## Proposed Changes
Scope certificate active state update to the current course.

@pupilfirst/developers

