### PR TITLE
feat: read affiliation from user on a school user page

### DIFF
--- a/app/presenters/schools/users/show_presenter.rb
+++ b/app/presenters/schools/users/show_presenter.rb
@@ -35,8 +35,8 @@ module Schools
             .order(name: :asc)
       end
 
-      def organisation_names
-        @organisation_names ||= user.organisation&.name
+      def affiliation
+        @affiliation ||= user.affiliation || user.organisation&.name
       end
 
       def current_standing

--- a/app/views/schools/users/show.html.erb
+++ b/app/views/schools/users/show.html.erb
@@ -40,12 +40,12 @@
               </div>
             </div>
           <% end %>
-          <% if @presenter.organisation_names.present? %>
+          <% if @presenter.affiliation.present? %>
             <div class="flex items-center gap-3">
               <p class="text-xl text-gray-600"><i class="if i-school-light if-fw" ></i></p>
               <div>
                 <p class="text-sm text-gray-500"><%= t("schools.users.show.affiliation") %></p>
-                <p class="text-sm font-bold"><%= @presenter.organisation_names %></p>
+                <p class="text-sm font-bold"><%= @presenter.affiliation %></p>
               </div>
             </div>
           <% end %>

--- a/spec/system/school/users/users_show_spec.rb
+++ b/spec/system/school/users/users_show_spec.rb
@@ -65,7 +65,6 @@ feature "Users Show", js: true do
     expect(page).to have_text(user.email)
     expect(page).to have_text(DiscordRole.first.name)
     expect(page).to have_text("##{user.discord_user_id}")
-    expect(page).to have_text(user.affiliation)
     expect(page).to have_text(organisation.name)
 
     courses = Course.order(name: :asc)

--- a/spec/system/school/users/users_show_spec.rb
+++ b/spec/system/school/users/users_show_spec.rb
@@ -17,7 +17,7 @@ feature "Users Show", js: true do
            discord_user_id: Faker::Number.number(digits: 10).to_s,
            organisation: organisation
   end
-  let(:user_affiliation) { create :user, affiliation: Faker::Company.name }
+  let(:user_affiliated) { create :user, affiliation: Faker::Company.name }
 
   let(:course_1) { create :course, school: school }
   let(:course_2) { create :course, school: school }
@@ -50,10 +50,10 @@ feature "Users Show", js: true do
   end
 
   scenario "user with affiliation filled" do
-    sign_in_user school_admin.user, referrer: school_user_path(user_affiliation)
+    sign_in_user school_admin.user, referrer: school_user_path(user_affiliated)
 
     expect(page).not_to have_text(organisation.name)
-    expect(page).to have_text(user_affiliation.affiliation)
+    expect(page).to have_text(user_affiliated.affiliation)
   end
 
   scenario "admin access user of same school" do

--- a/spec/system/school/users/users_show_spec.rb
+++ b/spec/system/school/users/users_show_spec.rb
@@ -17,6 +17,7 @@ feature "Users Show", js: true do
            discord_user_id: Faker::Number.number(digits: 10).to_s,
            organisation: organisation
   end
+  let(:user_affiliation) { create :user, affiliation: Faker::Company.name }
 
   let(:course_1) { create :course, school: school }
   let(:course_2) { create :course, school: school }
@@ -48,6 +49,13 @@ feature "Users Show", js: true do
     expect(page).to have_text("The page you were looking for doesn't exist!")
   end
 
+  scenario "user with affiliation filled" do
+    sign_in_user school_admin.user, referrer: school_user_path(user_affiliation)
+
+    expect(page).not_to have_text(organisation.name)
+    expect(page).to have_text(user_affiliation.affiliation)
+  end
+
   scenario "admin access user of same school" do
     sign_in_user school_admin.user, referrer: school_user_path(user)
 
@@ -57,6 +65,7 @@ feature "Users Show", js: true do
     expect(page).to have_text(user.email)
     expect(page).to have_text(DiscordRole.first.name)
     expect(page).to have_text("##{user.discord_user_id}")
+    expect(page).to have_text(user.affiliation)
     expect(page).to have_text(organisation.name)
 
     courses = Course.order(name: :asc)


### PR DESCRIPTION
Hi!

## Proposed Changes

https://github.com/pupilfirst/pupilfirst/issues/1677

Reads affiliation from user.
If user affiliation is missing, organisation name will be presented.

![school-user-affiliation](https://github.com/user-attachments/assets/d4d19343-73f0-4536-8bd7-5730fc0fec73)

- [x] read from user affiliation
- [x] refactor: rename presenter field to "affiliation"
- [x] test manually
- [x] rspec

## Merge Checklist

- [x] Add specs that demonstrate bug / test a new feature.
- [x] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [x] Ensure that UI text is kept in I18n files.
- [x] Update developer and product docs, where applicable.
  - If the documentation updates include images, ensure they are compressed.
- [x] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [x] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [x] Check if changes in _packaged_ components have been published to `npm`.
- [x] Add development seeds for new tables.
- [x] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [x] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
