### PR TITLE
fix: unsupported option in discord_role relation

### DIFF
--- a/app/models/discord_role.rb
+++ b/app/models/discord_role.rb
@@ -1,6 +1,5 @@
 class DiscordRole < ApplicationRecord
   belongs_to :school
   has_and_belongs_to_many :users,
-                          dependent: :destroy,
                           join_table: "additional_user_discord_roles"
 end


### PR DESCRIPTION
## Proposed Changes

![discord_role](https://github.com/user-attachments/assets/9bde2be4-0835-47f5-88d0-31015023bb30)
[It seems](https://guides.rubyonrails.org/association_basics.html#options-for-has-and-belongs-to-many) there is no `dependent` option for `has_and_belongs_to_many`.

- [X] remove unsuported option
- [ ] add test that associative table is still cleared on role delete
- [ ] check are there more occurences in app

@pupilfirst/developers

## Merge Checklist

- [ ] Add specs that demonstrate bug / test a new feature.
- [X] Check if route, query, or mutation authorization looks correct.
  - Add tests for authorization, if required.
- [X] Ensure that UI text is kept in I18n files.
- [X] Update developer and product docs, where applicable.
  - If the documentation updates include images, ensure they are compressed.
- [X] Prep screenshot or demo video for changelog entry, and attach it to issue.
- [X] Check if new tables or columns that have been added need to be handled in the following services:
  - `Users::DeleteAccountService`
  - `Courses::CloneService`
  - `Courses::DeleteService`
  - `Courses::DemoContentService`
  - `Levels::CloneService`
  - `Schools::DeleteService`
- [X] Check if changes in _packaged_ components have been published to `npm`.
- [X] Add development seeds for new tables.
- [X] If the updates involve Graph mutations ensure that the files are migrated to the new approach without a mutator.
- [X] If the updates involve adding a new table ensure that rate limiting is added and documented in the `docs/developers/rate_limiting.md` file.
